### PR TITLE
updating groupdata to account for changes in spec to fetch abort

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -406,7 +406,9 @@
         },
         "DOM": {
             "overview":   [ "Document Object Model" ],
-            "interfaces": [ "Attr",
+            "interfaces": [ "AbortController",
+                            "AbortSignal",
+                            "Attr",
                             "ByteString",
                             "CDATASection",
                             "CharacterData",
@@ -563,11 +565,7 @@
             "interfaces": [ "Body",
                             "Headers",
                             "Request",
-                            "Response",
-                            "FetchController",
-                            "FetchObserver",
-                            "FetchSignal",
-                            "ObserverCallback" ],
+                            "Response" ],
             "methods":    [ "WindowOrWorkerGlobalScope.fetch()" ],
             "properties": [],
             "events":     []


### PR DESCRIPTION
In the Fetch API, we had the experimental FetchController and FetchSignal interfaces - these have now become AbortController and AbortSignal, and now live in the DOM spec

* https://dom.spec.whatwg.org/#interface-abortcontroller
* https://dom.spec.whatwg.org/#interface-AbortSignal