### PR TITLE
Fix partial support when browser info is missing

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -456,6 +456,34 @@ function getData(queryString, obj) {
   }, obj);
 }
 
+
+/*
+  Find out partial support for a main feature if
+  - there are notes present in sub features
+  - the sub features don't have the same support version as the main feature
+    (if the sub feature support is unknown, it is not flagged as partial support though)
+*/
+function identifyPartialSupport(featureNames, feature) {
+  for (let subfeatureName of featureNames) {
+    // if this is actually a subfeature (i.e. it is not a __compat object)
+    // and the subfeature has a __compat object
+    if ((subfeatureName !== '__compat') && (feature[subfeatureName].__compat)) {
+      let browserNames = Object.keys(feature.__compat.support);
+      for (let browser of browserNames) {
+        let mainFeatureSupport = feature.__compat.support[browser];
+        let subFeatureSupport = feature[subfeatureName].__compat.support[browser];
+        if (subFeatureSupport &&
+           (mainFeatureSupport.version_added != subFeatureSupport.version_added ||
+            subFeatureSupport.notes)) {
+          feature.__compat.support[browser].partial_support = true;
+        }
+      }
+    }
+  }
+  return feature;
+}
+
+
 /*
 Get features that should be displayed according to the query and the depth setting
 Flatten them into a features array
@@ -466,27 +494,12 @@ function traverseFeatures(obj, depth, identifier) {
     for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
-
+          // there are sub features below this node,
+          // so we need to identify partial support for the main feature
           let featureNames = Object.keys(obj[i]);
           if (featureNames.length > 1) {
-            // there are sub features below this node,
-            // so we need to identify partial support for the main feature
-            for (let subfeatureName of featureNames) {
-              // if this is actually a subfeature (i.e. it is not a __compat object)
-              // and the subfeature has a __compat object
-              if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                let browserNames = Object.keys(obj[i].__compat.support);
-                for (let browser of browserNames) {
-                  if (obj[i].__compat.support[browser].version_added !=
-                      obj[i][subfeatureName].__compat.support[browser].version_added ||
-                      obj[i][subfeatureName].__compat.support[browser].notes) {
-                    obj[i].__compat.support[browser].partial_support = true;
-                  }
-                }
-              }
-            }
+            obj[i] = identifyPartialSupport(featureNames, obj[i]);
           }
-
           features.push({[identifier + i]: obj[i].__compat});
         }
         traverseFeatures(obj[i], depth, i + '.');

--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -536,6 +536,33 @@ function getData(queryString, obj) {
 }
 
 /*
+  Find out partial support for a main feature if
+  - there are notes present in sub features
+  - the sub features don't have the same support version as the main feature
+    (if the sub feature support is unknown, it is not flagged as partial support though)
+*/
+function identifyPartialSupport(featureNames, feature) {
+  for (let subfeatureName of featureNames) {
+    // if this is actually a subfeature (i.e. it is not a __compat object)
+    // and the subfeature has a __compat object
+    if ((subfeatureName !== '__compat') && (feature[subfeatureName].__compat)) {
+      let browserNames = Object.keys(feature.__compat.support);
+      for (let browser of browserNames) {
+        let mainFeatureSupport = feature.__compat.support[browser];
+        let subFeatureSupport = feature[subfeatureName].__compat.support[browser];
+        if (subFeatureSupport &&
+           (mainFeatureSupport.version_added != subFeatureSupport.version_added ||
+            subFeatureSupport.notes)) {
+         feature.__compat.support[browser].partial_implementation = true;
+        }
+      }
+    }
+  }
+  return feature;
+}
+
+
+/*
 Get features that should be displayed according to the query and the depth setting
 Flatten them into a features array
 */
@@ -545,34 +572,19 @@ function traverseFeatures(obj, depth, identifier) {
     for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
-
+          // there are sub features below this node,
+          // so we need to identify partial support for the main feature
           let featureNames = Object.keys(obj[i]);
           if (featureNames.length > 1) {
-            // there are sub features below this node,
-            // so we need to identify partial support for the main feature
-            for (let subfeatureName of featureNames) {
-              // if this is actually a subfeature (i.e. it is not a __compat object)
-              // and the subfeature has a __compat object
-              if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                let browserNames = Object.keys(obj[i].__compat.support);
-                for (let browser of browserNames) {
-                  if (obj[i].__compat.support[browser].version_added !=
-                    obj[i][subfeatureName].__compat.support[browser].version_added ||
-                    obj[i][subfeatureName].__compat.support[browser].notes) {
-                      obj[i].__compat.support[browser].partial_implementation = true;
-                    }
-                  }
-                }
-              }
-            }
-
-            features.push({[identifier + i]: obj[i].__compat});
+            obj[i] = identifyPartialSupport(featureNames, obj[i]);
           }
-          traverseFeatures(obj[i], depth, i + '.');
+          features.push({[identifier + i]: obj[i].__compat});
         }
+        traverseFeatures(obj[i], depth, i + '.');
       }
     }
   }
+}
 
   var compatData = getData(query, bcd);
   var features = [];

--- a/tests/macros/fixtures/compat/support_variations.json
+++ b/tests/macros/fixtures/compat/support_variations.json
@@ -144,6 +144,33 @@
                     }
                 }
             }
+        },
+        "browser_info_missing_in_subfeature": {
+            "__compat": {
+                "support": {
+                    "firefox": {
+                        "version_added": "25"
+                    }
+                }
+            },
+            "subfeature": {
+                "__compat": {
+                    "support": {
+                        "firefox": {
+                            "version_added": "25"
+                        }
+                    }
+                },
+                "subsubfeature_with_missing_browser_info": {
+                    "__compat": {
+                        "support": {
+                            "chrome": {
+                                "version_added": "35"
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/macros/test-compat.js
+++ b/tests/macros/test-compat.js
@@ -314,6 +314,19 @@ describeMacro('Compat', function () {
               '25');
         });
     });
+    itMacro('Creates correct cell content when the browser info is missing in a sub feature and doesn\'t mark it as partial support', function (macro) {
+        return macro.call('html.browser_info_missing_in_subfeature').then(function(result) {
+            let dom = JSDOM.fragment(result);
+            assert.include(Array.from(dom.querySelector('.bc-table tbody tr:nth-child(1) td:nth-child(4)').classList),
+              'bc-supports-yes');
+            assert.include(dom.querySelector('.bc-table tbody tr:nth-child(1) td:nth-child(4)').textContent,
+              '25');
+            assert.include(Array.from(dom.querySelector('.bc-table tbody tr:nth-child(2) td:nth-child(4)').classList),
+              'bc-supports-yes');
+            assert.include(dom.querySelector('.bc-table tbody tr:nth-child(2) td:nth-child(4)').textContent,
+              '25');
+        });
+    });
 
 
     // Test icons in main cells


### PR DESCRIPTION
This should fix the issue described here https://discourse.mozilla.org/t/compat-macro-error/22164
It occurs on pages like http://localhost:8000/en-US/docs/Web/API/WebGL2RenderingContext

As `traverseFeatures` is weird enough already, I decided to move out the code that identifies when we flag something as partial support.

I also added a test so that we shouldn't regress this again in the future.

This patch fixes both, the beta and the non-beta version. Hopefully we will soon only have one macro, so that we can avoid this kind of duplicate patching.