### PR TITLE
bug 760240: provide interactive-examples settings to macros

### DIFF
--- a/lib/kumascript/conf.js
+++ b/lib/kumascript/conf.js
@@ -46,6 +46,9 @@ var DEFAULT_CONFIG = {
         enabled: true,
         host: "127.0.0.1",
         port: 9070
+    },
+    interactive_examples: {
+        base_url: "https://interactive-examples.mdn.mozilla.net"
     }
 };
 

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -324,6 +324,11 @@ var Server = ks_utils.Class({
                 env.revalidate_at = (new Date()).getTime();
             }
 
+            // Add a clone of the interactive-examples settings to "env".
+            env.interactive_examples = ks_conf.nconf.get(
+                'interactive_examples'
+            );
+
             var ctx = {
                 env: env,
                 log: res.log

--- a/macros/EmbedInteractiveExample.ejs
+++ b/macros/EmbedInteractiveExample.ejs
@@ -10,7 +10,7 @@
 let jsEditorClass = "";
 let surveyClass = "interactive-editor-survey";
 let surveyLink = "https://www.surveygizmo.com/s3/3780959/MDN-Interactive-Editor";
-let url = "https://interactive-examples.mdn.mozilla.net/" + $0;
+let url = kuma.url.resolve(env.interactive_examples.base_url, $0);
 
 if ($0.includes('/js/')) {
     jsEditorClass = 'interactive-js';

--- a/tests/macros/test-EmbedInteractivExample.js
+++ b/tests/macros/test-EmbedInteractivExample.js
@@ -1,0 +1,41 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('EmbedInteractiveExample', function () {
+    itMacro('Typical settings and argument', function (macro) {
+        macro.ctx.env.interactive_examples = {
+            base_url: "https://interactive-examples.mdn.mozilla.net",
+        };
+        return assert.eventually.equal(
+            macro.call('pages/css/animation.html'),
+            `<iframe class="interactive " width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/css/animation.html"></iframe><p class="interactive-editor-survey">We would like to get your feedback on our new interactive editor. If you have a minute, <a href="https://www.surveygizmo.com/s3/3780959/MDN-Interactive-Editor" rel="noopener">take our survey</a>, and contribute to the future of MDN.</p>`
+        );
+    });
+    itMacro('Changes in settings and argument are reflected', function (macro) {
+        macro.ctx.env.interactive_examples = {
+            base_url: "https://www.fleetwood-mac.com",
+        };
+        return assert.eventually.equal(
+            macro.call('pages/http/headers.html'),
+            `<iframe class="interactive " width="100%" height="250" frameborder="0" src="https://www.fleetwood-mac.com/pages/http/headers.html"></iframe><p class="interactive-editor-survey">We would like to get your feedback on our new interactive editor. If you have a minute, <a href="https://www.surveygizmo.com/s3/3780959/MDN-Interactive-Editor" rel="noopener">take our survey</a>, and contribute to the future of MDN.</p>`
+        );
+    });
+    itMacro('Trailing slash in setting and leading slash in argument', function (macro) {
+        macro.ctx.env.interactive_examples = {
+            base_url: "https://interactive-examples.mdn.mozilla.net/",
+        };
+        return assert.eventually.equal(
+            macro.call('/pages/css/animation.html'),
+            `<iframe class="interactive " width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/css/animation.html"></iframe><p class="interactive-editor-survey">We would like to get your feedback on our new interactive editor. If you have a minute, <a href="https://www.surveygizmo.com/s3/3780959/MDN-Interactive-Editor" rel="noopener">take our survey</a>, and contribute to the future of MDN.</p>`
+        );
+    });
+});


### PR DESCRIPTION
This PR:
- adds the interactive-example settings to kumascript, and makes them available in macros via the `env.interactive_examples` object
- changes the `EmbedInteractiveExample.ejs` macro to use the new setting, as well as provides tests for the macro
- is meant to replace the approach outlined in https://github.com/mozilla/kuma/pull/4404#issuecomment-327259243, which although [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) seemed like an unnecessarily complicated way to provide the setting to kumascript.
- does not provide the survey URL as part of the settings, since that seems only temporary per https://github.com/mozilla/kuma/pull/4404#issuecomment-327328890