### PR TITLE
WebAssemblySidebar: Remove trailing slash

### DIFF
--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -1,6 +1,6 @@
 <%
 var locale = env.locale;
-var baseURL = "/" + locale + "/docs/WebAssembly/";
+var baseURL = "/" + locale + "/docs/WebAssembly";
 
 var text = mdn.localStringMap({
   'en-US': {
@@ -25,14 +25,14 @@ var text = mdn.localStringMap({
   <li data-default-state="open"><a href="<%=baseURL%>"><strong><%=text['WebAssembly_home_page']%></strong></a>
   <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Tutorials']%></a>
     <ol>
-      <li><a href="<%=baseURL%>Concepts"><%=text['WebAssembly_concepts']%></a></li>
-      <li><a href="<%=baseURL%>C_to_wasm"><%=text['Compiling_to_wasm']%></a></li>
-      <li><a href="<%=baseURL%>Using_the_JavaScript_API"><%=text['JavaScript_API']%></a></li>
-      <li><a href="<%=baseURL%>Understanding_the_text_format"><%=text['Text_format']%></a></li>
-      <li><a href="<%=baseURL%>Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>
-      <li><a href="<%=baseURL%>Loading_and_running"><%=text['Loading_and_running']%></a></li>
-      <li><a href="<%=baseURL%>Caching_modules"><%=text['Caching_modules']%></a></li>
-      <li><a href="<%=baseURL%>Exported_functions"><%=text['Exported_functions']%></a></li>
+      <li><a href="<%=baseURL%>/Concepts"><%=text['WebAssembly_concepts']%></a></li>
+      <li><a href="<%=baseURL%>/C_to_wasm"><%=text['Compiling_to_wasm']%></a></li>
+      <li><a href="<%=baseURL%>/Using_the_JavaScript_API"><%=text['JavaScript_API']%></a></li>
+      <li><a href="<%=baseURL%>/Understanding_the_text_format"><%=text['Text_format']%></a></li>
+      <li><a href="<%=baseURL%>/Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>
+      <li><a href="<%=baseURL%>/Loading_and_running"><%=text['Loading_and_running']%></a></li>
+      <li><a href="<%=baseURL%>/Caching_modules"><%=text['Caching_modules']%></a></li>
+      <li><a href="<%=baseURL%>/Exported_functions"><%=text['Exported_functions']%></a></li>
     </ol>
   </li>
   <li data-default-state="open"><a href="<%=baseURL%>"><%=text['Object_reference']%></a>

--- a/tests/macros/test-WebAssemblySidebar.js
+++ b/tests/macros/test-WebAssemblySidebar.js
@@ -14,8 +14,8 @@ var expected = `\
 <section class="Quick_links" id="Quick_Links">
 
 <ol>
-  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/"><strong>WebAssembly home page</strong></a>
-  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/">Tutorials</a>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly"><strong>WebAssembly home page</strong></a>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly">Tutorials</a>
     <ol>
       <li><a href="/en-US/docs/WebAssembly/Concepts">WebAssembly concepts</a></li>
       <li><a href="/en-US/docs/WebAssembly/C_to_wasm">Compiling from C/C++ to WebAssembly</a></li>
@@ -27,7 +27,7 @@ var expected = `\
       <li><a href="/en-US/docs/WebAssembly/Exported_functions">Exported WebAssembly functions</a></li>
     </ol>
   </li>
-  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/">Object reference</a>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly">Object reference</a>
     <ol>
       <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly" title="Title for WebAssembly"><code>WebAssembly</code></a></li>
       <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module" title="Title for WebAssembly.Module"><code>WebAssembly.Module</code></a></li>

--- a/tests/macros/test-WebAssemblySidebar.js
+++ b/tests/macros/test-WebAssemblySidebar.js
@@ -1,0 +1,74 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var sinon = require('sinon'),
+    utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro,
+    beforeEachMacro = utils.beforeEachMacro;
+chai.use(chaiAsPromised);
+
+var expected = `\
+<section class="Quick_links" id="Quick_Links">
+
+<ol>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/"><strong>WebAssembly home page</strong></a>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/">Tutorials</a>
+    <ol>
+      <li><a href="/en-US/docs/WebAssembly/Concepts">WebAssembly concepts</a></li>
+      <li><a href="/en-US/docs/WebAssembly/C_to_wasm">Compiling from C/C++ to WebAssembly</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Using_the_JavaScript_API">Using the WebAssembly JavaScript API</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Understanding_the_text_format">Understanding WebAssembly text format</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Text_format_to_wasm">Converting WebAssembly text format to wasm</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Loading_and_running">Loading and running WebAssembly code</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Caching_modules">Caching compiled WebAssembly modules</a></li>
+      <li><a href="/en-US/docs/WebAssembly/Exported_functions">Exported WebAssembly functions</a></li>
+    </ol>
+  </li>
+  <li data-default-state="open"><a href="/en-US/docs/WebAssembly/">Object reference</a>
+    <ol>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly" title="Title for WebAssembly"><code>WebAssembly</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module" title="Title for WebAssembly.Module"><code>WebAssembly.Module</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance" title="Title for WebAssembly.Instance"><code>WebAssembly.Instance</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory" title="Title for WebAssembly.Memory"><code>WebAssembly.Memory</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table" title="Title for WebAssembly.Table"><code>WebAssembly.Table</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError" title="Title for WebAssembly.CompileError"><code>WebAssembly.CompileError</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError" title="Title for WebAssembly.LinkError"><code>WebAssembly.LinkError</code></a></li>
+      <li><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError" title="Title for WebAssembly.RuntimeError"><code>WebAssembly.RuntimeError</code></a></li>
+    </ol>
+  </li>
+</ol>
+
+</section>`;
+
+
+describeMacro('WebAssemblySidebar', function () {
+    beforeEachMacro(function (macro) {
+        // Mock calls to template("jsxref", [partialSlug])
+        var endpoints = [
+                'WebAssembly',
+                'WebAssembly.Module',
+                'WebAssembly.Instance',
+                'WebAssembly.Memory',
+                'WebAssembly.Table',
+                'WebAssembly.CompileError',
+                'WebAssembly.LinkError',
+                'WebAssembly.RuntimeError'],
+            baseURL = '/en-US/docs/Web/JavaScript/Reference/Global_Objects/';
+
+        macro.ctx.template = sinon.stub();
+        for (let jsSlug of endpoints) {
+            var partialSlug = jsSlug.replace('.', '/'),
+                url = baseURL + partialSlug;
+            macro.ctx.template.withArgs('jsxref', [jsSlug]).returns(
+                '<a href="' + url + '" title="Title for ' + jsSlug + '">' +
+                '<code>' + jsSlug + '</code></a>');
+        }
+    });
+
+    itMacro('Generates WebAssembly Sidebar', function (macro) {
+        return assert.eventually.equal(macro.call(), expected);
+    });
+});


### PR DESCRIPTION
Add a test for ``{{WebAssemblySidebar}}``, and remove the trailing slash to address [bug 1418133](https://bugzilla.mozilla.org/show_bug.cgi?id=1418133).