### PR TITLE
bug 1406546: add prod-push Jenkins branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,14 +89,14 @@ node {
 
         break
 
-      case utils.STAGE_BRANCH_NAME:
+      case [utils.STAGE_BRANCH_NAME, utils.PROD_BRANCH_NAME]:
         stage("Announce") {
           utils.announce_push()
         }
 
         stage("Check Pull") {
-            // Ensure the image can be successfully pulled from the registry.
-            utils.ensure_pull()
+          // Ensure the image can be successfully pulled from the registry.
+          utils.ensure_pull()
         }
 
         stage("Prepare Infra") {


### PR DESCRIPTION
This PR adds the Jenkins machinery for the `prod-push` branch, which simply pushes the latest commit tagged Kumascript image to production. It does NOT push an associated Kuma image to production. The Kuma repo has its own `prod-push` branch for that (see https://github.com/mozilla/kuma/pull/4588).