### PR TITLE
bug 1408460: Update Live Sample URL for AWS stage

### DIFF
--- a/macros/LiveSampleURL.ejs
+++ b/macros/LiveSampleURL.ejs
@@ -20,13 +20,16 @@ base = base.replace('developer.mozilla.org', 'mdn.mozillademos.org');
 // HACK: This may be the result of server misconfiguration.
 // If we're on production, be sure we use https; otherwise,
 // use the same scheme as pageUrl.
+// TODO: make the sample base URL a kumascript config item
 
 if (pageUrl.indexOf("developer.mozilla.org") != -1) {
   // Production
   base = base.replace('http://', 'https://');
-} else if (pageUrl.indexOf("developer.allizom.org") != -1) {
+} else if (pageUrl.indexOf("stage.mdn.moz.works") != -1) {
   // Staging
   base = base.replace('http://', 'https://');
+  base = base.replace('https://stage.mdn.moz.works',
+                      'https://stage-files.mdn.moz.works');
 } else {
   // Not production - use the same scheme as the main site
   if (pageUrl.indexOf("http://") != -1) {


### PR DESCRIPTION
The base URL for live samples on stage should be https://stage-files.mdn.moz.works. This is the quick version. The better way would be to pass the base sample URL as a config item to KumaScript, but we have more pressing AWS transition issues at the moment.