### PR TITLE
Add tests to avoid division by zero

### DIFF
--- a/macros/L10nStatusOverview.ejs
+++ b/macros/L10nStatusOverview.ejs
@@ -98,20 +98,30 @@ getPages(pageList);
   <tbody>
     <%
         for (var key in result) {
-        if (result.hasOwnProperty(key) && typeof key != 'undefined') {
-            var pageCounter = result[key].metrics.pages.counter || 0;
-            var translationCounter = result[key].metrics.translations.counter || 0;
-            var updateCounter = result[key].metrics.updateNeeded.counter || 0;
+            if (result.hasOwnProperty(key) && typeof key != 'undefined') {
+                var pageCounter = result[key].metrics.pages.counter || 0;
+                var translationCounter = result[key].metrics.translations.counter || 0;
+                var updateCounter = result[key].metrics.updateNeeded.counter || 0;
 
-            totalPages += pageCounter;
-            totalTranslated += translationCounter;
-            totalUpToDate += updateCounter;
+                totalPages += pageCounter;
+                totalTranslated += translationCounter;
+                totalUpToDate += updateCounter;
 
-            var translationPercent = Math.floor((translationCounter / pageCounter) * 100);
-            var uptodatePercent = Math.floor((updateCounter / pageCounter) * 100);
+                if (pageCounter === 0) {
+                    var translationPercent =  100;
+                    var uptodatePercent = 100;
+                } else {
+                     var translationPercent = Math.floor((translationCounter / pageCounter) * 100);
+                     var uptodatePercent = Math.floor((updateCounter / pageCounter) * 100);
+                }
 
-            var totalTranslatedPercent = Math.floor((totalTranslated / totalPages) * 100);
-            var totalUpToDatePercent = Math.floor((totalUpToDate / totalPages) * 100);
+                if (totalPages === 0) {
+                    var totalTranslatedPercent = 100;
+                    var totalUpToDatePercent = 100;
+                } else {
+                    var totalTranslatedPercent = Math.floor((totalTranslated / totalPages) * 100);
+                    var totalUpToDatePercent = Math.floor((totalUpToDate / totalPages) * 100);
+                }
     %>
         <tr>
             <td><a href="<%=result[key].url%>"><%=key.replace(statusStr, "", "i")%></a></td>

--- a/macros/L10nStatusOverview.ejs
+++ b/macros/L10nStatusOverview.ejs
@@ -106,21 +106,19 @@ getPages(pageList);
                 totalPages += pageCounter;
                 totalTranslated += translationCounter;
                 totalUpToDate += updateCounter;
-
-                if (pageCounter === 0) {
-                    var translationPercent =  100;
-                    var uptodatePercent = 100;
-                } else {
-                     var translationPercent = Math.floor((translationCounter / pageCounter) * 100);
-                     var uptodatePercent = Math.floor((updateCounter / pageCounter) * 100);
+                
+                var translationPercent =  0;
+                var uptodatePercent = 0;
+                if (pageCounter !== 0) {
+                    translationPercent = Math.floor((translationCounter / pageCounter) * 100);
+                    uptodatePercent = Math.floor((updateCounter / pageCounter) * 100);
                 }
 
-                if (totalPages === 0) {
-                    var totalTranslatedPercent = 100;
-                    var totalUpToDatePercent = 100;
-                } else {
-                    var totalTranslatedPercent = Math.floor((totalTranslated / totalPages) * 100);
-                    var totalUpToDatePercent = Math.floor((totalUpToDate / totalPages) * 100);
+                var totalTranslatedPercent = 0;
+                var totalUpToDatePercent = 0;
+                if (totalPages !== 0) {
+                    totalTranslatedPercent = Math.floor((totalTranslated / totalPages) * 100);
+                    totalUpToDatePercent = Math.floor((totalUpToDate / totalPages) * 100);
                 }
     %>
         <tr>


### PR DESCRIPTION
In L10nStatusOverview tables, consider result is 100% when divisor is 0.
Also regularized indentation inside one of the for loop.

--

We could also consider result should be 0, matter of choice.