### PR TITLE
Remove unused Fx_minversion_note_{start|end} macros

### DIFF
--- a/macros/Fx_minversion_note_end.ejs
+++ b/macros/Fx_minversion_note_end.ejs
@@ -1,1 +1,0 @@
-<%- template("minversionNoteGenericEnd") %>

--- a/macros/Fx_minversion_note_start.ejs
+++ b/macros/Fx_minversion_note_start.ejs
@@ -1,1 +1,0 @@
-<%- template("minversionNoteGenericStart", ["Firefox",$0]) %>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=Fx_minversion_note_start&topic=none

https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=Fx_minversion_note_end&topic=none