### PR TITLE
Compat: add runtime_flag

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -236,6 +236,10 @@ function writeFlagsNote(supportData, browserId) {
     output += `${flagText} compile flag${valueToSet}.`;
   }
 
+  if (supportData.flag.type === 'runtime_flag') {
+    output += `${flagText} runtime flag${valueToSet}.`;
+  }
+
   return output;
 }
 

--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -303,6 +303,10 @@ function writeFlagsNote(supportData, browserId) {
     output += `${flagText} compile flag${valueToSet}.`;
   }
 
+  if (supportData.flag.type === 'runtime_flag') {
+    output += `${flagText} runtime flag${valueToSet}.`;
+  }
+
   return output;
 }
 

--- a/tests/macros/fixtures/compat/flags.json
+++ b/tests/macros/fixtures/compat/flags.json
@@ -12,6 +12,7 @@
                     },
                     "chrome_android": {
                         "version_added": "55",
+                        "version_removed": "60",
                         "flag": {
                             "type": "compile_flag",
                             "name": "--datetime-format-to-parts"
@@ -29,7 +30,14 @@
                                 "value_to_set": "true"
                             }
                         }
-                    ]
+                    ],
+                    "edge": {
+                        "version_added": "17",
+                        "flag": {
+                            "type": "runtime_flag",
+                            "name": "--number-format-to-parts"
+                        }
+                    }
                 }
             }
         }

--- a/tests/macros/test-compat.js
+++ b/tests/macros/test-compat.js
@@ -353,4 +353,22 @@ describeMacro('Compat', function () {
               'ic-prefix');
         });
     });
+
+
+    // Test flags
+    itMacro('Creates correct notes for flags', function (macro) {
+        return macro.call('flags.feature').then(function(result) {
+            let dom = JSDOM.fragment(result);
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[0].textContent,
+              'Disabled From version 10: this feature is behind the Enable experimental Web Platform features preference. To change preferences in Chrome, visit chrome://flags.');
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[1].textContent,
+              'Disabled From version 17: this feature is behind the --number-format-to-parts runtime flag.');
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[2].textContent,
+               ''); // empty for the "version_added: 12" range that has no flag
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[3].textContent,
+              'Disabled From version 5: this feature is behind the layout.css.vertical-text.enabled preference (needs to be set to true). To change preferences in Firefox, visit about:config.');
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[4].textContent,
+              'Disabled From version 55 until version 60 (exclusive): this feature is behind the --datetime-format-to-parts compile flag.');
+        });
+    });
 });


### PR DESCRIPTION
- Fixes https://github.com/mdn/kumascript/issues/415 by implementing a note for the new flag type "runtime_flag"
- Adds tests for all flag types.