### PR TITLE
bug 741582: Ensure templates get their own copy of the API context

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -285,6 +285,7 @@ var APIContext = ks_utils.Class({
         _.each(args, function (v, i) {
             $this['$'+i] = v;
         });
+        return this;
     },
 
     // #### template(name, arguments)

--- a/lib/kumascript/macros.js
+++ b/lib/kumascript/macros.js
@@ -155,11 +155,10 @@ var MacroProcessor = ks_utils.Class({
             // Make sure the template was loaded...
             var tmpl = templates[tok.name];
             if (!tmpl) { return next('{{ ' + tok.name + ' }}'); }
- 
             try {
                 // Try executing the template with macro arguments
-                api_ctx.setArguments(tok.args);
-                tmpl.execute(tok.args, api_ctx, function (err, result) {
+                clone_ctx = _.clone(api_ctx).setArguments(tok.args);
+                tmpl.execute(tok.args, clone_ctx, function (err, result) {
                     if (err) { 
                         // There was an error executing the template. :(
                         errors.push(new TemplateExecutionError({

--- a/tests/fixtures/documents/library-test-expected.txt
+++ b/tests/fixtures/documents/library-test-expected.txt
@@ -1,3 +1,5 @@
 Testing a library:
 
-* The result was a SUCCESS!
+* First: The result was A HUGE SUCCESS!
+* Second: The result was A FOLLOWUP SUCCESS!
+* Third: The result was AN ENCORE!

--- a/tests/fixtures/documents/library-test.txt
+++ b/tests/fixtures/documents/library-test.txt
@@ -1,3 +1,5 @@
 Testing a library:
 
-* {{ library1-used("SUCCESS!") }}
+* First: {{ library1-used("A HUGE SUCCESS") }}
+* Second: {{ library1-used("A FOLLOWUP SUCCESS") }}
+* Third: {{ library1-used("AN ENCORE") }}

--- a/tests/fixtures/templates/library1-used.ejs
+++ b/tests/fixtures/templates/library1-used.ejs
@@ -1,2 +1,2 @@
 <% var library1 = require('library1'); %>
-<%= library1.result($0) %>
+The result <%= library1.result($0) %>

--- a/tests/fixtures/templates/library1.ejs
+++ b/tests/fixtures/templates/library1.ejs
@@ -1,5 +1,5 @@
 <%
-exports.result = function (str) {
-    return "The result was a " + str;
+module.exports.result = function (str) {
+    return "was " + str + "!";
 };
 %>


### PR DESCRIPTION
This reproduces & fixes a bug. I think it's bug 741582, but I'm not totally sure.
