### PR TITLE
Add Audio Output Devices API.

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -61,6 +61,10 @@ var specList = {
         name : "ECMAScript Async Functions",
         url  : "https://tc39.github.io/ecmascript-asyncawait/"
     },
+    'Audio Output': {
+        name : "Audio Output Devices API",
+        url  : "https://w3c.github.io/mediacapture-output/"
+    },
     'Background Sync': {
         name : "Web Background Synchronization",
         url  : "https://wicg.github.io/BackgroundSync/spec/"

--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -24,6 +24,7 @@ var status = {
   'Async Function'             : 'Draft',
   'ARIA'                       : 'CR',
   'ARIA in HTML'               : 'WD',
+  'Audio Output'               : 'CR',
   'Background Sync'            : 'Living',
   'Background Tasks'           : 'PR',
   'Battery API'                : 'CR',


### PR DESCRIPTION
There is some urgency with this. Someone has tried to add it to appropriate pages:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/sinkId
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId
(I'll be correcting the links to match this PR, shortly. Nevertheless, the specifications table will still show 'Unknown' until this is merged.)