### PR TITLE
Remove ie_mobile; add samsunginternet_android

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -76,9 +76,9 @@ const browsers = {
     chrome_android: s_chrome_android,
     edge_mobile: 'Edge mobile',
     firefox_android: s_firefox_android,
-    ie_mobile: 'IE mobile',
     opera_android: 'Opera Android',
     safari_ios: 'iOS Safari',
+    samsunginternet_android: 'Samsung Internet',
   },
   "webextensions": {
     chrome: "Chrome",

--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -45,7 +45,7 @@ var s_no_data_found = mdn.localString({
 
 const browsers = {
   "desktop": ['chrome', 'edge', 'firefox', 'ie', 'opera', 'safari'],
-  "mobile": ['webview_android', 'chrome_android', 'edge_mobile', 'firefox_android', 'ie_mobile', 'opera_android', 'safari_ios'],
+  "mobile": ['webview_android', 'chrome_android', 'edge_mobile', 'firefox_android', 'opera_android', 'safari_ios', 'samsunginternet_android'],
   "server": ['nodejs'],
   "webextensions-desktop": ['chrome', 'edge', 'firefox', 'opera'],
   "webextensions-mobile": ['firefox_android']


### PR DESCRIPTION
This requires a Kuma PR adding an icon for` samsunginternet_android` first, but otherwise this should be all that's needed on the macro side.