### PR TITLE
Delete Gengoheiki.ejs

### DIFF
--- a/macros/Gengoheiki.ejs
+++ b/macros/Gengoheiki.ejs
@@ -1,2 +1,0 @@
-<% /* This template is same as Template:原語併記 */ %>
-<%- Web.html($0) %> (<span style="color: green;"><%- Web.html($1) %></span>)


### PR DESCRIPTION
Japanese utility macro that basically enclosed one of the arg in parenthesis and added a pale green. I've replace calls with "$1 ($2)" (where $1 is the first arg of the macro and $2 the second)