### PR TITLE
Fix link to SpeechSynthesisVoice in sidebar

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -2025,7 +2025,7 @@
                             "SpeechSynthesisErrorEvent",
                             "SpeechSynthesisEvent",
                             "SpeechSynthesisUtterance",
-                            "SpeechSynthehesisVoice" ],
+                            "SpeechSynthesisVoice" ],
             "methods":    [],
             "properties": [],
             "events":     [ "audiostart",


### PR DESCRIPTION
There was a typo in the link to "SpeechSynthesisVoice" in the Web Speech API sidebar.