### PR TITLE
Update possible values list.

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -6,12 +6,16 @@
 // List of all specifications and their current status.
 //
 // Possible values:
-//  ED          Editor's Draft
-//  WD          Working Draft
-//  CR          Candidate Recommendation
-//  REC         Recommendation
+//  ED          W3C Editor's Draft
+//  WD          W3C Working Draft
+//  CR          W3C Candidate Recommendation
+//  PR          W3C Proposed Recommendation
+//  REC         W3C Recommendation
+//  Draft       Drafts put out by groups other than W3C
 //  Living      A living specification (constantly maintained)
+//  Obsolete    An obsolete standard
 //  Standard    A long-time accepted standard, unspecified
+//  RFC         An IETF request for comment
 //
 
 var status = {


### PR DESCRIPTION
There are abbreviations processed by the macro that aren't listed in the Possible values. There are still 3 abbreviations that aren't listed and that need special consideration.

RR ('Release Candidate') and LC ('Last Call Working Draft') - There are currently no specs that use these. I recommend removing them as possible labels, unless they're considered needed but rare.

Old-Transforms ('This has been merged in another draft. Please update.') - Seems to have been created for 'CSS3 2D Transforms' and ‘CSS3 3D Transforms’. Something else should be used in stead and the status removed from the macro. I don’t have a recommendation because I haven’t seen a page that uses them.