### PR TITLE
bug 1407454: create and register hash-tagged image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ node {
     switch (env.BRANCH_NAME) {
       case 'master':
         stage('Build') {
+          sh 'make build-kumascript'
           sh 'make build-kumascript KS_VERSION=latest'
         }
 
@@ -47,6 +48,7 @@ node {
         }
 
         stage('Push KumaScript Docker Image') {
+          sh 'make push-kumascript'
           sh 'make push-kumascript KS_VERSION=latest'
         }
 


### PR DESCRIPTION
Start creating and registering hash-tagged Docker images for Kumascript on Jenkins builds for the `master` branch. This solidifies Kubernetes deployments as well as allows them to be rolled back.

We still need to create and register `latest`-tagged images, as they're used for local development.