### PR TITLE
Fix encoding of paths in subpages/subpagesExpand/translations

### DIFF
--- a/macros/DekiScript-Page.ejs
+++ b/macros/DekiScript-Page.ejs
@@ -50,7 +50,7 @@
     // Optional self, defaults to false. Include the path page in the results
     subpages: function (path, depth, self) {
         var mdn = require_macro('MDN:Common');
-        var url = build_api_url((path ? path : env.url) + '$children');
+        var url = build_api_url((path ? encodeURI(path) : env.url) + '$children');
         var depth_check = parseInt(depth);
         if (depth_check >= 0) {
             url += '?depth=' + depth_check;
@@ -73,7 +73,7 @@
     // Optional self, defaults to false. Include the path page in the results
     subpagesExpand: function (path, depth, self) {
         var mdn = require_macro('MDN:Common');
-        var url = build_api_url((path ? path : env.url) + '$children?expand');
+        var url = build_api_url((path ? encodeURI(path) : env.url) + '$children?expand');
         var depth_check = parseInt(depth);
         if (depth_check >= 0) {
             url += '&depth=' + depth_check;
@@ -213,7 +213,7 @@
 
     translations: function (path) {
         var mdn = require_macro('MDN:Common');
-        var url = build_api_url((path ? path : env.url) + '$json');
+        var url = build_api_url((path ? encodeURI(path) : env.url) + '$json');
         var json = mdn.fetchJSONResource(url);
         var result = [];
         if (json != null) {


### PR DESCRIPTION
Fixes: https://github.com/mdn/kumascript/issues/307
Replaces: https://github.com/mdn/kumascript/pull/308
It's a regression introduced in: https://github.com/mdn/kumascript/pull/241
It should fix many of the pages with errors: https://developer.mozilla.org/fr/docs/with-errors (and other non-English pages)