### PR TITLE
bug 1406546: ensure image can be pulled prior to deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,11 @@ node {
           utils.announce_push()
         }
 
+        stage("Check Pull") {
+            // Ensure the image can be successfully pulled from the registry.
+            utils.ensure_pull()
+        }
+
         stage("Prepare Infra") {
           // Checkout the "mozmeao/infra" repo's "master" branch into the
           // "infra" sub-directory of the current working directory.


### PR DESCRIPTION
This is the `kumascript` companion PR to https://github.com/mozilla/kuma/pull/4587, which it depends upon for the `utils.ensure_pull` and `make pull-kumascript` functionality.