### PR TITLE
bug 1432106: AddonSidebar: Update link

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -20,7 +20,7 @@ function currentPageIsUnder(root) {
 
     <li><a href="<%=baseURL%>WebExtensions#Getting_started">Getting started</a>
       <ol>
-        <li><a href="<%=baseURL%>WebExtensions/What_are_WebExtensions_">What are extensions?</a></li>
+        <li><a href="<%=baseURL%>WebExtensions/What_are_WebExtensions">What are extensions?</a></li>
         <li><a href="<%=baseURL%>WebExtensions/Your_first_WebExtension">Your first extension</a></li>
         <li><a href="<%=baseURL%>WebExtensions/Your_second_WebExtension">Your second extension</a></li>
         <li><a href="<%=baseURL%>WebExtensions/Anatomy_of_a_WebExtension">Anatomy of an extension</a>


### PR DESCRIPTION
This addresses [bug 1432106](https://bugzilla.mozilla.org/show_bug.cgi?id=1432106).

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/What_are_WebExtensions_

is now a redirect to:

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/What_are_WebExtensions

The question mark "?" was encoded as an underscore, so it was removed from the slug.