### PR TITLE
Browser Kompatibilität -> Browserkompatibilität

### DIFF
--- a/macros/SeeCompatTable.ejs
+++ b/macros/SeeCompatTable.ejs
@@ -1,7 +1,7 @@
 <%
 
 var str = mdn.localString({
-    "de"    : "<strong>Dies ist eine experimentelle Technologie</strong><br />Da diese Technologie noch nicht definitiv implementiert wurde, sollte die <a href='#Browser_compatibility'>Browser Kompatibilität</a> beachtet werden. Es ist auch möglich, dass der Syntax in einer späteren Spezifikation noch geändert wird.",
+    "de"    : "<strong>Dies ist eine experimentelle Technologie</strong><br />Da diese Technologie noch nicht definitiv implementiert wurde, sollte die <a href='#Browser_compatibility'>Browserkompatibilität</a> beachtet werden. Es ist auch möglich, dass der Syntax in einer späteren Spezifikation noch geändert wird.",
     "es"    : "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#Experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#Browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
     "fr"    : "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#Browser_compatibility'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
     "ja"    : "<strong>これは実験段階の機能です。</strong><br />この機能は複数のブラウザーで開発中の状態にあります。<a href='#Browser_compatibility'>互換性テーブル</a>をチェックしてください。また、実験段階の機能の構文と挙動は、仕様変更に伴い各ブラウザーの将来のバージョンで変更になる可能性があることに注意してください。 ",


### PR DESCRIPTION
In many german pages is written "Browserkompatibilität"  and not "Browser Kompatibilität"