### PR TITLE
Fixed link to web_status.json

### DIFF
--- a/macros/UILocalizationStatus.ejs
+++ b/macros/UILocalizationStatus.ejs
@@ -8,26 +8,29 @@ var projectColumnTitle = mdn.localString({
     "en-US": "Project",
     "de"   : "Projekt",
     "fr"   : "Projet",
-    "ru"   : "Проект"
+    "ru"   : "Проект",
+    "uk"   : "Проект"
 });
 
 var wordsColumnTitle = mdn.localString({
     "en-US": "Strings",
     "de"   : "Wörter",
     "fr"   : "Mots",
-    "ru"   : "Строки"
+    "ru"   : "Строки",
+    "uk"   : "Рядки"
 });
 
 var statusColumnTitle = mdn.localString({
     "en-US": "Status",
     "de"   : "Status",
     "fr"   : "Statut",
-    "ru"   : "Статус"
+    "ru"   : "Статус",
+    "uk"   : "Стан"
 });
 
 var locale = $0;
 var MDN = require_macro("MDN:Common");
-var url = 'http://l10n.mozilla-community.org/~flod/webstatus/web_status.json';
+var url = 'https://l10n.mozilla-community.org/webstatus/web_status.json';
 var mdnProjects = ["mdn", "mdn-js", "mdn-promote"];
 var result = [];
 


### PR DESCRIPTION
For a while the UILocalizationStatus macro was broken and now I finally figured out what's wrong.
The old link http://l10n.mozilla-community.org/~flod/webstatus/web_status.json was unavailable so every page using UILocalizationStatus macro was broken.

You can easily open https://l10n.mozilla-community.org/webstatus/web_status.json link and make sure that it's working.