### PR TITLE
Bug 747158 page exists

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -19,6 +19,7 @@
 
 // ### Prerequisites
 var util = require('util'),
+    crypto = require('crypto'),
     vm = require("vm"),
     _ = require('underscore'),
     async = require('async'),
@@ -63,14 +64,21 @@ var BaseAPI = ks_utils.Class({
 //
 // Grab bag of Kuma-specific API methods and utilities. 
 //
-// This has to live here, rather than in an auto-required template. Because,
-// it grants access to some node.js modules that are otherwise inaccessible to
-// templates which are not allowed to use require() from node.js
+// This has to live in a node.js module, rather than in an auto-required
+// template: It grants access to some node.js modules that are otherwise
+// inaccessible to templates which are not allowed to use node.js require()
+//
+// However, the contents here will be somewhat Kuma-specific. It might be less
+// useful to someone trying to use KumaScript separately from Kuma.
 var KumaAPI = ks_utils.Class(BaseAPI, {
 
     // #### debug
     // Expose util.debug from node.js
     debug: util.debug,
+
+    // #### inspect
+    // Expose util.inspect from node.js
+    inspect: util.inspect,
     
     // #### url
     // Expose url from node.js to templates
@@ -83,6 +91,30 @@ var KumaAPI = ks_utils.Class(BaseAPI, {
                  replace(/>/g,'&gt;').
                  replace(/</g,'&lt;').
                  replace(/"/g,'&quot;');
+    },
+
+    // #### baseUrl
+    // Get the base URL to documents in Kuma, based on the current page URL.
+    baseUrl: function () {
+        var p = this.url.parse(this.parent.env.url, true);
+        return p.protocol + '//' + p.host + '/en-US/docs/';
+    },
+
+    // #### pageExists
+    // Determine whether a Kuma page exists
+    pageExists: function (path) {
+        var $this = this;
+        var key = 'kuma:page_exists:' + this.parent.md5(path.toLowerCase());
+        return this.parent.cacheFn(key, 3600, function (next) {
+            var doc_url = $this.baseUrl() + path + '?raw'; 
+            var opts = { method: 'HEAD', url: doc_url };
+            request(opts, function (err, resp, body) {
+                if (resp && 200 == resp.statusCode) {
+                    result = true;
+                }
+                next(result);
+            });            
+        })
     }
 
 });
@@ -144,9 +176,9 @@ var APIContext = ks_utils.Class({
     initialize: function (options) {
         _.each(this.options.apis, _.bind(this.installAPI, this));
 
-        // Make the env vars more easily used, if given
-        if (this.options && this.options.env) {
+        if (this.options) {
             this.env = this.options.env;
+            this.log = this.options.log;
         }
 
         // Create a memcache instance, if necessary
@@ -239,24 +271,35 @@ var APIContext = ks_utils.Class({
     },
 
     // #### cacheFn
-    // Cache the results of a function
+    // Cache the results of a function with the given key and timeout
     cacheFn: function (key, tm_out, to_cache) {
         var result = null,
             f = new Future(),
+            env = this.env,
             mc = this.memcached;
         mc.get(key, function (err, c_result) {
-            if (c_result) {
-                result = c_result; f['return']();
+            if (c_result && env.cache_control != 'no-cache') {
+                result = c_result;
+                f['return']();
             } else {
                 to_cache(function (val) {
                     mc.set(key, val, tm_out, function (err, c_result) {
-                        result = val; f['return']();
+                        result = val;
+                        f['return']();
                     })
                 })
             }
         });
         f.wait();
         return result;
+    },
+
+    // #### md5
+    // Return the MD5 hex digest of the given utf8 string
+    md5: function (str) {
+        var md5 = crypto.createHash('md5')
+        md5.update(str, 'utf8');
+        return md5.digest('hex')
     },
 
     // #### template(name, arguments)

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -177,9 +177,8 @@ var Server = ks_utils.Class({
         var api_ctx = new ks_api.APIContext({
             server_options: $this.options,
             env: env_vars,
-            request: req,
-            response: res,
-            source: src
+            source: src,
+            log: res.log
         });
         
         try {


### PR DESCRIPTION
This depends on PR #9, review that one first.

This is 1/2 of the optimization for `wiki.pageExists`. It makes HTTP HEAD requests against Kuma, but caches the results in memcache.

The other 1/2 will be a Kuma pull request, offering a management command that preloads memcache with results straight from the database.

Between the two halves, `wiki.pageExists` should be a cache hit 99% of the time, with the 1% of misses covered by HTTP HEAD requests. (No, I didn't actually measure those percentages.)
