### PR TITLE
Add case for "CSS Flexible Lengths"

### DIFF
--- a/macros/CSS_Ref.ejs
+++ b/macros/CSS_Ref.ejs
@@ -325,6 +325,10 @@ if (types.some(function(type) { return type === "units"; })) {
                 unitInfo.urlPath = "angle#" + unit;
                 break;
 
+            case "CSS Flexible Lengths":
+                unitInfo.urlPath = "flex_value#" + unit;
+                break;
+
             case "CSS Frequencies":
                 unitInfo.urlPath = "frequency#" + unit;
                 break;


### PR DESCRIPTION
Fix the link for the `fr` unit. cf. https://github.com/mdn/data/pull/129