### PR TITLE
Integrate mdn-data npm package

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -469,6 +469,11 @@
       "from": "mdn-browser-compat-data@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.1.tgz"
     },
+    "mdn-data": {
+      "version": "1.0.0",
+      "from": "mdn-data@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.0.0.tgz"
+    },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "request": "2.79.0",
     "underscore": "1.8.3",
     "winston": "2.3.0",
-    "mdn-browser-compat-data": "0.x"
+    "mdn-browser-compat-data": "0.x",
+    "mdn-data": "1.x"
   },
   "devDependencies": {
     "mocha": "3.4.1",


### PR DESCRIPTION
We are currently using data stored in the mdn-data by directly accessing the github file from kumascript.

We agreed this was a bad idea, and a temporary workaround.

As I am moving the data stored in {{InterfaceData}} macro (macros/InterfaceData.json) in mdn/data [I don't want to extend the workaround solution, now that we have TheGoodWay(tm) of doing it], I need kumascript to be able to access mdn/data content like it does for mdn/browser-compat-data.

Once this is done, I will be able to create a new macro using it, and we will be able to remove direct calls to github from 4 macros :-)

I'm not 100% sure I've not done all the set-up needed here. So be especially careful during the review. Thank you very much.