### PR TITLE
Added "HTML Microdata"

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -771,7 +771,7 @@
   },
   "HTML Microdata": {
     "name": "HTML Microdata",
-    "url": "https://www.w3.org/TR/microdata/",
+    "url": "https://w3c.github.io/microdata/",
     "status": "WD"
   },
   "HTML4.01": {

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -769,6 +769,11 @@
     "url": "https://w3c.github.io/html-media-capture/",
     "status": "REC"
   },
+  "HTML Microdata": {
+    "name": "HTML Microdata",
+    "url": "https://www.w3.org/TR/microdata/",
+    "status": "WD"
+  },
   "HTML4.01": {
     "name": "HTML 4.01 Specification",
     "url": "https://www.w3.org/TR/html401/",


### PR DESCRIPTION
HTML Microdata has been working draft in W3C.
The latest working draft is issued on Oct 10, 2017.
https://www.w3.org/TR/microdata/