### PR TITLE
Created the new ListGroups macro

### DIFF
--- a/macros/ListGroups.ejs
+++ b/macros/ListGroups.ejs
@@ -1,0 +1,103 @@
+<%
+// ListGroups
+//
+// Generates a list of each group (API) from the GroupData JSON and
+// returns it. This can be used to create an index of APIs.
+
+var locale = env.locale;
+var APIHref = '/' + locale + '/docs/Web/API';
+var output = '';
+
+// Conveniences to shorten names of some functions
+
+var htmlEscape = kuma.htmlEscape;
+var spacesToUnderscores = web.spacesToUnderscores;
+
+// Get the GroupData database
+
+var groupData = string.deserialize(template('GroupData'))[0];
+var groupNames = Object.keys(groupData);
+groupNames.sort();
+
+function containsTag(tagList, tag) {
+  var ret = false;
+
+  if (!tagList || tagList == undefined) {
+    return 0;
+  }
+  tag = tag.toLowerCase();
+  tagList.forEach(function(t) {
+    if (t.toLowerCase() === tag) {
+      ret = true;
+    }
+  });
+  return ret;
+}
+
+// Start building the lists for each letter
+
+var outputByLetter = [];
+
+groupNames.forEach(function(name, idx, arr) {
+  var groupObj = groupData[name];
+  var firstLetter = name[0];
+  var groupOutput = '';
+  var overviewName = name;
+  var badge = "";
+
+  if (groupObj.hasOwnProperty("overview")) {
+    overviewName = groupObj.overview;
+  }
+
+  var groupUrl = APIHref + "/" + spacesToUnderscores(htmlEscape(overviewName));
+  var page = wiki.getPage(groupUrl);
+
+  // Go through the tags and build badges if there are any to add
+
+  if (page && page != undefined) {
+    var tags = page.tags;
+
+    if (tags) {
+      if (containsTag(tags, "Non-standard") || containsTag(tags, "Non standard")) {
+        badge = " " + template("NonStandardBadge", ["1"]);
+      }
+
+      if (containsTag(tags, "Obsolete")) {
+        badge += " " + template("ObsoleteBadge", [1]);
+      } else if (containsTag(tags, "Deprecated")) {
+        badge += " " + template("DeprecatedBadge", [1]);
+      }
+
+      if (containsTag(tags, "Experimental")) {
+        badge += " " + template("ExperimentalBadge", [1]);
+      }
+
+      if (badge.length) {
+        badge = "<span class='indexListBadges'>" + badge + "</span>";
+      }
+    }
+  }
+
+  // Finish constructing the HTML and then append it to the text for the corresponding
+  // letter group.
+
+  var groupOutput = "<li><a href='" + groupUrl + "'>" + name + "</a>" + badge + "</li>";
+
+  if (!outputByLetter[firstLetter]) {
+    outputByLetter[firstLetter] = groupOutput;
+  } else {
+    outputByLetter[firstLetter] += groupOutput;
+  }
+});
+
+// Now output the whole thing
+
+var keys = Object.keys(outputByLetter);
+
+keys.forEach(function(letter, idx, arr) {
+  output += "<span>" + letter + "</span><ul>" + outputByLetter[letter] + "</ul>";
+});
+
+%><div class="index">
+  <%-output%>
+</div>


### PR DESCRIPTION
This macro pulls in the contents of GroupData.json, then constructs a set of alphabetically-grouped lists of each group, with links to the groups' overview pages. This makes it easy to create and have automatically maintained a list of all APIs on MDN.

At this point, I'm mostly looking for feedback on the output. I have a couple of places where this could be handy (especially if I find a way to look for APIs in a given subset of MDN's content). This will also help me with the replacement of the current Web/API landing page, which everyone hates.