### PR TITLE
Fix for JSON parsing that accepts only 2-item lists

### DIFF
--- a/lib/kumascript/parser.pegjs
+++ b/lib/kumascript/parser.pegjs
@@ -92,7 +92,7 @@ JSONNumber
   = "-" ? ( "0" / [1-9] [0-9]* ) ( "." [0-9]+ )? ( [eE] [+-]? [0-9]+ )?
 
 JSONArray
-  = "[" ( __ JSONValue ( __ "," __ JSONValue ) )? __ "]"
+  = "[" ( __ JSONValue ( __ "," __ JSONValue )* )? __ "]"
 
 ArgumentList
   = head:Argument tail:(__ "," __ Argument)* {

--- a/tests/test-parser.js
+++ b/tests/test-parser.js
@@ -10,11 +10,22 @@ var PEG = require("pegjs"),
 
 module.exports = nodeunit.testCase({
   "JSON values are parsed correctly": function (test) {
-    var tokens = ks_parser.parse('{{ f({ "a": "x", "b": -1e2, "c": 0.5, "d": [1,2] }) }}');
+    var tokens = ks_parser.parse('{{ f({ "a": "x", "b": -1e2, "c": 0.5, "d": [1,2, 3] }) }}');
     test.deepEqual(tokens,
                    [{type: "MACRO",
                      name: "f",
-                     args: [{a: "x", b: -1e2, c: 0.5, d: [1, 2]}],
+                     args: [{a: "x", b: -1e2, c: 0.5, d: [1, 2, 3]}],
+                     offset: 0}],
+                   "The macro is parsed correctly");
+    test.done();
+  },
+
+  "JSON parameter should allow a single-item list": function (test) {
+    var tokens = ks_parser.parse('{{ f({ "a": ["one"] }) }}');
+    test.deepEqual(tokens,
+                   [{type: "MACRO",
+                     name: "f",
+                     args: [{a: ["one"]}],
                      offset: 0}],
                    "The macro is parsed correctly");
     test.done();


### PR DESCRIPTION
Turns out the current JSON parsing only accepts 2-item lists. Any other number of items results in a syntax error
