### PR TITLE
Correct Japanese translation in spec2.ejs

### DIFF
--- a/macros/spec2.ejs
+++ b/macros/spec2.ejs
@@ -109,7 +109,7 @@ var label = {
   }),
   'Obsolete' : mdn.localString({
       'en-US' : 'Obsolete',
-      'ja'    : '廃止された',
+      'ja'    : '廃止',
       'de'    : 'Veraltet',
       'ru'    : 'Устаревшая',
       'pt-BR' : 'Obsoleto'


### PR DESCRIPTION
廃止された is unnatural as a status. 廃止 is more preferred.