### PR TITLE
bug 866459: Attempt to retry template loading on error

### DIFF
--- a/lib/kumascript/caching.js
+++ b/lib/kumascript/caching.js
@@ -378,7 +378,7 @@ module.exports.request = function (req_opts, cb) {
         // Handle a cache entry younger than max-age as an implicit 304
         var now = (new Date()).getTime();
         var age = (now - parseInt(validated_at)) / 1000;
-        if (age < max_age) {
+        if (max_age > 0 && age < max_age) {
             return handle304(memcached, key, timeout, null, false, cb);
         }
 

--- a/lib/kumascript/loaders.js
+++ b/lib/kumascript/loaders.js
@@ -139,6 +139,10 @@ var FileLoader = ks_utils.Class(BaseLoader, {
 var HTTPLoader = ks_utils.Class(BaseLoader, {
 
     default_options: {
+        // Maximum number of retry attempts
+        max_retries: 5,
+        // Time to wait between retry attempts
+        retry_wait: 100,
         // URL template used to resolve template name to URL.
         url_template: 'http://localhost/templates/{name}.ejs',
         // Class used to render templates
@@ -170,13 +174,24 @@ var HTTPLoader = ks_utils.Class(BaseLoader, {
             cache_control: this.options.cache_control,
             url: tmpl_url
         };
-        ks_caching.request(req_opts, function (err, resp, source, cache_hit) {
-            if (err) {
-                cb(err, null, false);
-            } else {
-                $this.compile(source, cb, cache_hit);
-            }
-        });
+
+        var retries_left = $this.options.max_retries;
+        var attempt = function () {
+            ks_caching.request(req_opts, function (err, resp, source, cache_hit) {
+                if (err || !source) {
+                    if (retries_left-- > 0) {
+                        $this.statsd.increment('loader.retries.overall');
+                        $this.statsd.increment('loader.retries.by_name.' + name);
+                        setTimeout(attempt, $this.options.retry_wait);
+                    } else {
+                        cb(err, null, false);
+                    }
+                } else {
+                    $this.compile(source, cb, cache_hit);
+                }
+            });
+        }
+        attempt();
     }
 
 });

--- a/lib/kumascript/macros.js
+++ b/lib/kumascript/macros.js
@@ -273,7 +273,7 @@ var MacroProcessor = ks_utils.Class(EventEmitter, {
             var loader_options = _.clone(this.options.loader.options);
 
             // Use a Cache-Control header that forces a fresh cache.
-            loader_options.cache_control = 'max-age=0';
+            loader_options.cache_control = 'no-cache';
             loader_options.statsd = this.statsd;
 
             var loader = new loader_class(loader_options);

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -46,6 +46,10 @@ var Server = ks_utils.Class({
         template_cache_control: "max-age=3600",
         // Prefix used in headers intended for env variables
         env_header_prefix: 'x-kumascript-env-',
+        // Max number of loader retries.
+        loader_max_retries: 5,
+        // Time to wait between loader retries.
+        loader_retry_wait: 100,
         // Max number of macro workers
         numWorkers: 16,
         // Max number of concurrent macro processing jobs per request.
@@ -89,7 +93,9 @@ var Server = ks_utils.Class({
                         memcache: this.options.memcache,
                         statsd_conf: this.options.statsd_conf,
                         url_template: this.options.template_url_template,
-                        cache_control: this.options.template_cache_control
+                        cache_control: this.options.template_cache_control,
+                        max_retries: this.options.loader_max_retries,
+                        retry_wait: this.options.loader_retry_wait
                     }
                 }
             });


### PR DESCRIPTION
Not sure this entirely addresses the issue, but we might try giving this a shot: If KumaScript encounters an error or blank content when attempting to load a template from Kuma, we'll wait a little bit and try again.
