### PR TITLE
Change flag to flags; update flag note generation

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -188,8 +188,8 @@ for either a preference flag or a compile flag.
 function writeFlagsNote(supportData, browserId) {
   let output = '';
 
-  const firefoxPrefs = 'To change preferences in Firefox, visit about:config.';
-  const chromePrefs = 'To change preferences in Chrome, visit chrome://flags.';
+  const firefoxPrefs = ' To change preferences in Firefox, visit about:config.';
+  const chromePrefs = ' To change preferences in Chrome, visit chrome://flags.';
 
   if (typeof(supportData.version_added) === 'string') {
     output = `From version ${supportData.version_added}`;
@@ -197,48 +197,67 @@ function writeFlagsNote(supportData, browserId) {
 
   if (typeof(supportData.version_removed) === 'string') {
     if (output) {
-      output += ` until version ${supportData.version_removed} (exclusive)`;
+      output += ' ';
+      output += `until version ${supportData.version_removed} (exclusive)`;
     } else {
       output = `Until version ${supportData.version_removed} (exclusive)`;
     }
   }
 
-  let flagTextStart = 'This';
+  let start = 'This';
   if (output) {
     output += ':';
-    flagTextStart = ' this';
+    start = ' this';
   }
 
-  let flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
+  start += ' feature is behind the ';
 
-  // value_to_set is optional
-  let valueToSet = '';
-  if (supportData.flag.value_to_set) {
-    valueToSet = ` (needs to be set to <code>${supportData.flag.value_to_set}</code>)`;
-  }
+  let flagsText = '';
+  let settings = '';
 
-  if (supportData.flag.type === 'preference') {
-    let prefSettings = '';
-    switch (browserId) {
-      case 'firefox':
-      case 'firefox_android':
-        prefSettings = firefoxPrefs;
-      break;
-      case 'chrome':
-      case 'chrome_android':
-        prefSettings = chromePrefs;
-      break;
+  for (i = 0; i < supportData.flags.length; i++) {
+    let flag = supportData.flags[i];
+    let nameString = `<code>${flag.name}</code>`;
+
+    // value_to_set is optional
+    let valueToSet = '';
+    if (flag.value_to_set) {
+      valueToSet = ` (needs to be set to <code>${flag.value_to_set}</code>)`;
     }
-    output += `${flagText} preference${valueToSet}. ${prefSettings}`;
+
+    let typeString = '';
+    if (flag.type === 'preference') {
+      switch (browserId) {
+        case 'firefox':
+        case 'firefox_android':
+          settings = firefoxPrefs;
+        break;
+        case 'chrome':
+        case 'chrome_android':
+          settings = chromePrefs;
+        break;
+      }
+      typeString = ` preference${valueToSet}`;
+    }
+
+    if (flag.type === 'compile_flag') {
+      typeString = ` compile flag${valueToSet}`;
+    }
+
+    if (flag.type === 'runtime_flag') {
+      typeString = ` runtime flag${valueToSet}`;
+    }
+
+    flagsText += nameString + typeString;
+
+    if (i != supportData.flags.length - 1) {
+      flagsText += ' and the ';
+    } else {
+      flagsText += '.';
+    }
   }
 
-  if (supportData.flag.type === 'compile_flag') {
-    output += `${flagText} compile flag${valueToSet}.`;
-  }
-
-  if (supportData.flag.type === 'runtime_flag') {
-    output += `${flagText} runtime flag${valueToSet}.`;
-  }
+  output += start + flagsText + settings;
 
   return output;
 }
@@ -304,7 +323,7 @@ function writeSupportInfo(supportData, browserId, compatNotes) {
     }
 
     // there is a flag and it needs a note, too
-    if (supportData.flag) {
+    if (supportData.flags) {
       let flagNote = writeFlagsNote(supportData, browserId);
       let noteIndex = compatNotes.indexOf(flagNote);
       noteAnchors.push(`<sup><a href="#compatNote_${noteIndex+1}">${noteIndex+1}</a></sup>`);
@@ -350,7 +369,7 @@ function collectCompatNotes() {
       }
     }
     // collect flags
-    if (supportEntry.hasOwnProperty('flag')) {
+    if (supportEntry.hasOwnProperty('flags')) {
       let flagNote = writeFlagsNote(supportEntry, browserName);
       if (notesArray.indexOf(flagNote) === -1) {
         notesArray.push(flagNote);

--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -243,9 +243,6 @@ First checks version_added and version_removed to create a string indicating whe
 a preference setting is present. Then creates a (browser specific) string
 for either a preference flag or a compile flag.
 
-// TODO handle array of flags (rename flag to flags)
-// see https://github.com/mdn/browser-compat-data/issues/546
-
 // TODO Need to localize this
 
 `supportData` is a support_statement
@@ -254,8 +251,8 @@ for either a preference flag or a compile flag.
 function writeFlagsNote(supportData, browserId) {
   let output = '';
 
-  const firefoxPrefs = 'To change preferences in Firefox, visit about:config.';
-  const chromePrefs = 'To change preferences in Chrome, visit chrome://flags.';
+  const firefoxPrefs = ' To change preferences in Firefox, visit about:config.';
+  const chromePrefs = ' To change preferences in Chrome, visit chrome://flags.';
 
   if (typeof(supportData.version_added) === 'string') {
     output = `From version ${supportData.version_added}`;
@@ -270,42 +267,60 @@ function writeFlagsNote(supportData, browserId) {
     }
   }
 
-  let flagTextStart = 'This';
+  let start = 'This';
   if (output) {
     output += ':';
-    flagTextStart = ' this';
+    start = ' this';
   }
 
-  let flagText = `${flagTextStart} feature is behind the <code>${supportData.flag.name}</code>`;
+  start += ' feature is behind the ';
 
-  // value_to_set is optional
-  let valueToSet = '';
-  if (supportData.flag.value_to_set) {
-    valueToSet = ` (needs to be set to <code>${supportData.flag.value_to_set}</code>)`;
-  }
+  let flagsText = '';
+  let settings = '';
 
-  if (supportData.flag.type === 'preference') {
-    let prefSettings = '';
-    switch (browserId) {
-      case 'firefox':
-      case 'firefox_android':
-        prefSettings = firefoxPrefs;
-      break;
-      case 'chrome':
-      case 'chrome_android':
-        prefSettings = chromePrefs;
-      break;
+  for (i = 0; i < supportData.flags.length; i++) {
+    let flag = supportData.flags[i];
+    let nameString = `<code>${flag.name}</code>`;
+
+    // value_to_set is optional
+    let valueToSet = '';
+    if (flag.value_to_set) {
+      valueToSet = ` (needs to be set to <code>${flag.value_to_set}</code>)`;
     }
-    output += `${flagText} preference${valueToSet}. ${prefSettings}`;
+
+    let typeString = '';
+    if (flag.type === 'preference') {
+      switch (browserId) {
+        case 'firefox':
+        case 'firefox_android':
+          settings = firefoxPrefs;
+        break;
+        case 'chrome':
+        case 'chrome_android':
+          settings = chromePrefs;
+        break;
+      }
+      typeString = ` preference${valueToSet}`;
+    }
+
+    if (flag.type === 'compile_flag') {
+      typeString = ` compile flag${valueToSet}`;
+    }
+
+    if (flag.type === 'runtime_flag') {
+      typeString = ` runtime flag${valueToSet}`;
+    }
+
+    flagsText += nameString + typeString;
+
+    if (i != supportData.flags.length - 1) {
+      flagsText += ' and the ';
+    } else {
+      flagsText += '.';
+    }
   }
 
-  if (supportData.flag.type === 'compile_flag') {
-    output += `${flagText} compile flag${valueToSet}.`;
-  }
-
-  if (supportData.flag.type === 'runtime_flag') {
-    output += `${flagText} runtime flag${valueToSet}.`;
-  }
+  output += start + flagsText + settings;
 
   return output;
 }
@@ -330,9 +345,7 @@ function writeCellIcons(support) {
     output += writeIcon('altname', support.alternative_name) + ' ';
   }
 
-  if (support.flag) {
-    // TODO handle array of flags (rename flag to flags)
-    // see https://github.com/mdn/browser-compat-data/issues/546
+  if (support.flags) {
     output += writeIcon('disabled') + ' ';
   }
 
@@ -399,9 +412,7 @@ function writeNotes(support, browserId) {
       });
     }
 
-    if (support.flag) {
-      // TODO handle array of flags (rename flag to flags)
-      // see https://github.com/mdn/browser-compat-data/issues/546
+    if (support.flags) {
       notes.push({
         icon: writeIcon('disabled'),
         text: writeFlagsNote(support, browserId)
@@ -449,7 +460,7 @@ function writeCompatCells(supportData) {
         supportInfo += getCellString(support.version_added,
                                      support.version_removed,
                                      support.partial_implementation);
-        if (support.notes || support.prefix || support.flag || support.alternative_name) {
+        if (support.notes || support.prefix || support.flags || support.alternative_name) {
           needsNotes = true;
         }
       }

--- a/tests/macros/fixtures/compat/flags.json
+++ b/tests/macros/fixtures/compat/flags.json
@@ -5,18 +5,22 @@
                 "support": {
                     "chrome": {
                         "version_added": "10",
-                        "flag": {
-                            "type": "preference",
-                            "name": "Enable experimental Web Platform features"
-                        }
+                        "flags": [
+                            {
+                                "type": "preference",
+                                "name": "Enable experimental Web Platform features"
+                            }
+                        ]
                     },
                     "chrome_android": {
                         "version_added": "55",
                         "version_removed": "60",
-                        "flag": {
-                            "type": "compile_flag",
-                            "name": "--datetime-format-to-parts"
-                        }
+                        "flags": [
+                            {
+                                "type": "compile_flag",
+                                "name": "--datetime-format-to-parts"
+                            }
+                        ]
                     },
                     "firefox": [
                         {
@@ -24,19 +28,36 @@
                         },
                         {
                             "version_added": "5",
-                            "flag": {
-                                "type": "preference",
-                                "name": "layout.css.vertical-text.enabled",
-                                "value_to_set": "true"
-                            }
+                            "flags": [
+                                {
+                                    "type": "preference",
+                                    "name": "layout.css.vertical-text.enabled",
+                                    "value_to_set": "true"
+                                }
+                            ]
                         }
                     ],
                     "edge": {
                         "version_added": "17",
-                        "flag": {
-                            "type": "runtime_flag",
-                            "name": "--number-format-to-parts"
-                        }
+                        "flags": [
+                            {
+                                "type": "runtime_flag",
+                                "name": "--number-format-to-parts"
+                            }
+                        ]
+                    },
+                    "opera": {
+                        "version_added": "45",
+                        "flags": [
+                            {
+                                "type": "preference",
+                                "name": "foo.enabled"
+                            },
+                            {
+                                "type": "preference",
+                                "name": "bar.enabled"
+                            }
+                        ]
                     }
                 }
             }

--- a/tests/macros/test-compat.js
+++ b/tests/macros/test-compat.js
@@ -368,6 +368,8 @@ describeMacro('Compat', function () {
             assert.equal(dom.querySelectorAll('section.bc-history dl dd')[3].textContent,
               'Disabled From version 5: this feature is behind the layout.css.vertical-text.enabled preference (needs to be set to true). To change preferences in Firefox, visit about:config.');
             assert.equal(dom.querySelectorAll('section.bc-history dl dd')[4].textContent,
+              'Disabled From version 45: this feature is behind the foo.enabled preference and the bar.enabled preference.');
+            assert.equal(dom.querySelectorAll('section.bc-history dl dd')[5].textContent,
               'Disabled From version 55 until version 60 (exclusive): this feature is behind the --datetime-format-to-parts compile flag.');
         });
     });


### PR DESCRIPTION
See the corresponding BCD change https://github.com/mdn/browser-compat-data/pull/701 (we will need to release both at the same time).

Creating a note for flag(s) is becoming quite hairy now and this is not even localized yet. :(
The second commit back ports this to the old table (Compat.ejs).

Please review, but **do not merge yet**.