### PR TITLE
Add icons in case of support ranges

### DIFF
--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -326,6 +326,11 @@ Generates icons for the main cell
 function writeCellIcons(support) {
   let output = '<div class="bc-icons">';
 
+  if (Array.isArray(support)) {
+    // the first entry should be the most relevant/recent and will be used for the main cell
+    support = support[0];
+  }
+
   if (support.prefix) {
     output += writeIcon('prefix', support.prefix) + ' ';
     legendItems.add('prefix');

--- a/tests/macros/test-compat.js
+++ b/tests/macros/test-compat.js
@@ -353,6 +353,13 @@ describeMacro('Compat', function () {
               'ic-prefix');
         });
     });
+    itMacro('Adds a note icon if the first element in a support array has a note', function (macro) {
+        return macro.call('notes.feature').then(function(result) {
+            let dom = JSDOM.fragment(result);
+            assert.include(Array.from(dom.querySelector('.bc-browser-firefox > .bc-icons > abbr > i').classList),
+              'ic-footnote');
+        });
+    });
 
 
     // Test flags


### PR DESCRIPTION
Fixes https://github.com/mdn/kumascript/issues/541

In cases when we have support ranges instead of a single support information, we should display the icons of the first one and most relevant support range in the main cell as well.

Example: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer The cell for Firefox 57 shouldn't just be green, but also contain the icons for the note and for the flag. Just like the first cell that is presented when you expand the support history.