### PR TITLE
Update "What's Deployed" link for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Dependency Status](https://david-dm.org/mdn/kumascript.svg?theme=shields.io)](https://david-dm.org/mdn/kumascript)
 [![devDependency Status](https://david-dm.org/mdn/kumascript/dev-status.svg?theme=shields.io)](https://david-dm.org/mdn/kumascript#info=devDependencies)
 
-[What's Deployed](https://whatsdeployed.io/s-FHK)
+[What's Deployed](https://whatsdeployed.io/s-4kW)
 
 ## Overview
 


### PR DESCRIPTION
Staging is moving to stage.mdn.moz.works, so the What's Deployed short URL needs to update.