### PR TITLE
Delete Dopracuj.ejs

### DIFF
--- a/macros/Dopracuj.ejs
+++ b/macros/Dopracuj.ejs
@@ -1,7 +1,0 @@
-<div style="background:lemonchiffon;border:solid navajowhite 1px;text-align:center;margin-bottom:1em;border-radius:10px;overflow:hidden">
-    <div><span style="color:#000;">UWAGA:</span> <b>Tłumaczenie tej strony nie zostało zakończone</b>.</div>
-    <div>
-        <small>Może być ona <span style="color: #000;">niekompletna</span> lub <span style="color: #000;">wymagać korekty</span>.</small><br />
-        <a href="/pl/docs/Project:Pomoc">Chcesz pomóc?</a> | Dokończ tłumaczenie | Sprawdź ortografię | <a href="/pl/docs/tag/Strony_wymagające_dopracowania">Więcej takich stron+.</a>
-    </div>
-</div>


### PR DESCRIPTION
This a Polish macro equivalent to the "Localization in progress" CTA banner.
I've removed all calls from inside articles, added "Localization in progress" flags where relevant, and checked if this macro was called from inside KumaScript code.