### PR TITLE
Delete k-rate.ejs

### DIFF
--- a/macros/k-rate.ejs
+++ b/macros/k-rate.ejs
@@ -1,1 +1,0 @@
-<a href="/<%- env.locale %>/docs/DOM/AudioParam#k-rate">k-rate</a>


### PR DESCRIPTION
It's funny because:
* this macro was a sheer link used across less than 30 pages
* k-rate is pronounced "karate" in French