### PR TITLE
Delete named-bug.ejs

### DIFF
--- a/macros/named-bug.ejs
+++ b/macros/named-bug.ejs
@@ -1,1 +1,0 @@
-<a rel="external" class="external" href="https://bugzilla.mozilla.org/show_bug.cgi?id=<%= $0 %>" title="https://bugzilla.mozilla.org/show_bug.cgi?id=<%= $0 %>" target="_blank"><%= ($1 || $0) %></a>


### PR DESCRIPTION
I replaced all calls of this macro by {{bug}} ones.
It doesn't seem to be used in KumaScript code.