### PR TITLE
Update HTMLSidebar macro for new HTML element page titles

### DIFF
--- a/macros/HTMLSidebar.ejs
+++ b/macros/HTMLSidebar.ejs
@@ -118,7 +118,7 @@ var text = mdn.localStringMap({
   </li>
   <li><strong><a href="/<%=locale%>/docs/Web/HTML/Reference"><%=text['Reference']%></a></strong></li>
   <li data-default-state="<%=state('Elements')%>"><a href="/<%=locale%>/docs/Web/HTML/Element"><%=text['HTML_Elements']%></a>
-   <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Element', 1])%>
+   <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Element', 0, 0, "<", ">"])%>
   </li>
   <li data-default-state="<%=state('Global_attributes')%>"><a href="/<%=locale%>/docs/Web/HTML/Global_attributes"><%=text['Global_attributes']%></a>
    <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Global_attributes'])%>


### PR DESCRIPTION
For SEO reasons, the element pages' titles are being changed to the
form:

`<elementname>`: The Element Name element

This patch updates `HTMLSidebar` to strip off everything that isn't
the element name, so the title is what's expected by other parts of
the site. This lets the sidebar's list of HTML elements be correctly
formatted.

THIS PATCH REQUIRES THE `ListSubpagesForSidebar` PATCH (PR #401).