### PR TITLE
Updated the cssxref() macro's link text logic

### DIFF
--- a/macros/MDN-Common.ejs
+++ b/macros/MDN-Common.ejs
@@ -1,5 +1,5 @@
 <% var MDN = module.exports = {
-    
+
     /**
      * Return an HTML link using the given url, text, and title.
      */
@@ -11,7 +11,7 @@
             '</a>'
         ].join('');
     },
-    
+
     /**
      * Given a set of names and a corresponding list of values, apply HTML
      * escaping to each of the values and return an object with the results
@@ -24,7 +24,7 @@
         });
         return e;
     },
-    
+
     /**
      * Given a set of strings like this:
      *     { "en-US": "Foo", "de": "Bar", "es": "Baz" }
@@ -67,7 +67,7 @@
      *    "bye": { "en-US": "Goodbye!", "de": "Auf Wiedersehen!" }
      *   }
      * Returns the one, which matches the current locale.
-     * 
+     *
      * Example:
      *   getLocalString({"hello": {"en-US": "Hello!", "de": "Hallo!"}},
      *       "hello");
@@ -85,24 +85,24 @@
 
         return strings[key][lang];
     },
-    
+
     /**
      * Given a string, replaces all placeholders outlined by
      * $1$, $2$, etc. (i.e. numeric placeholders) or
      * $firstVariable$, $secondVariable$, etc. (i.e. string placeholders)
      * within it.
-     * 
+     *
      * If numeric placeholders are used, the 'replacements' parameter must be
      * an array. The number within the placeholder indicates the index within the
      * replacement array starting by 1.
      * If string placeholders are used, the 'replacements' parameter must be an
      * object. Its property names represent the placeholder names and their
      * values the values to be inserted.
-     * 
+     *
      * Examples:
      *   replacePlaceholders("$1$ $2$, $1$ $3$!", ["hello", "world", "contributor"])
      *   => "hello world, hello contributor!"
-     * 
+     *
      *   replacePlaceholders("$hello$ $world$, $hello$ $contributor$!",
      *       {hello: "hallo", world: "Welt", contributor: "Mitwirkender"})
      *   => "hallo Welt, hallo Mitwirkender!"
@@ -120,7 +120,8 @@
     },
 
     /**
-     * Given a string, escapes all quotes within it.
+     * Given a string, escapes all quotes within it and removes all
+     * HTML tags, leaving only plaintext.
      */
     escapeQuotes: function(a) {
         var b = "";
@@ -131,7 +132,7 @@
         }
         return b.replace(/(<([^>]+)>)/ig, "");
     },
-    
+
     /**
      * #### fetchCompatTableJSON
      * Sets proper headers and makes a request to get compat table data
@@ -153,10 +154,10 @@
     getFileContent: function(fileObjOrUrl) {
         var url = fileObjOrUrl.url || fileObjOrUrl;
         if(!url) return '';
-        
+
         var result = '',
             base_url = '';
-        
+
         // New file urls include attachment host, so we don't need to prepend it
         var fUrl = kuma.url.parse(url);
         if (!fUrl.host) {
@@ -186,7 +187,7 @@
 
     /**
      * #### cacheFnIgnoreCacheControl
-     * Cache a function, and use cached results no matter what 
+     * Cache a function, and use cached results no matter what
      * Cache-Control we get from a shift-refresh.
      */
     cacheFnIgnoreCacheControl: function (key, tm_out, to_cache) {
@@ -217,7 +218,7 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### memcacheSet(key, value, timeout)
     //
     // Store a value in memcache with the given key and timeout (in seconds)
@@ -235,7 +236,7 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### memcacheGet(key)
     //
     // Fetch the value for a key from memcache
@@ -253,11 +254,11 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### defaults(object, *defaults)
     //
-    // Fill in undefined properties in object with values from the defaults 
-    // objects, and return the object. As soon as the property is filled, 
+    // Fill in undefined properties in object with values from the defaults
+    // objects, and return the object. As soon as the property is filled,
     // further defaults will have no effect.
     //
     // Stolen from http://underscorejs.org/#defaults
@@ -271,25 +272,25 @@
         });
         return obj;
     },
-        
+
     // #### fetchJSONResource
-    // Fetch an HTTP resource with JSON representation, parse the JSON and 
+    // Fetch an HTTP resource with JSON representation, parse the JSON and
     // return a JS object.
     fetchJSONResource: function (url, opts) {
         opts = MDN.defaults(opts || {}, {
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': 'application/json',
                        'Content-Type': 'application/json' },
         });
         return JSON.parse(MDN.fetchHTTPResource(url, opts));
     },
-    
+
     // #### fetchHTTPResource
     // Fetch an HTTP resource, return the response body.
     fetchHTTPResource: function (url, opts) {
         opts = MDN.defaults(opts || {}, {
             method: 'GET',
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': "text/plain",
                        'Content-Type': "text/plain" },
             url: url,
@@ -330,11 +331,11 @@
                             next(buffer.toString());
                         }
                     });
-                });                 
-                req.on('error', function(err) { next(null); });                
+                });
+                req.on('error', function(err) { next(null); });
             } catch (e) {
                 next(null);
-            }            
+            }
         };
         if (opts.ignore_cache_control) {
             return MDN.cacheFnIgnoreCacheControl(opts.cache_key, opts.cache_timeout, to_cache);
@@ -342,13 +343,13 @@
             return cacheFn(opts.cache_key, opts.cache_timeout, to_cache);
         }
     },
-    
+
     /* Returns the appropriate string (usually a comma+space) for usage in a enumeration list for the current locale */
     listSeparator: function() {
         var listSeparators = { "en-US": ", ", "ar": "،", "fa": "،", "ja": "、", "ko": "·", "mn": "᠂", "ur": "،", "zh−TW": "、" };
         return mdn.localString(listSeparators);
     },
-    
+
     /*
      * FILE READING
      *
@@ -359,39 +360,39 @@
       // Check to see if the delimiter is defined. If not,
       // then default to comma.
       strDelimiter = (strDelimiter || ",");
-    
+
       // Create a regular expression to parse the CSV values.
       var objPattern = new RegExp(
         (
           // Delimiters.
           "(\\" + strDelimiter + "|\\r?\\n|\\r|^)" +
-    
+
           // Quoted fields.
           "(?:\"([^\"]*(?:\"\"[^\"]*)*)\"|" +
-    
+
           // Standard fields.
           "([^\"\\" + strDelimiter + "\\r\\n]*))"
         ),
         "gi"
         );
-    
-    
+
+
       // Create an array to hold our data. Give the array
       // a default empty first row.
       var arrData = [[]];
-    
+
       // Create an array to hold our individual pattern
       // matching groups.
       var arrMatches = null;
-    
-    
+
+
       // Keep looping over the regular expression matches
       // until we can no longer find a match.
       while (arrMatches = objPattern.exec( strData )){
-    
+
         // Get the delimiter that was found.
         var strMatchedDelimiter = arrMatches[ 1 ];
-    
+
         // Check to see if the given delimiter has a length
         // (is not the start of string) and if it matches
         // field delimiter. If id does not, then we know
@@ -400,53 +401,53 @@
           strMatchedDelimiter.length &&
           (strMatchedDelimiter != strDelimiter)
           ){
-    
+
           // Since we have reached a new row of data,
           // add an empty row to our data array.
           arrData.push( [] );
-    
+
         }
-    
-    
+
+
         // Now that we have our delimiter out of the way,
         // let's check to see which kind of value we
         // captured (quoted or unquoted).
         if (arrMatches[ 2 ]){
-    
+
           // We found a quoted value. When we capture
           // this value, unescape any double quotes.
           var strMatchedValue = arrMatches[ 2 ].replace(
             new RegExp( "\"\"", "g" ),
             "\""
             );
-    
+
         } else {
-    
+
           // We found a non-quoted value.
           var strMatchedValue = arrMatches[ 3 ];
-    
+
         }
-    
-    
+
+
         // Now that we have our value string, let's add
         // it to the data array.
         arrData[ arrData.length - 1 ].push( strMatchedValue );
       }
-    
+
       // Return the parsed data.
       return( arrData );
     },
-    
+
     loadArrayFromCSV: function(url, separator) {
         url = url.replace(/&amp;/i, "&");
         var html = MDN.fetchHTTPResource(url, {
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': 'text/csv',
                        'Content-Type': 'text/csv' },
         });
         return MDN.CSVToArray(html, separator);
     },
-    
+
     /* http://www.bugzilla.org/docs/4.2/en/html/api/Bugzilla/WebService/Bug.html#search */
     bzSearch: function (query) {
         /* Fix colon (":") encoding problems */

--- a/macros/cssxref.ejs
+++ b/macros/cssxref.ejs
@@ -13,7 +13,7 @@
 
   Examples:
   {{cssxref("background")}} =>
-      <a href="/en-US/docs/Web/CSS/background" title="The background CSS 
+      <a href="/en-US/docs/Web/CSS/background" title="The background CSS
       property is..."><code>background</code></a>
   {{cssxref("length")}} =>
       <a href="/en-US/docs/Web/CSS/length" title="The <length> CSS data type
@@ -22,7 +22,7 @@
       <a href="/en-US/docs/Web/CSS/linear-gradient" title="The CSS
       linear-gradient() function creates..."><code>linear-gradient()</code></a>
   {{cssxref("margin-top", "top margin")}} =>
-      <a href="/en-US/docs/Web/CSS/margin-top" title="The margin-top CSS 
+      <a href="/en-US/docs/Web/CSS/margin-top" title="The margin-top CSS
       property of an element sets..."><code>top margin</code></a>
   {{cssxref("filter", "", "#url")}} =>
       <a href="/en-US/docs/Web/CSS/filter#url()"><code>filter</code></a>
@@ -31,8 +31,9 @@
 var lang = env.locale;
 var url = "";
 var urlWithoutAnchor = "";
-var str = ($1 || $0);
+var linkText = ($1 || $0);
 var localStrings = string.deserialize(template("L10n:Common"));
+var summary = "";
 
 // Deal with CSS data types by removing <>
 var slug = $0.replace(/&lt;(.*)&gt;/g, '$1');
@@ -48,38 +49,37 @@ switch ($0) {
         break;
 }
 
-str = str.toLowerCase();
 urlWithoutAnchor = "/" + lang + "/docs/Web/CSS/" + slug;
 url = urlWithoutAnchor + $2;
 
-var thisPage = null; // Will be lazy evaluated
+var targetPage = wiki.getPage(urlWithoutAnchor);
+
+// If the link text parameter wasn't included, try to use the
+// title of the target page.
+
 if (!$1) {
-    thisPage = wiki.getPage(urlWithoutAnchor); // lazy evaluation
-
-    // Append parameter brackets to CSS functions
-    if (page.hasTag(thisPage, "CSS Function")) {
-        str += "()";
+    if (targetPage && targetPage.title) {
+        linkText = kuma.htmlEscape(targetPage.title);
     }
 
-    // Enclose CSS data types in arrow brackets
-    if (page.hasTag(thisPage, "CSS Data Type") && !/^&lt;.+&gt;$/.test(str)) {
-        str = "&lt;" + str + "&gt;";
-    }
-}
+    // If the link text has a space in it, we won't wrap it in
+    // <code>, since the text is obviously not an API term.
 
-var summary = "";
-
-if (!$2) {
-    //if (!thisPage) thisPage = wiki.getPage(url); // lazy evaluation // Disabled to test performance (we get a lot of Kumascript errors)
-
-    if (thisPage && thisPage.summary) {
-        summary = mdn.escapeQuotes(thisPage.summary);
-    } else {
-        summary = mdn.getLocalString(localStrings, "summary");
+    if (!linkText.includes(" ")) {
+        linkText = "<code>" + linkText + "</code>";
     }
 }
 
-var entry = "<a href=\"" + url + "\"" + (summary?" title=\""+summary+"\"":"") + "><code>" + str + "</code></a>";
+// If the page has a summary, grab it for the tooltip; otherwise,
+// use the default tooltip string.
+
+if (targetPage.summary) {
+    summary = mdn.escapeQuotes(targetPage.summary);
+} else {
+    summary = mdn.getLocalString(localStrings, "summary");
+}
+
+var entry = "<a href=\"" + url + "\"" + (summary?" title=\""+summary+"\"":"") + ">" + linkText + "</a>";
 
 
 %><%- entry %>


### PR DESCRIPTION
This code updates cssxref() to use simpler logic to select the link text for the target page. If the page exists, the macro now by default uses the page's title as the link text, unless $1 is specified, in which case that is used instead. If the page doesn't exist, then $1 is used, falling back to $0 if $1 isn't given.

This makes the code simpler and cleaner, but more importantly, corrects the display of CSS terms like translateX(), where the name is mixed-case; the macro was previously forcing them to lower-case.