### PR TITLE
Moving the "Publishing your extension" page

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -86,7 +86,6 @@ function currentPageIsUnder(root) {
         <li><a href="<%=baseURL%>WebExtensions/Getting_started_with_web-ext">Getting started with web-ext</a>
         <li><a href="<%=baseURL%>WebExtensions/web-ext_command_reference">web-ext command reference</a></li>
         <li><a href="<%=baseURL%>WebExtensions/WebExtensions_and_the_Add-on_ID">Extensions and the Add-on ID</a></li>
-        <li><a href="<%=baseURL%>WebExtensions/Publishing_your_WebExtension">Publishing your extension</a></li>
 
       </ol>
     </li>  
@@ -118,6 +117,7 @@ function currentPageIsUnder(root) {
     <li><a href="<%=baseURL%>Distribution">Publishing add-ons</a>
       <ol>
         <li><a href="<%=baseURL%>Distribution">Signing and distribution overview</a></li>
+        <li><a href="<%=baseURL%>WebExtensions/Publishing_your_WebExtension">Publishing your extension</a></li>
         <li><a href="<%=baseURL%>Distribution/Submitting_an_add-on">Submit an add-on</a></li>
         <li><a href="<%=baseURL%>Listing">Creating an appealing listing</a></li>
         <li><a href="<%=baseURL%>AMO/Policy/Reviews">Review policies</a></li>

--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -58,9 +58,10 @@ function currentPageIsUnder(root) {
     <li><a href="<%=baseURL%>WebExtensions#How_to">How to</a>
       <ol>
         <li><a href="<%=baseURL%>WebExtensions/Intercept_HTTP_requests">Intercept HTTP requests</a></li>
-        <li><a href="<%=baseURL%>WebExtensions/Modify_a_web_page">Modify a web page</a>
-        <li><a href="<%=baseURL%>WebExtensions/Add_a_button_to_the_toolbar">Add a button to the toolbar</a>
+        <li><a href="<%=baseURL%>WebExtensions/Modify_a_web_page">Modify a web page</a></li>
+        <li><a href="<%=baseURL%>WebExtensions/Add_a_button_to_the_toolbar">Add a button to the toolbar</a></li>
         <li><a href="<%=baseURL%>WebExtensions/Implement_a_settings_page">Implement a settings page</a></li>
+        <li><a href="<%=baseURL%>WebExtensions/Working_with_the_Tabs_API">Work with the Tabs API</a></li>
       </ol>
     </li>
 


### PR DESCRIPTION
from the "Firefox workflow" section to the "Publishing and Distribution" section as per https://trello.com/c/aGv5HuNF