### PR TITLE
Catch SIGTERM to gracefully clean up child processes & exit

### DIFF
--- a/run.js
+++ b/run.js
@@ -144,7 +144,14 @@ function runMaster () {
         process.exit(0);
     }
 
-    process.on('SIGINT', performExit);
+    process.on('SIGINT', function (err) {
+        log.info("Received SIGINT, exiting...");
+        performExit();
+    });
+    process.on('SIGTERM', function (err) {
+        log.info("Received SIGTERM, exiting...");
+        performExit();
+    });
     process.on('uncaughtException', function (err) {
         statsd.increment('kumascript.master_exceptions');
         log.error('uncaughtException:', err.message);


### PR DESCRIPTION
This is a fix for the recurring restart issues we've been having for kumascript in production. The parent process wasn't gracefully exiting on `kill -TERM`, and instead just said "see ya suckers" and orphaned all the child processes.
