### PR TITLE
Remove jsfile-warning

### DIFF
--- a/macros/jsfile-warning.ejs
+++ b/macros/jsfile-warning.ejs
@@ -1,7 +1,0 @@
-<%
-var text = "This section describes the <code>File</code> component of the SpiderMonkey JavaScript interpreter. " +
-           "<code>File</code> is non-standard, not generally compiled into distributions, is a potential source " +
-           "of huge security holes, and not well tested.";
-
-
-%><%-template("Warning", [text])%>


### PR DESCRIPTION
Was used in a couple of Spidermonkey pages, now replaced with static HTML:

https://developer.mozilla.org/en-US/search?locale=en-US&kumascript_macros=jsfile-warning&topic=none