### PR TITLE
Remove ie_mobile label; add samsunginternet_android label

### DIFF
--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -56,10 +56,6 @@
          "en-US": "Internet Explorer",
          "nl"   : "Internet Explorer"
     },
-    "bc_icon_name_ie_mobile": {
-         "en-US": "IE mobile",
-         "nl"   : "IE mobile"
-    },
     "bc_icon_name_nodejs": {
          "en-US": "Node.js",
          "nl"   : "Node.js"
@@ -80,6 +76,10 @@
     "bc_icon_name_safari_ios": {
          "en-US": "iOS Safari",
          "nl"   : "iOS Safari"
+    },
+    "bc_icon_name_samsunginternet_android": {
+         "en-US": "Samsung Internet",
+         "nl"   : "Samsung Internet"
     },
     "bc_history_head": {
         "en-US": "Implementation Notes",


### PR DESCRIPTION
I forgot this in https://github.com/mdn/kumascript/pull/430 :disappointed: 

See the tooltip for the Samsung Internet icon here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility It should display "Samsung Internet".