### PR TITLE
spec2 macro: Make ESDraft a Draft instead of a Living.

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -152,7 +152,7 @@ var status = {
   'ES6'                        : 'Standard',
   'ES2016'                     : 'Standard',
   'ES2017'                     : 'Standard',
-  'ESDraft'                    : 'Living',
+  'ESDraft'                    : 'Draft',
   'ES Int 1.0'                 : 'Standard',
   'ES Int 2.0'                 : 'Standard',
   'ES Int Draft'               : 'Draft',


### PR DESCRIPTION
Hello,

Regarding
https://github.com/mdn/kumascript/blob/master/macros/spec2.ejs#L155

'ESDraft' should not be classified as 'Living', it should be a 'Draft' as defined here: 

https://github.com/mdn/kumascript/blob/master/macros/spec2.ejs#L14

ECMA TC39 does not publish “living standards”. The term “living standard” only applies to specifications edited by WHATWG. TC39 has a conventional release model. 

The difference is that WHATWG “living standards” are always up-to-date and normative while ECMAScript drafts are simply non-normative, unfinished drafts of the next ECMAScript version.

Kind Regards