### PR TITLE
Strings in JSON arguments cannot contain ")"

### DIFF
--- a/lib/kumascript/parser.pegjs
+++ b/lib/kumascript/parser.pegjs
@@ -70,7 +70,7 @@ JSONArgument
     }
 
 JSONObject
-  = "{" __ JSONPair ( __ "," __ JSONPair )* __ "}"
+  = "{" ( __ JSONPair ( __ "," __ JSONPair )* )? __ "}"
 
 JSONPair
   = JSONString __ ":" __ JSONValue
@@ -89,7 +89,7 @@ JSONNumber
   = "-" ? ( "0" / [1-9] [0-9]* ) ( "." [0-9]+ )? ( [eE] [+-]? [0-9]+ )?
 
 JSONArray
-  = "[" __ JSONValue ( __ "," __ JSONValue ) __ "]"
+  = "[" ( __ JSONValue ( __ "," __ JSONValue ) )? __ "]"
 
 ArgumentList
   = head:Argument tail:(__ "," __ Argument)* {

--- a/tests/test-parser.js
+++ b/tests/test-parser.js
@@ -42,5 +42,16 @@ module.exports = nodeunit.testCase({
                    [{type: "MACRO", name: "f", args: [{a: "f)"}], offset: 0}],
                    "The macro is parsed correctly");
     test.done();
+  },
+
+  "Empty JSON values are allowed": function (test) {
+    var tokens = ks_parser.parse('{{ f({}) }}');
+    test.deepEqual(tokens, [{type: "MACRO", name: "f", args: [{}], offset: 0}],
+                   "Empty JSON objects are parsed correctly");
+
+    tokens = ks_parser.parse('{{ f({ "a": [] }) }}');
+    test.deepEqual(tokens, [{type: "MACRO", name: "f", args: [{a: []}], offset: 0}],
+                   "Empty JSON objects are parsed correctly");
+    test.done();
   }
 });


### PR DESCRIPTION
The page at https://developer.mozilla.org/en-US/docs/Introduction_%28alternate%29 has a syntax error:

```
Syntax error at line 15, column 61: Expected valid JSON object as the parameter of the preceding macro but "{ \"fr\": \"fr/Introduction_(alternative" found.
   15 | <p><br> {{ languages( { "fr": "fr/Introduction_(alternative)" }) }}</p>
--------------------------------------------------------------------^
```

This happens because the Kumascript parser does not allow ")" anywhere in a JSON argument, even within a string.  Here's a patch to fix this by adding a real JSON grammar based on the one at json.org.

This patch does _not_ change any of the non-JSON parsing, but as a follow-up perhaps some of the non-JSON rules like Number and DoubleQuotedArgumentChars could be merged with the JSON equivalents.
