### PR TITLE
bug 1398947: use KS_VERSION instead of VERSION

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node {
     switch (env.BRANCH_NAME) {
       case 'master':
         stage('Build') {
-          sh 'make build-kumascript VERSION=latest'
+          sh 'make build-kumascript KS_VERSION=latest'
         }
 
         stage('Lint') {
@@ -47,7 +47,7 @@ node {
         }
 
         stage('Push KumaScript Docker Image') {
-          sh 'make push-kumascript VERSION=latest'
+          sh 'make push-kumascript KS_VERSION=latest'
         }
 
         break


### PR DESCRIPTION
This PR fixes the Jenkins build/push pipeline for the Kumascript master branch (see https://ci.us-west.moz.works/blue/organizations/jenkins/kumascript_multibranch_pipeline/detail/master/187/pipeline). When running the "build-kumascript" and "push-kumascript" commands within the Kuma-based Makefile, we were using `VERSION=latest` when we should have been using `KS_VERSION=latest`. This resulted in running the Kumascript tests (`make test VERSION=latest`) against an image different from the one just built using `make build-kumascript VERSION=latest`.