### PR TITLE
Delete ListeDeDiscussion.ejs

### DIFF
--- a/macros/ListeDeDiscussion.ejs
+++ b/macros/ListeDeDiscussion.ejs
@@ -1,1 +1,0 @@
-<%- template("DiscussionList", [$0,$1]) %>


### PR DESCRIPTION
This one was a pure "french" alias for DiscussionList, I've replaced the calls.