### PR TITLE
Fix typo in French translation for Spec2 macro

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -438,7 +438,7 @@ var unknown_label = mdn.localString({
     'ja'    : '不明',
     'de'    : 'Unbekannt',
     'ru'    : 'Неизвестно',
-    'fr'    : 'Statut incoonu',
+    'fr'    : 'Statut inconnu',
     'pt-BR' : 'Desconhecido'
 });
 


### PR DESCRIPTION
Fixes a small typo in the spec2 macro for the French translation of "Unknown status"