### PR TITLE
Fix link js(x)ref link creation to avoid trailing slashes

### DIFF
--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -35,8 +35,8 @@ var output = "";
 if (slug) {
 var locale = env.locale;
 var rtlLocales = ['ar', 'he', 'fa'];
-var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/' + text['refslug'] + text['stdlibslug'];
-var mainObj = slug.replace('Web/JavaScript/' + text['refslug'] + text['stdlibslug'], '').split('/')[0];
+var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/' + text['refslug'] + '/' + text['stdlibslug'];
+var mainObj = slug.replace('Web/JavaScript/' + text['refslug'] + '/' + text['stdlibslug'] + '/', '').split('/')[0];
 
 // Data for inheritance chain
 var inheritance = ["Object", "Function"];
@@ -60,7 +60,7 @@ if (typeof inheritanceData[mainObj] != 'undefined') {
 // Data for related pages
 var groupData = {
     "Error": ["Error", "EvalError", "InternalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"],
-    "Intl": ["Intl", "Collator", "DateTimeFormat", "NumberFormat"],
+    "Intl": ["Intl", "Collator", "DateTimeFormat", "NumberFormat", "PluralRules"],
     "TypedArray": ["TypedArray", "Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
                    "Int32Array", "Uint32Array", "Float32Array", "Float64Array"],
     "Proxy": ["Proxy", "handler"],
@@ -253,7 +253,7 @@ output += '<li><strong><a href="'+slug_stdlib+'">'+text['stdlib']+'</a></strong>
           output += '<li><strong>'+text['Inheritance']+'</strong></li>';
         }
 
-        output += '<li><strong><a href="'+slug_stdlib + resultTitle +'"><code>'+resultTitle+'</code></a></strong></li>';
+        output += '<li><strong><a href="'+slug_stdlib + '/' + resultTitle +'"><code>'+resultTitle+'</code></a></strong></li>';
 
         if (resultProperties.length > 0) {
           output += buildSublist(resultProperties, text['Properties'], resultOpen);
@@ -265,7 +265,7 @@ output += '<li><strong><a href="'+slug_stdlib+'">'+text['stdlib']+'</a></strong>
         if (len == 1 && group.length > 0) {
             output += '<li><strong>'+text['Related']+'</strong></li>';
             for (var i = 0; i < group.length; i++) {
-              output += '<li><strong><a href="'+ slug_stdlib + group[i].replace(".", "/") +'"><code>'+group[i]+'</code></a></strong></li>';
+              output += '<li><strong><a href="'+ slug_stdlib + '/' + group[i].replace(".", "/") +'"><code>'+group[i]+'</code></a></strong></li>';
             }
         }
 

--- a/macros/L10n-JavaScript.json
+++ b/macros/L10n-JavaScript.json
@@ -1,22 +1,22 @@
 {
     "slug_reference": {
-        "en-US": "Reference/",
-        "es"   : "Referencia/",
-        "fr"   : "Reference/",
-        "ca"   : "Referencia/",
-        "pl"   : "Referencje/",
-        "ru"   : "Reference/"
+        "en-US": "Reference",
+        "es"   : "Referencia",
+        "fr"   : "Reference",
+        "ca"   : "Referencia",
+        "pl"   : "Referencje",
+        "ru"   : "Reference"
     },
-    
+
     "slug_global_objects": {
-        "en-US": "Global_Objects/",
-        "es"   : "Objetos_globales/",
-        "fr"   : "Objets_globaux/",
-        "ca"   : "Objectes_globals/",
-        "pl"   : "Obiekty/",
-        "ru"   : "Global_Objects/"
+        "en-US": "Global_Objects",
+        "es"   : "Objetos_globales",
+        "fr"   : "Objets_globaux",
+        "ca"   : "Objectes_globals",
+        "pl"   : "Obiekty",
+        "ru"   : "Global_Objects"
     },
-    
+
     "stdlib": {
         "en-US": "Standard built-in objects",
         "fr"   : "Objets standards",

--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -25,17 +25,17 @@ var l10n = {
 
 var str = $1 || $0;
 
-var URL = "/" + env.locale + "/docs/Web/JavaScript/" + l10n.refslug;
+var URL = "/" + env.locale + "/docs/Web/JavaScript/" + l10n.refslug + '/';
 
 var api  = $0.replace('()', '').replace('.prototype.', '.');
 
 var page = wiki.getPage(URL + $0);
-var objectPage = wiki.getPage(URL + l10n.slug +  $0);
+var objectPage = wiki.getPage(URL + l10n.slug + '/' +  $0);
 
 if ((api.indexOf("..") === -1) && (api.indexOf(".") !== -1)) { // Handle try...catch case
-    URL += l10n.slug + api.replace('.', '/');
+    URL += l10n.slug + '/' + api.replace('.', '/');
 } else if (!page.slug && objectPage.slug) {
-    URL += l10n.slug + $0;
+    URL += l10n.slug + '/' + $0;
 } else {
     URL += $0;
 }


### PR DESCRIPTION
Should fix https://bugzilla.mozilla.org/show_bug.cgi?id=1418133

I also added Intl.PluralRules to JSRef as I'm about to document that (one line change).