### PR TITLE
bug 1431259: change stage domain to developer.allizom.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Dependency Status](https://david-dm.org/mdn/kumascript.svg?theme=shields.io)](https://david-dm.org/mdn/kumascript)
 [![devDependency Status](https://david-dm.org/mdn/kumascript/dev-status.svg?theme=shields.io)](https://david-dm.org/mdn/kumascript#info=devDependencies)
 
-[What's Deployed](https://whatsdeployed.io/s-4kW)
+[What's Deployed](https://whatsdeployed.io/s-SWJ)
 
 ## Overview
 

--- a/macros/LiveSampleURL.ejs
+++ b/macros/LiveSampleURL.ejs
@@ -25,10 +25,10 @@ base = base.replace('developer.mozilla.org', 'mdn.mozillademos.org');
 if (pageUrl.indexOf("developer.mozilla.org") != -1) {
   // Production
   base = base.replace('http://', 'https://');
-} else if (pageUrl.indexOf("stage.mdn.moz.works") != -1) {
+} else if (pageUrl.indexOf("developer.allizom.org") != -1) {
   // Staging
   base = base.replace('http://', 'https://');
-  base = base.replace('https://stage.mdn.moz.works',
+  base = base.replace('https://developer.allizom.org',
                       'https://stage-files.mdn.moz.works');
 } else {
   // Not production - use the same scheme as the main site


### PR DESCRIPTION
This PR updates a macro to reflect the new domain name (actually a return to the old domain name!) for stage `developer.allizom.org`.