### PR TITLE
remove unused macro xultu-ref

### DIFF
--- a/macros/xultu-ref.ejs
+++ b/macros/xultu-ref.ejs
@@ -1,1 +1,0 @@
-<%-template("XULElem", [$0])%>


### PR DESCRIPTION
Remove unused macro `xultu-ref`.

https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=xultu-ref&topic=none