### PR TITLE
Remove legacy `autocomplete` and `autocompleteerror` events

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -790,8 +790,6 @@
             "methods":    [],
             "properties": [],
             "events":     [ "abort",
-                            "autocomplete",
-                            "autocompleteerror",
                             "DOMContentLoaded",
                             "afterprint",
                             "afterscriptexecute",


### PR DESCRIPTION
Remove from the HTML spec at: https://github.com/whatwg/html/commit/6a257aae619f85390eee20b47767f34887450fcd#diff-36cd38f49b9afa08222c0dc9ebfe35ebL117476