### PR TITLE
Remove non-standard_polyfill_header

### DIFF
--- a/macros/non-standard_polyfill_header.ejs
+++ b/macros/non-standard_polyfill_header.ejs
@@ -1,1 +1,0 @@
-<%- template("non-standardGenericPolyFill", ["header", $0]) %>


### PR DESCRIPTION
Only called from some Persona-specific API pages, like those under https://developer.mozilla.org/en-US/docs/Web/API/IdentityManager. AFAICT it just calls a nonexistent macro, and only doesn't generate an error because KS throws errors away in this situation :).

Now removed: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=non-standard_polyfill_header&topic=none
