### PR TITLE
Delete Suivant.ejs

### DIFF
--- a/macros/Suivant.ejs
+++ b/macros/Suivant.ejs
@@ -1,5 +1,0 @@
-<%
-/* one parameter: path of Next page */
-/* please use Next instead of this template */
-%>
-<%- template("Next", [$0]) %>


### PR DESCRIPTION
This macro is a "translation" of Next. I've removed all the occurences in fr pages and it doesn't show up anymore.
Having done a quick search across the codebase, it doesn't seem used by another macro.
Let's get rid of this one.