### PR TITLE
bug 1395684: fix api-test for require()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ services:
   - docker
 
 before_script:
+  # Remove the local, Travis-generated "node_modules" directory, because when
+  # we run the linters and tests, the local directory will be mounted into the
+  # container and its "node_modules" directory would override the one we want
+  # used, which is the one located at the root-level of the container.
+  - rm -rf node_modules
   # Move TravisCI's checkout of kumascript into a submodule of kuma
   - cd ..
   - git clone https://github.com/mozilla/kuma --depth 2

--- a/tests/fixtures/documents/require-test-expected.txt
+++ b/tests/fixtures/documents/require-test-expected.txt
@@ -1,4 +1,4 @@
 Testing "require" of npm package:
 
-* First: Does "version" exist? yes!
-* Second: Does "data.css.properties" exist? yes!
+* First: Does "http.headers.Accept" exist? yes!
+* Second: Does "css.properties" exist? yes!

--- a/tests/fixtures/documents/require-test.txt
+++ b/tests/fixtures/documents/require-test.txt
@@ -1,4 +1,4 @@
 Testing "require" of npm package:
 
-* First: {{ require-used("version") }}
-* Second: {{ require-used("data.css.properties") }}
+* First: {{ require-used("http.headers.Accept") }}
+* Second: {{ require-used("css.properties") }}


### PR DESCRIPTION
This fixes the api test "A template can import an npm module with require()", which started failing when the new `mdn-browser-compat-data` npm module, which has a new format, was released.
The test is using a test macro called `require-used` that is called with arguments assuming the old BCD format (e.g., the "version" and "data" keys), so I simply changed the arguments based on the new format.