### PR TITLE
Add Input Events Level 2.

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -641,6 +641,10 @@ var specList = {
         name : 'InputDeviceCapabilities',
         url  : 'http://wicg.github.io/InputDeviceCapabilities/'
     },
+    'InputEvents2': {
+        name : 'Input Events Level 2',
+        url  : 'https://w3c.github.io/input-events/index.html'
+    },
     'IntersectionObserver': {
         name : 'Intersection Observer',
         url  : 'https://wicg.github.io/IntersectionObserver/'

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -168,6 +168,7 @@ var status = {
   'HTML5.2'                    : 'ED',
   'HTML WHATWG'                : 'Living',
   'InputDeviceCapabilities'    : 'ED',
+  'InputEvents2'               : 'ED',
   'IndexedDB'                  : 'REC',
   'IndexedDB 2'                : 'ED',
   'IntersectionObserver'       : 'ED',

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -168,7 +168,7 @@ var status = {
   'HTML5.2'                    : 'ED',
   'HTML WHATWG'                : 'Living',
   'InputDeviceCapabilities'    : 'ED',
-  'InputEvents2'               : 'ED',
+  'InputEvents2'               : 'WD',
   'IndexedDB'                  : 'REC',
   'IndexedDB 2'                : 'ED',
   'IntersectionObserver'       : 'ED',


### PR DESCRIPTION
[Items listed here](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent) are part of this spec, not DOM Level 3 Events as shown.