### PR TITLE
updating web animations api spec location

### DIFF
--- a/macros/SpecName.ejs
+++ b/macros/SpecName.ejs
@@ -1003,7 +1003,7 @@ var specList = {
     },
     'Web Animations':{
         name : 'Web Animations',
-        url  : 'https://w3c.github.io/web-animations/'
+        url  : 'https://drafts.csswg.org/web-animations/'
     },
     'WebAssembly Embedding':{
         name : 'WebAssembly features for web embedding',


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1426032