### PR TITLE
Update URL structure for IETF RFCs for HTTPS

### DIFF
--- a/macros/RFC.ejs
+++ b/macros/RFC.ejs
@@ -12,7 +12,7 @@
 // it, and the default text shown has ", section $2" appended to it.
 //
 
-var link = "http://tools.ietf.org/html/" + $0;
+var link = "https://tools.ietf.org/html/rfc" + $0;
 var text = "";
 
 var commonl10n = string.deserialize(template('L10n:Common'));


### PR DESCRIPTION
Access to the old http-based URLs was automatically redirect to URLs in the format of: `https://tools.ietf.org/html/rfc<document number>`.  This PR updates the RFC macro such that HTTPS is used by default, matching the way in which tools.ietf.org is now serving RFC content and helping improve performance (1 fewer redirect) but helps avoid security issues with having insecure HTTP-based requests.

See https://en.wikipedia.org/wiki/Template:Cite_IETF/doc#URL_generation for a more detailed summary of URLs.