### PR TITLE
Remove unused EmbedCompatTable macro

### DIFF
--- a/macros/EmbedCompatTable.ejs
+++ b/macros/EmbedCompatTable.ejs
@@ -1,7 +1,0 @@
-<%
-
-/*
- * Project retired, macro should be removed from use.
- */
-
-%>


### PR DESCRIPTION
I removed this from the remaining pages https://developer.mozilla.org/en-US/search?kumascript_macros=EmbedCompatTable&locale=%2A&topic=none

RIP old compat API