### PR TITLE
Update Web Auth

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1350,9 +1350,9 @@
     "status": "REC"
   },
   "WebAuthn": {
-    "name": "Web Authentication Level 1",
+    "name": "Web Authentication: An API for accessing Public Key Credentials Level 1",
     "url": "https://w3c.github.io/webauthn/",
-    "status": "WD"
+    "status": "CR"
   },
   "WebDriver": {
     "name": "WebDriver",


### PR DESCRIPTION
It's now a [candidate recommendation](https://www.w3.org/TR/2018/CR-webauthn-20180320). This PR also updates its title which I suspect has been out of date for some time.