### PR TITLE
bug 1395745: add endpoint for serving revision hash

### DIFF
--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -138,6 +138,7 @@ var Server = ks_utils.Class({
             app.get('/macros/?', _.bind($this.macros_list_GET, $this));
             app.get('/healthz/?', _.bind($this.liveness_GET, $this));
             app.get('/readiness/?', _.bind($this.readiness_GET, $this));
+            app.get('/revision/?', _.bind($this.revision_GET, $this));
         });
     },
 
@@ -287,6 +288,14 @@ var Server = ks_utils.Class({
                 res.status(503).send(msg);
             }
         });
+    },
+
+    // #### GET /revision
+    //
+    // Return the value of the git commit hash for HEAD.
+    revision_GET: function (req, res) {
+        res.set({'content-type': 'text/plain; charset=utf-8'})
+           .send(process.env.REVISION_HASH || "undefined");
     },
 
     // #### _evalMacros()

--- a/tests/test-server.js
+++ b/tests/test-server.js
@@ -315,4 +315,12 @@ describe('test-server', function () {
             );
         });
     });
+
+    it('Revision endpoint returns git commit hash', function (done) {
+        testRequest(getURL('/revision'), done, function (resp, result) {
+            assert.equal(resp.statusCode, 200);
+            assert.equal(result, process.env.REVISION_HASH);
+            assert.equal(resp.headers['content-type'], 'text/plain; charset=utf-8');
+        });
+    });
 });


### PR DESCRIPTION
This PR adds the `/revision` endpoint and associated test. It depends on https://github.com/mozilla/kuma/pull/4399. The endpoint returns the value of the environment variable `REVISION_HASH`, the git commit hash of HEAD baked into the kumascript Docker image at the time of the build.