### PR TITLE
wrap path argument to build_api_url with encodeURI

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -387,7 +387,7 @@ var APIContext = ks_utils.Class({
         }
         return url.resolve(
             this.options.doc_base_url,
-            ks_utils.strip_base_url(path)
+            ks_utils.strip_base_url(encodeURI(path))
         );
     }
 });

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -113,7 +113,7 @@ describe('test-api', function () {
     });
 
     describe('The API offers a function to build absolute API URLs', function () {
-        const test_path = 'en-US/docs/<Web>?look=fancy&font=big#note';
+        const test_path = 'fr/docs/<Requêtes_média>?look=fancy&font=big#note';
         beforeEach(function() {
             this.doc_base_url = 'https://api:8000';
             this.api = new ks_api.APIContext({


### PR DESCRIPTION
Fixes: #307 
Replaces: #308, #422 

This PR corrects a regression I introduced in #241. I had thought that `url.resolve` would internally perform the same operation as `encodeURI`, not realizing that although it does encode characters like "<" and ">", it does not UTF-8 encode non-ASCII unicode characters like "é" as `encodeURI` does.

I also modified one of the existing tests for `build_api_url` to check for this case, so we can detect any future regressions.

This should fix many of the pages with errors: https://developer.mozilla.org/fr/docs/with-errors (and other non-English pages).

Thanks to @SphinxKnight and @Elchi3 (as well as apologies for being the cause of this issue! 😞 )