### PR TITLE
remove unused macro xultu-attr

### DIFF
--- a/macros/xultu-attr.ejs
+++ b/macros/xultu-attr.ejs
@@ -1,1 +1,0 @@
-<span style="color: #009900;"><code><%=$0%></code></span>


### PR DESCRIPTION
Removes unused macro `xultu-attr`.

https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=xultu-attr&topic=none