### PR TITLE
Add a call to action to old compat tables

### DIFF
--- a/macros/CompatibilityTable.ejs
+++ b/macros/CompatibilityTable.ejs
@@ -13,17 +13,14 @@ var s_header = mdn.localString({
 var repoLink = 'https://github.com/mdn/browser-compat-data';
 var migrationLink = '/' + env.locale + '/docs/MDN/Contribute/Structures/Compatibility_tables';
 var cta = mdn.localString({
-    "en-US": `This compatibility table is outdated.
-              Please help us to <a href="${migrationLink}">migrate</a> this data
-              to <a href="${repoLink}">github.com/mdn/browser-compat-data</a>
-              so the new compat table can be shown.`,
-    "de": `Diese Browserkompatibilitätstabelle ist veraltet.
-          Hilf mit die Daten in das <a href="${repoLink}">github.com/mdn/browser-compat-data</a> Repository
-          zu <a href="${migrationLink}">migrieren</a>, sodass die neue Tabelle angezeigt werden kann.`,
-    "fr": `Ce tableau de compatibilité n'est plus à jour.
-           Vous pouvez nous aider à <a href="${migrationLink}">migrer</a>
-           ces données vers <a href="${repoLink}">github.com/mdn/browser-compat-data</a>
-           afin d'afficher le nouveau tableau de compatibilité.`,
+  "en-US": `<strong><a href="${repoLink}">We're converting our compatibility data into a machine-readable JSON format</a></strong>.
+            This compatibility table still uses the old format,
+            because we haven't yet converted the data it contains.
+            <strong><a href="${migrationLink}">Find out how you can help!</a></strong>`,
+  "de":     `<strong><a href="${repoLink}">Wir konvertieren die Kompatibilitätsdaten in ein maschinenlesbares JSON Format</a></strong>.
+            Diese Kompatibilitätstabelle liegt noch im alten Format vor,
+            denn die darin enthaltenen Daten wurden noch nicht konvertiert.
+            <strong><a href="${migrationLink}">Finde heraus wie du helfen kannst!</a></strong>`,
 });
 
 %>

--- a/macros/CompatibilityTable.ejs
+++ b/macros/CompatibilityTable.ejs
@@ -10,7 +10,23 @@ var s_header = mdn.localString({
     "fr":    [ "Ordinateur", "Mobile" ]
 });
 
-%><div class="htab">
+var repoLink = 'https://github.com/mdn/browser-compat-data';
+var migrationLink = '/' + env.locale + '/docs/MDN/Contribute/Structures/Compatibility_tables';
+var cta = mdn.localString({
+    "en-US": `This compatibility table is outdated.
+              Please help us to <a href="${migrationLink}">migrate</a> this data
+              to <a href="${repoLink}">github.com/mdn/browser-compat-data</a>
+              so the new compat table can be shown.`,
+    "de": `Diese Browserkompatibilitätstabelle ist veraltet.
+          Hilf mit die Daten in das <a href="${repoLink}">github.com/mdn/browser-compat-data</a> Repository
+          zu <a href="${migrationLink}">migrieren</a>, sodass die neue Tabelle angezeigt werden kann.`,
+});
+
+%>
+
+<p class="warning"><%-cta%></p>
+
+<div class="htab">
     <a id="AutoCompatibilityTable" name="AutoCompatibilityTable"></a>
     <ul>
         <li class="selected"><a href="javascript:;"><%- s_header[0] %></a></li>

--- a/macros/CompatibilityTable.ejs
+++ b/macros/CompatibilityTable.ejs
@@ -21,6 +21,10 @@ var cta = mdn.localString({
             Diese Kompatibilitätstabelle liegt noch im alten Format vor,
             denn die darin enthaltenen Daten wurden noch nicht konvertiert.
             <strong><a href="${migrationLink}">Finde heraus wie du helfen kannst!</a></strong>`,
+  "fr":     `<strong><a href="${repoLink}">Nous convertissons les données de compatibilité dans un format JSON</a></strong>.
+            Ce tableau de compatibilité utilise encore l'ancien format
+            car nous n'avons pas encore converti les données qu'il contient.
+            <strong><a href="${migrationLink}">Vous pouvez nous aider en contribuant !</a></strong>`,
 });
 
 %>

--- a/macros/CompatibilityTable.ejs
+++ b/macros/CompatibilityTable.ejs
@@ -20,6 +20,10 @@ var cta = mdn.localString({
     "de": `Diese Browserkompatibilitätstabelle ist veraltet.
           Hilf mit die Daten in das <a href="${repoLink}">github.com/mdn/browser-compat-data</a> Repository
           zu <a href="${migrationLink}">migrieren</a>, sodass die neue Tabelle angezeigt werden kann.`,
+    "fr": `Ce tableau de compatibilité n'est plus à jour.
+           Vous pouvez nous aider à <a href="${migrationLink}">migrer</a>
+           ces données vers <a href="${repoLink}">github.com/mdn/browser-compat-data</a>
+           afin d'afficher le nouveau tableau de compatibilité.`,
 });
 
 %>


### PR DESCRIPTION
I want to migrate faster. Let's add this warning to all readers of old compat tables:

![compat-cta](https://user-images.githubusercontent.com/349114/35875765-952e1aa8-0b70-11e8-83b3-480827fb4dbb.png)

@wbamberg can you review the wording?
@SphinxKnight can you translate the string to French?
@jwhitlock This will need a re-render of all MDN to be most effective.
