### PR TITLE
Fix spec status for Navigator.share

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -289,6 +289,7 @@ var status = {
   'WebIDL'                     : 'CR',
   'WebMIDI API'                : 'WD',
   'Web Notifications'          : 'Living',
+  'Web Share API'              : 'ED',
   'Web Speech API'             : 'Draft',
   'WebRTC 1.0'                 : 'WD',
   'Web Telephony'              : 'Draft',


### PR DESCRIPTION
In https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share