### PR TITLE
Add special case for <flex>

### DIFF
--- a/macros/cssxref.ejs
+++ b/macros/cssxref.ejs
@@ -37,10 +37,14 @@ var localStrings = string.deserialize(template("L10n:Common"));
 // Deal with CSS data types by removing <>
 var slug = $0.replace(/&lt;(.*)&gt;/g, '$1');
 
-// Special case <color> and <position>
+// Special case <color>, <flex>, and <position>
 switch ($0) {
     case '&lt;color&gt;':
         slug = 'color_value';
+        break;
+
+    case '&lt;flex&gt;':
+        slug = 'flex_value';
         break;
 
     case '&lt;position&gt;':


### PR DESCRIPTION
The `<flex>` data type is used on, e.g., https://developer.mozilla.org/en-US/docs/Web/CSS/minmax.