### PR TITLE
Delete SeznamDiskuzí.ejs

### DIFF
--- a/macros/SeznamDiskuzí.ejs
+++ b/macros/SeznamDiskuzí.ejs
@@ -1,5 +1,0 @@
-<ul>
-  <li>Zobrazit fóra Mozilla.org jako:
-<%- template("DiscussionList", [$0,$1]) %>
-  </li>
-</ul>


### PR DESCRIPTION
This macro is a Czech translation for the "canonical" macro DiscussionList. I've removed all calls across documents.