### PR TITLE
remove unused macro xultu-value

### DIFF
--- a/macros/xultu-value.ejs
+++ b/macros/xultu-value.ejs
@@ -1,1 +1,0 @@
-<span style="color: #FFA600; font-weight: bold;"><%=$0%></span>


### PR DESCRIPTION
Removed unused macro `xultu-value`.

https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=xultu-value&topic=none