### PR TITLE
Bug 754921: improve messages with invalid syntax

### DIFF
--- a/lib/kumascript/parser.pegjs
+++ b/lib/kumascript/parser.pegjs
@@ -41,7 +41,22 @@ Arguments
   = "(" __ args:ArgumentList? __ ")" { return args; }
 
 ArgumentsJSON
-  = "(" json_args:[^)]+ ")" { return [JSON.parse(json_args.join(''))]; }
+  = "(" __ &"{" json_args:[^)]+ __ ")" {
+        try {
+            return [JSON.parse(json_args.join(''))];
+        } catch (e) {
+            // Try to provide better diagnostics than
+            // "Syntax error at line , column" using PEG's internal APIs.
+            var errorPosition = computeErrorPosition();
+            throw new PEG.parser.SyntaxError(
+              ["valid JSON object as the parameter of the preceding macro"],
+              json_args.join(''),
+              offset,
+              errorPosition.line,
+              errorPosition.column
+            );
+        }
+    }
 
 ArgumentList
   = head:Argument tail:(__ "," __ Argument)* {

--- a/tests/fixtures/macros-syntax-error-argumentlist.txt
+++ b/tests/fixtures/macros-syntax-error-argumentlist.txt
@@ -1,0 +1,9 @@
+Testing that an invalid ArgumentsList still
+produces a sensible error message.
+
+{{ add(1,) }}
+---
+Testing that an invalid ArgumentsList still
+produces a sensible error message.
+
+{{ add(1,) }}

--- a/tests/fixtures/macros-syntax-error-argumentsjson.txt
+++ b/tests/fixtures/macros-syntax-error-argumentsjson.txt
@@ -1,0 +1,16 @@
+Testing that an invalid ArgumentsJSON still
+produces a sensible error message.
+
+{{ MacroWithJson({
+    "es":"es/JavaScript/Acerca_de_JavaScript",
+    "en": "en/JavaScript/About_JavaScript",
+}) }}
+---
+Testing that an invalid ArgumentsJSON still
+produces a sensible error message.
+
+{{ MacroWithJson({
+    "es":"es/JavaScript/Acerca_de_JavaScript",
+    "en": "en/JavaScript/About_JavaScript",
+}) }}
+


### PR DESCRIPTION
1) When JSON.parse() failed on invalid JSON (e.g. extraneous trailing
comma) in ArgumentsJSON it raised a SyntaxError with no position
information, which was displayed to the user as:

  Syntax error at line , column : Unexpected token

2) Also before this change all invalid parameter syntax (such as
{{macro(1,)}} matched the ArgumentsJSON production, thus hitting the bug
(1) described above.

3) Also improved a helper in test-macros.js to help newbies (like
myself) understand the structure of the testcase fixtures.
