### PR TITLE
Remove links to legacy add-ons; fix bug #362

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -133,7 +133,7 @@ function currentPageIsUnder(root) {
     </li>
 
     <li><a href="https://discourse.mozilla-community.org/c/add-ons"><strong>Community and support</a></strong></li>
-    <li><a href="<%=baseURL%>Channels">Channels</a>
+    <li><a href="#">Channels</a>
       <ol>
         <li><a href="https://blog.mozilla.org/addons">Add-ons blog</a></li>
         <li><a href="https://discourse.mozilla-community.org/c/add-ons">Add-on forums</a></li>
@@ -143,14 +143,5 @@ function currentPageIsUnder(root) {
       </ol>
     </li>
 
-    <li><a href="<%=baseURL%>Legacy_add_ons"><strong>Legacy add-ons</strong></a></li>
-    <li><a href="#">Legacy technologies</a>
-      <ol>
-        <li><a href="<%=baseURL%>SDK">Add-on SDK</a></li>
-        <li><a href="<%=baseURL%>Legacy_Firefox_for_Android">Legacy Firefox for Android</a></li>
-        <li><a href="<%=baseURL%>Bootstrapped_extensions">Bootstrapped extensions</a></li>
-        <li><a href="<%=baseURL%>Overlay_Extensions">Overlay extensions</a></li>
-      </ol>
-    </li>
   </ol>
 </section>


### PR DESCRIPTION
Now we don't have to support legacy add-ons any more I'm archiving the docs, so should remove links to those docs form the sidebar.

I also snuck in a fix for https://github.com/mdn/kumascript/issues/362. I hope that's OK, but can do it as a separate PR if you like.