### PR TITLE
Improve maintainability of CompatEdge macro

### DIFF
--- a/macros/CompatEdge.ejs
+++ b/macros/CompatEdge.ejs
@@ -7,20 +7,6 @@
 var edgeVersion = "";
 var edgeHTMLVersion = $0;
 
-var str20OrEarlier = mdn.localString({
-    "en-US" : "20 or earlier",
-    "es"    : "20 o anterior",
-    "fr"    : "20 ou moins",
-    "de"    : "20 oder früher",
-    "ru"    : "20 или ранее"
-});
-
-var strUnknown = mdn.localString({
-    "en-US" : "Unknown",
-    "es"    : "Desconocido",
-    "de"    : "Unbekannt"
-});
-
 var title = mdn.localString({
     "en-US" : "Released on $releaseDate$.",
     "es"    : "Publicado en $releaseDate$.",
@@ -30,180 +16,44 @@ var title = mdn.localString({
 });
 
 var releases = {
-    "12.10240": { // Desktop release
+    "12.10240": { // Desktop
         version: "20",
         date: "2015-07-15",
-        url: "https://blogs.windows.com/bloggingwindows/2015/07/15/build-10240-now-available-for-windows-insiders-in-fast-and-slow-rings/"
+        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/10240/"
     },
-    "12.10512": { // Mobile release
-        version: "20",
-        date: "2015-08-12",
-        url: "https://blogs.windows.com/windowsexperience/2015/08/12/announcing-windows-10-mobile-insider-preview-build10512/"
-    },
-    "12.10525": { // Desktop release
-        version: "20",
-        date: "2015-08-18",
-        url: "https://blogs.windows.com/bloggingwindows/2015/08/18/announcing-windows-10-insider-preview-build-10525/"
-    },
-    "12.10532": { // Desktop release
-        version: "20",
-        date: "2015-08-27",
-        url: "https://blogs.windows.com/bloggingwindows/2015/08/27/windows-10-insider-preview-build-10532-for-pc/"
-    },
-    "12.10536": { // Mobile release
-        version: "20",
-        date: "2015-09-15",
-        url: "https://blogs.windows.com/windowsexperience/2015/09/14/announcing-windows-10-mobile-insider-preview-build-10536/"
-    },
-    "13.10547": { // Desktop release
-        version: "21",
-        date: "2015-09-18",
-        url: "https://blogs.windows.com/windowsexperience/2015/09/18/announcing-windows-10-insider-preview-build-10547/"
-    },
-    "13.10549": { // Mobile release
-        version: "21",
-        date: "2015-10-14",
-        url: "https://blogs.windows.com/windowsexperience/2015/10/14/announcing-windows-10-mobile-insider-preview-build-10549/"
-    },
-    "13.10565": { // Desktop release
-        version: "23",
-        date: "2015-10-12",
-        url: "https://blogs.windows.com/windowsexperience/2015/10/12/announcing-windows-10-insider-preview-build-10565/"
-    },
-    "13.10572": { // Mobile release
-        version: "25",
-        date: "2015-10-20",
-        url: "https://blogs.windows.com/windowsexperience/2015/10/20/announcing-windows-10-mobile-insider-preview-build-10572/"
-    },
-    "13.10576": { // Desktop release
-        version: "25",
-        date: "2015-10-29",
-        url: "https://blogs.windows.com/windowsexperience/2015/10/29/announcing-windows-10-insider-preview-build-10576/"
-    },
-    "13.10581": { // Mobile release
-        version: "25",
-        date: "2015-10-29",
-        url: "https://blogs.windows.com/windowsexperience/2015/10/29/announcing-windows-10-mobile-insider-preview-build-10581/"
-    },
-    "13.10586": { // Desktop & mobile release
+    "13.10586": { // Desktop, mobile, Xbox & server
         version: "25",
         date: "2015-11-05",
-        url: "https://blogs.windows.com/windowsexperience/2015/11/05/announcing-windows-10-insider-preview-build-10586/"
+        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/10586/"
     },
-    "13.11082": { // Desktop release
-        version: "25",
-        date: "2015-12-16",
-        url: "https://blogs.windows.com/windowsexperience/2015/12/16/announcing-windows-10-insider-preview-build-11082/"
-    },
-    "13.11099": { // Desktop release
-        version: "27",
-        date: "2016-01-13",
-        url: "https://blogs.windows.com/windowsexperience/2016/01/13/announcing-windows-10-insider-preview-build-11099/"
-    },
-    "13.11102": { // Desktop release
-        version: "28",
-        date: "2016-01-21",
-        url: "https://blogs.windows.com/windowsexperience/2016/01/21/announcing-windows-10-insider-preview-build-11102/"
-    },
-    "13.14251": { // Desktop release
-        version: "28",
-        date: "2016-01-27",
-        url: "https://blogs.windows.com/windowsexperience/2016/01/27/announcing-windows-10-insider-preview-build-14251/"
-    },
-    "13.14257": { // Desktop release
-        version: "28",
-        date: "2016-02-03",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14257/"
-    },
-    "14.14267": { // Desktop & mobile release
-        version: "31",
-        date: "2016-02-18",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14267/"
-    },
-    "14.14271": { // Desktop release
-        version: "31",
-        date: "2016-02-24",
-        url: "https://blogs.windows.com/windowsexperience/2016/02/24/announcing-windows-10-insider-preview-build-14271-mobile-build-14267-1004/"
-    },
-    "14.14279": { // Desktop release
-        version: "31",
-        date: "2016-03-04",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14279/"
-    },
-    "14.14283": { // Mobile release
-        version: "31",
-        date: "2016-03-10",
-        url: "https://blogs.windows.com/windowsexperience/2016/03/10/announcing-windows-10-mobile-insider-preview-build-14283/"
-    },
-    "14.14291": { // Desktop & mobile release
-        version: "34",
-        date: "2016-03-17",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14291/"
-    },
-    "14.14295": { // Desktop & mobile release
-        version: "34",
-        date: "2016-03-25",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14295/"
-    },
-    "14.14316": { // Desktop release
-        version: "37",
-        date: "2016-04-06",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14316/"
-    },
-    "14.14322": { // Mobile release
-        version: "37",
-        date: "2016-04-14",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/mobile/14322/"
-    },
-    "14.14327": { // Mobile release
-        version: "37",
-        date: "2016-04-20",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/mobile/14327/"
-    },
-    "14.14328": { // Desktop & mobile release
-        version: "37",
-        date: "2016-04-22",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14328/"
-    },
-    "14.14332": { // Desktop & mobile release
-        version: "37",
-        date: "2016-04-26",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14332/"
-    },
-    "14.14342": { // Desktop release
-        version: "38",
-        date: "2016-05-10",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14342/"
-    },
-    "14.14352": {
-        version: "38",
-        date: "2016-05-31",
-        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14352/"
-    },
-    "14.14393": {
+    "14.14393": { // Desktop & mobile
         version: "38",
         date: "2016-08-02",
         url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14393/"
+    },
+    "15.15063": { // Desktop
+        version: "40",
+        date: "2017-04-11",
+        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/15063/"
+    },
+    "16.16299": { // Desktop
+        version: "41",
+        date: "2017-09-26",
+        url: "https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/16299/"
     }
 };
 
 var release = releases[edgeHTMLVersion];
 if (!release) {
-    if (Math.floor(Number(edgeHTMLVersion)) <= 12) {
-        release = {
-            version: str20OrEarlier
-        };
-    } else {
-        release = {
-            version: strUnknown
-        };
-    }
+    release = {
+        version: "Insider"
+    };
 }
 var result = "";
 
 if (release.url) {
     var titleStr = "";
-    if (release.version) {
+    if (release.date) {
         titleStr = " title=\"" +
             mdn.replacePlaceholders(title, {releaseDate: release.date}) +
             "\"";


### PR DESCRIPTION
Most of the logged releases were Insider builds, which are effectively nightly builds. It makes no sense to track unfinished releases so I've removed all Insider releases, and added 2 missing final releases.

Knowing that a feature is available in a nightly is useful though, so unknown versions are marked as Insider. It is possible to automatically generate a url for these builds. If people want it, let me know.

I spotted and fixed a bad value check (`release.version` vs. `release.date`) as well.

I did have a go at testing this change, however I was unable to sign in or edit. And to my knowledge, the sample database does not use `CompatEdge`.