### PR TITLE
Stop determining partial_support from sub feature support

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -489,27 +489,6 @@ function traverseFeatures(obj, depth, identifier) {
     for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
-
-          let featureNames = Object.keys(obj[i]);
-          if (featureNames.length > 1) {
-            // there are sub features below this node,
-            // so we need to identify partial support for the main feature
-            for (let subfeatureName of featureNames) {
-              // if this is actually a subfeature (i.e. it is not a __compat object)
-              // and the subfeature has a __compat object
-              if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                let browserNames = Object.keys(obj[i].__compat.support);
-                for (let browser of browserNames) {
-                  if (obj[i].__compat.support[browser].version_added !=
-                      obj[i][subfeatureName].__compat.support[browser].version_added ||
-                      obj[i][subfeatureName].__compat.support[browser].notes) {
-                    obj[i].__compat.support[browser].partial_support = true;
-                  }
-                }
-              }
-            }
-          }
-
           features.push({[identifier + i]: obj[i].__compat});
         }
         traverseFeatures(obj[i], depth, i + '.');

--- a/macros/CompatBeta.ejs
+++ b/macros/CompatBeta.ejs
@@ -614,27 +614,6 @@ function traverseFeatures(obj, depth, identifier) {
     for (let i in obj) {
       if (!!obj[i] && typeof(obj[i])=="object" && i !== '__compat') {
         if (obj[i].__compat) {
-
-          let featureNames = Object.keys(obj[i]);
-          if (featureNames.length > 1) {
-            // there are sub features below this node,
-            // so we need to identify partial support for the main feature
-            for (let subfeatureName of featureNames) {
-              // if this is actually a subfeature (i.e. it is not a __compat object)
-              // and the subfeature has a __compat object
-              if ((subfeatureName !== '__compat') && (obj[i][subfeatureName].__compat)) {
-                let browserNames = Object.keys(obj[i].__compat.support);
-                for (let browser of browserNames) {
-                  if (obj[i].__compat.support[browser].version_added !=
-                    obj[i][subfeatureName].__compat.support[browser].version_added ||
-                    obj[i][subfeatureName].__compat.support[browser].notes) {
-                      obj[i].__compat.support[browser].partial_implementation = true;
-                    }
-                  }
-                }
-              }
-            }
-
             features.push({[identifier + i]: obj[i].__compat});
           }
           traverseFeatures(obj[i], depth, i + '.');

--- a/tests/macros/fixtures/compat/support_variations.json
+++ b/tests/macros/fixtures/compat/support_variations.json
@@ -117,33 +117,6 @@
                     }
                 }
             }
-        },
-        "partial_support_due_to_subfeature": {
-            "__compat": {
-                "support": {
-                    "firefox": {
-                        "version_added": "25"
-                    }
-                }
-            },
-            "subfeature": {
-                "__compat": {
-                    "support": {
-                        "firefox": {
-                            "version_added": "25"
-                        }
-                    }
-                },
-                "subsubfeature_with_different_version_than_parent_feature": {
-                    "__compat": {
-                        "support": {
-                            "firefox": {
-                                "version_added": "35"
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/tests/macros/test-compat.js
+++ b/tests/macros/test-compat.js
@@ -303,17 +303,6 @@ describeMacro('Compat', function () {
               '25 — 35');
         });
     });
-    itMacro('Creates correct cell content for partial support due to subfeature support with different version', function (macro) {
-        return macro.call('html.partial_support_due_to_subfeature').then(function(result) {
-            let dom = JSDOM.fragment(result);
-            assert.include(Array.from(dom.querySelector('.bc-table tbody tr:nth-child(2) td:nth-child(4)').classList),
-              'bc-supports-partial');
-            assert.equal(dom.querySelector('.bc-table tbody tr:nth-child(2) td:nth-child(4) abbr span').textContent,
-              'Partial support');
-            assert.include(dom.querySelector('.bc-table tbody tr:nth-child(2) td:nth-child(4)').textContent,
-              '25');
-        });
-    });
 
 
     // Test icons in main cells


### PR DESCRIPTION
After bugs like https://github.com/mdn/kumascript/pull/419 and the discourse discussion (https://discourse.mozilla.org/t/beta-testing-new-compatability-tables/21269/4), I feel like it's best to stop determining `partial_support` automatically from the sub feature support. As many pointed out, it's overly aggressive and doesn't make sense most of the time. In BCD, we have the full control: we can set `partial_support: true` and the cell will be yellow. We can set that for main features or for sub features whenever we need it.

Partial support is probably something that depends on several things. Like there could be a note that basically says that only half of the feature works, so there will be the asterisk (*) icon, but in that case `partial_support `should also be set to true, so that the cell is yellow meaning that this feature really only works half of the time. In other cases, the note is just a minor thing though, so partial support / yellow cell isn't needed. You can't tell automatically.
The same goes for how critical it is that certain sub features are supported. 
So, let's have this as human decisions instead of trying to rely on bad automatic marking, which is likely too aggressive or wrong in many cases.