### PR TITLE
Remove unused SourceIdentifier macro

### DIFF
--- a/macros/SourceIdentifier.ejs
+++ b/macros/SourceIdentifier.ejs
@@ -1,8 +1,0 @@
-<%
-// Insert a link to search for an identifier in the mozilla-central source repository.
-//
-//  $0 - Identifier to search for
-
-var url = "https://dxr.mozilla.org/mozilla-central/search?q=id:" + $0;
-%>
-<code><a href="<%=url%>"><%=$0%></a></code>


### PR DESCRIPTION
Not used https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=SourceIdentifier&topic=none