### PR TITLE
Remove obsoleto_texto

### DIFF
--- a/macros/obsoleto_texto.ejs
+++ b/macros/obsoleto_texto.ejs
@@ -1,5 +1,0 @@
-<%
-
-/* please use obsolete inline instead of this template */
-
-%><%- template("obsoleteGeneric", ["inline"]) %>


### PR DESCRIPTION
Used in a couple of pages:
https://developer.mozilla.org/es/docs/Web/API/Event
https://developer.mozilla.org/es/docs/Web/API/Range

The macro itself says to used obsolete inline instead, so I've updated those pages accordingly.