### PR TITLE
Closed <li> tag properly

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -700,7 +700,7 @@ var text = mdn.localStringMap({
 <section class="Quick_links" id="Quick_Links">
 
 <ol>
-  <li data-default-state="<%=currentPageIsUnder('Getting_started_with_the_web')%>"><a href="<%=baseURL%>Getting_started_with_the_web"><strong><%=text['Complete_beginners']%></strong></a>
+  <li data-default-state="<%=currentPageIsUnder('Getting_started_with_the_web')%>"><a href="<%=baseURL%>Getting_started_with_the_web"><strong><%=text['Complete_beginners']%></strong></a></li>
   <li data-default-state="<%=currentPageIsUnder('Getting_started_with_the_web')%>"><a href="<%=baseURL%>Getting_started_with_the_web"><%=text['Getting_started_with_the_web']%></a>
     <ol>
       <li><a href="<%=baseURL%>Getting_started_with_the_web"><%=text['Getting_started_with_the_web_overview']%></a></li>


### PR DESCRIPTION
Closed "li" tag properly on line 703. It was throwing errors on MDN when previewing the edited document.