### PR TITLE
Document how to hide the 'Open in...' buttons for EmbedLiveSample

### DIFF
--- a/macros/EmbedLiveSample.ejs
+++ b/macros/EmbedLiveSample.ejs
@@ -7,7 +7,9 @@
 //  $2 - The height of the iframe (optional)
 //  $3 - The url of a screenshot of the sample working as intended (optional)
 //  $4 - The slug from which to load the sample (optional; current page used if not provided)
-//  $5 - The class name of the frame; defaults to "sample-code-frame"
+//  $5 - The class name of the frame; defaults to "sample-code-frame". If you
+//  pass this parameter and give it a value other than "sample-code-frame",
+//  then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
 //
 // See also : LiveSampleLink
  


### PR DESCRIPTION
Document secret behavior of the class parameter: https://bugzilla.mozilla.org/show_bug.cgi?id=1425646#c1