### PR TITLE
Remove non-existent "muted" event

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1017,7 +1017,6 @@
                             "active",
                             "ended",
                             "mute",
-                            "muted",
                             "unmute",
                             "overconstrained",
                             "ratechange",


### PR DESCRIPTION
The Media Capture and Streams API entry in GroupData.json
incorrectly had a "muted" event. This removes that.