### PR TITLE
Fix bug 1275856 - added MediaRecorderErrorEvent

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1107,6 +1107,7 @@
         "MediaStream Recording": {
             "overview":   [ "MediaStream Recording API" ],
             "interfaces": [ "MediaRecorder",
+                            "MediaRecorderErrorEvent",
                             "BlobEvent" ],
             "methods":    [],
             "properties": [],


### PR DESCRIPTION
Added this interface to the list of interfaces under the
MediaStream Recording API.