### PR TITLE
Updated W3C HTML5 spec link

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -771,7 +771,7 @@
   },
   "HTML5 W3C": {
     "name": "HTML5",
-    "url": "https://www.w3.org/TR/html5/",
+    "url": "https://www.w3.org/TR/html50/",
     "status": "REC"
   },
   "HTML5.1": {


### PR DESCRIPTION
It moved recently. This is in the data for the spec tables, so many, many links are currently broken throughout our spec tables.