### PR TITLE
fix bug 1044068 - Prevent 'Cannot call execute of null' errors

### DIFF
--- a/lib/kumascript/caching.js
+++ b/lib/kumascript/caching.js
@@ -9,7 +9,7 @@ var util = require('util'),
     request = require('request'),
     Memcached = require('memcached'),
     _ = require('underscore'),
-    
+
     // TODO: Someday, strip out kumascript dependencies and spin this off into
     // its own package.
     ks_utils = require(__dirname + '/utils');
@@ -87,7 +87,7 @@ module.exports.ResponseCache = ks_utils.Class({
         if (supported_methods.indexOf(method) === -1) {
             return $this.revalidate(null, {}, req, res, null, response_cb);
         }
-        
+
         // Start building a cache key with the URL path.
         var cache_key_parts = [
             url.parse(req.url).pathname
@@ -107,7 +107,7 @@ module.exports.ResponseCache = ks_utils.Class({
         // Build a cache key based on all the parts.
         var cache_key = 'response-cache:' + crypto.createHash('sha1')
             .update(cache_key_parts.join('|')).digest('hex');
-         
+
         // Handy for diagnostics, maybe not needed
         res.header('X-Cache-Key', cache_key);
 
@@ -150,7 +150,7 @@ module.exports.ResponseCache = ks_utils.Class({
     // Runs the real response handler, caches the result if necessary.
     //
     // Lots of monkeypatching here to intercept the response events and build
-    // the cache entry for storage. 
+    // the cache entry for storage.
     //
     revalidate: function (cache_key, opts, req, res, err, response_cb) {
         var $this = this,
@@ -238,16 +238,16 @@ module.exports.ResponseCache = ks_utils.Class({
         $this.sendCommonHeaders(req, res, meta);
 
         res.header('X-Cache', 'HIT');
-        
+
         _.each(headers, function (header) {
             res.header(header[0], header[1]);
         });
-        
+
         var method = req.method.toUpperCase();
         if ('HEAD' != method) {
             res.write(body, 'utf-8');
         }
-        
+
         res.end();
     },
 
@@ -316,7 +316,7 @@ module.exports.ResponseCache = ks_utils.Class({
 
         // See above.
         if (options.no_cache) { return next($this.ERR_MISS); }
-        
+
         $this.memcached.get(key + ':meta', function (err, meta) {
             // Punt, if $this key is not even in the cache
             if (!meta) { return next($this.ERR_MISS); }
@@ -363,7 +363,9 @@ module.exports.request = function (req_opts, cb) {
     var statsd = ks_utils.getStatsD(req_opts);
 
     var base_key = 'kumascript:request:' + ks_utils.md5(req_opts.url);
-    var key = function (name) { return base_key + ':' + name; }
+    var key = function (name) { 
+        return base_key + ':' + name; 
+    };
 
     var ua_cc = parseCacheControl(req_opts['cache_control'] || '');
     var max_age = 0;
@@ -372,38 +374,58 @@ module.exports.request = function (req_opts, cb) {
     } else if (!_.isUndefined(ua_cc['max-age'])){
         max_age = parseInt(ua_cc['max-age']);
     }
-    
-    memcached.get(key('validated_at'), function (err, validated_at) {
 
-        // Handle a cache entry younger than max-age as an implicit 304
-        var now = (new Date()).getTime();
-        var age = (now - parseInt(validated_at)) / 1000;
-        if (max_age > 0 && age < max_age) {
-            return handle304(memcached, key, timeout, null, false, cb);
+    // Due to #1044068 (https://bugzil.la/1044068),
+    // we cannot assume that we have the "body" as memcached may have dumped it
+    // If this does become the case, we must "force" a 200 from kuma
+    var force200 = false;
+    memcached.get(key('body'), function(bodyCheckErr, bodyCheckResult) {
+        if(bodyCheckResult === false || bodyCheckResult === undefined) {
+            force200 = true;
         }
 
-        // Otherwise, issue a conditional GET request using the cached
-        // last-modified time.
-        memcached.get(key('last_mod'), function (err, last_mod) {
-            try {
-                buildHeaders(req_opts, last_mod);
-                request(req_opts, function (err, resp, source) {
-                    if (err) {
-                        cb(err, null);
-                    } else if (304 == resp.statusCode) {
-                        handle304(memcached, key, timeout, resp, true, cb);
-                    } else if (200 == resp.statusCode) {
-                        handle200(memcached, key, timeout, resp, source, cb);
-                    } else {
-                        cb("status " + resp.statusCode, null, null, false);
-                    }
-                });
-            } catch(e) {
-                cb(e, null, null, false);
-            }
-        });
+        memcached.get(key('validated_at'), function (err, validated_at) {
 
+            // Handle a cache entry younger than max-age as an implicit 304
+            // but only if we have the body since we're assuming 304
+            if(!force200) {
+                var now = (new Date()).getTime();
+                var age = (now - parseInt(validated_at)) / 1000;
+                if (max_age > 0 && age < max_age) {
+                    return handle304(memcached, key, timeout, null, false, cb);
+                }
+            }
+
+            // Otherwise, issue a conditional GET request using the cached
+            // last-modified time.
+            memcached.get(key('last_mod'), function (err, last_mod) {
+                try {
+                    // last_mod forces kuma to return a 200
+                    if(force200) {
+                       last_mod = 0;
+                    }
+                    buildHeaders(req_opts, last_mod);
+
+                    request(req_opts, function (err, resp, source) {
+                        if (err) {
+                            cb(err, null);
+                        } else if (304 == resp.statusCode) {
+                            handle304(memcached, key, timeout, resp, true, cb);
+                        } else if (200 == resp.statusCode) {
+                            handle200(memcached, key, timeout, resp, source, cb);
+                        } else {
+                            cb("status " + resp.statusCode, null, null, false);
+                        }
+                    });
+                } catch(e) {
+                    cb(e, null, null, false);
+                }
+            });
+
+        });
     });
+
+
 };
 
 // Build headers for conditional GET, but only if we're not under a

--- a/lib/kumascript/utils.js
+++ b/lib/kumascript/utils.js
@@ -72,6 +72,10 @@ var FakeMemcached = Class({
     },
     get: function (key, next) {
         next(null, this._cache[key]);
+    },
+    remove: function (key, next) {
+        delete this._cache[key];
+        next(null, true);
     }
 });
 


### PR DESCRIPTION
This is a working PR and should be treated as such.  Likely lots of conversation below.

Still to complete:
- [x] - A test to confirm my PR prevents the issue.
