### PR TITLE
Delete PotřebujePřeložit.ejs

### DIFF
--- a/macros/PotřebujePřeložit.ejs
+++ b/macros/PotřebujePřeložit.ejs
@@ -1,1 +1,0 @@
-<%- template("Note", ['Tato stránka není ještě zcela přeložena. Pomozte nám ji prosím <a href="Project:cs/Pr%c5%afvodce_p%c5%99ekladatele">dopřeložit</a>.']) %>


### PR DESCRIPTION
This macro was equivalent to the "call to action" banner which is displayed when the "Localization in progress" box is ticked. I've removed calls and ticked the box where relevant.