### PR TITLE
Delete AnteriorSiguiente.ejs

### DIFF
--- a/macros/AnteriorSiguiente.ejs
+++ b/macros/AnteriorSiguiente.ejs
@@ -1,6 +1,0 @@
-<%
-/* first parameter: path of Previous page */
-/* second parameter: path of Next page */
-/* please use PreviousNext instead of this template */
-%>
-<%- template("PreviousNext", [$0,$1]) %>


### PR DESCRIPTION
This macro is a Spanish translation of PreviousNext.ejs. I've replaced all occurences in the wiki and can't find any more pages using the search. This macro isn't used inside the kumascript codebase as far as I can tell.