### PR TITLE
Remove CXCLicenseBlock

### DIFF
--- a/macros/CXCLicenseBlock.ejs
+++ b/macros/CXCLicenseBlock.ejs
@@ -1,6 +1,0 @@
-<%
-var str = 'Copyright (c) 2003 by Doug Turner and Ian Oeschger. This material may be distributed only subject to the terms and conditions set forth in the <a class="external" href="http://www.opencontent.org/openpub/">Open Publication License</a>, v1.02 or later. Distribution of substantively modified versions of this document is prohibited without the explicit permission of the copyright holder. Distribution of the work or derivative of the work in any standard (paper) book form is prohibited unless prior permission is obtained from the copyright holder.';
-%>
-<div class="licenseblock">
-<p><%- str %></p>
-</div>


### PR DESCRIPTION
This was used in some old XPCOM tutorial content. I've replaced it with hardcoded HTML.

e.g. https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Guide/Creating_components/Starting_WebLock

https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=CXCLicenseBlock&topic=none