### PR TITLE
Changed "Publishing your extension" to "Package your extension"

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -123,7 +123,7 @@ function currentPageIsUnder(root) {
     <li><a href="<%=baseURL%>Distribution">Publishing add-ons</a>
       <ol>
         <li><a href="<%=baseURL%>Distribution">Signing and distribution overview</a></li>
-        <li><a href="<%=baseURL%>WebExtensions/Publishing_your_WebExtension">Publishing your extension</a></li>
+        <li><a href="<%=baseURL%>WebExtensions/Package_your_extension_">Package your extension</a></li>
         <li><a href="<%=baseURL%>Distribution/Submitting_an_add-on">Submit an add-on</a></li>
         <li><a href="<%=baseURL%>Source_Code_Submission">Source code submission</a></li>
         <li><a href="<%=baseURL%>Listing">Creating an appealing listing</a></li>


### PR DESCRIPTION
Hi Will, this one is slightly convoluted. Having moved the "Publish your extension" page to the "Publishing and distribution" section, it became clear that most of its content overlapped with existing pages in that section. Having removed the overlapping content it left the instructions for manually zipping your extension package, so the page was retitled and it seemed to make sense to provide it with a new slug at the same time. Hope this is all okay/makes sense.