### PR TITLE
Better support L10n for slug

### DIFF
--- a/macros/HTMLElement.ejs
+++ b/macros/HTMLElement.ejs
@@ -8,35 +8,40 @@
   $1 - Text to display (optional)
   $2 - Anchor within the page (optional)
 */
+
 var elementName = $0.toString().toLowerCase();
 var linkText = ($1 || elementName);
-switch (env.locale) {
-    case 'ja':
-        if (elementName === linkText && elementName.indexOf(" 要素") !== -1){
-            elementName = linkText.replace(" 要素","");
-        }
-        break;
-    default: break;
+var hash = $2 || "";
+
+// Do special clean up for the displayed text and
+// element name in case they are both the same
+if (linkText === elementName) {
+    // Special case some Japanese specificities
+    if (env.locale === "ja" && elementName.indexOf(" 要素") !== -1) {
+        elementName = linkText.replace(" 要素","");
+    }
+
+    // In case we display the element name itself, we display it as code
+    if(elementName.indexOf(" ") === -1) {
+        linkText = "<code>&lt;" + linkText + "&gt;</code>";
+    }
 }
 
+// Get locale strings
 var commonLocalStrings = string.deserialize(template("L10n:Common"));
-var sectionName = mdn.localString({
-    "es": "Elemento",
-    "en-US": "Element"
-});
-var url = "/" + env.locale + "/docs/Web/HTML/" + sectionName + "/" +
-    elementName;
+var slug = string.deserialize(template("L10n:Slug"));
+
+// Set up element URL
+slug = mdn.getLocalString(slug, "docs/Web/HTML/Element")
+var url = "/" + [env.locale, slug, elementName].join("/");
+
+// Retrieve target page summary
 var page = wiki.getPage(url);
-var summary = (page && page.summary) ? mdn.escapeQuotes(page.summary) :
-    mdn.getLocalString(commonLocalStrings, "summary");
+var summary = mdn.getLocalString(commonLocalStrings, "summary");
 
-// Add anchor after fetching the page contents
-url += $2;
-
-if (linkText === elementName && elementName.indexOf(" ") === -1) {
-    linkText = "<code>&lt;" + linkText + "&gt;</code>";
+if (page && page.summary) {
+    summary = mdn.escapeQuotes(page.summary);
 }
 
-var link = "<a href=\"" + url + "\" title=\"" + summary + "\">" + linkText +
-    "</a>";
-%><%- link %>
+%>
+<a href="<%- url + hash %>" title="<%- summary %>"><%- linkText %></a>

--- a/macros/HTTPMethod.ejs
+++ b/macros/HTTPMethod.ejs
@@ -1,18 +1,36 @@
 <%
+// Insert a link to the specified HTTP method
+//
+// PARAMETERS
+//  $0 - The method to link
+//  $1 - An optional alternative text to display
+//  $2 - ?
+//  $3 - If set, do not put the text in <code></code>
 
-var lang = env.locale;
+// Set up input values
 var method = $0.toUpperCase(); // Methods are always uppercase
 var str = $1 || $0;
-var rtlLocales = ['ar', 'he', 'fa'];
-var localStrings = string.deserialize(template("L10n:Common"));
-var URL = "/" + lang + '/docs/Web/HTTP/Methods/' + method;
-var anch = '';
+var anch = "";
 
+/* What is this made for? What is the use case? */
 if ($2) {
   str = str + '.' + $2;
   anch = '#' + $2;
 }
 
+if (!$3) {
+  str = ['<code>', str, '</code>'].join("");
+}
+
+// Get L10n strings
+var localStrings = string.deserialize(template("L10n:Common"));
+var slug         = string.deserialize(template("L10n:Slug"));
+
+// Set up status URL
+slug = mdn.getLocalString(slug, "docs/Web/HTTP/Methods");
+var URL = "/" + [env.locale, slug, method].join("/");
+
+// Get target page summary
 var page = wiki.getPage(URL);
 var summary = "";
 
@@ -24,8 +42,4 @@ if (!$2) {
     }
 }
 
-var code = '';
-var endcode = '';
-if (!$3) { code = '<code>'; endcode = '</code>' }
-
-%><a href="<%- URL+anch %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>
+%><a href="<%- URL + anch %>" title="<%- summary %>"><%- str %></a>

--- a/macros/HTTPStatus.ejs
+++ b/macros/HTTPStatus.ejs
@@ -1,18 +1,36 @@
 <%
+// Insert a link to the specified HTTP code status
+//
+// PARAMETERS
+//  $0 - The code status to link
+//  $1 - An optional alternative text to display
+//  $2 - ?
+//  $3 - If set, do not put the text in <code></code>
 
-var lang = env.locale;
+// Set up input values
 var status = $0;
 var str = $1 || $0;
-var rtlLocales = ['ar', 'he', 'fa'];
-var localStrings = string.deserialize(template("L10n:Common"));
-var URL = "/" + lang + '/docs/Web/HTTP/Status/' + status;
-var anch = '';
+var anch = "";
 
+/* What is this made for? What is the use case? */
 if ($2) {
   str = str + '.' + $2;
   anch = '#' + $2;
 }
 
+if (!$3) {
+  str = ['<code>', str, '</code>'].join("");
+}
+
+// Get L10n strings
+var localStrings = string.deserialize(template("L10n:Common"));
+var slug         = string.deserialize(template("L10n:Slug"));
+
+// Set up status URL
+slug = mdn.getLocalString(slug, "docs/Web/HTTP/Status");
+var URL = "/" + [env.locale, slug, status].join("/");
+
+// Get target page summary
 var page = wiki.getPage(URL);
 var summary = "";
 
@@ -24,8 +42,4 @@ if (!$2) {
     }
 }
 
-var code = '';
-var endcode = '';
-if (!$3) { code = '<code>'; endcode = '</code>' }
-
-%><a href="<%- URL+anch %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>
+%><a href="<%- URL + anch %>" title="<%- summary %>"><%- str %></a>

--- a/macros/L10n-Slug.json
+++ b/macros/L10n-Slug.json
@@ -30,17 +30,17 @@
 
   "docs/Web/JavaScript/Reference": {
     "en-US": "docs/Web/JavaScript/Reference",
-    "es"   : "docs/Web/JavaScript/Referencia",
     "ca"   : "docs/Web/JavaScript/Referencia",
+    "es"   : "docs/Web/JavaScript/Referencia",
     "pl"   : "docs/Web/JavaScript/Referencje"
   },
 
-  "docs/Web/JavaScript/Global_Objects": {
-    "en-US": "docs/Web/JavaScript/Global_Objects",
-    "ca"   : "docs/Web/JavaScript/Objectes_globals",
-    "es"   : "docs/Web/JavaScript/Objetos_globales",
-    "fr"   : "docs/Web/JavaScript/Objets_globaux",
-    "pl"   : "docs/Web/JavaScript/Obiekty"
+  "docs/Web/JavaScript/Reference/Global_Objects": {
+    "en-US": "docs/Web/JavaScript/Reference/Global_Objects",
+    "ca"   : "docs/Web/JavaScript/Referencia/Objectes_globals",
+    "es"   : "docs/Web/JavaScript/Referencia/Objetos_globales",
+    "fr"   : "docs/Web/JavaScript/Reference/Objets_globaux",
+    "pl"   : "docs/Web/JavaScript/Referencje/Obiekty"
   },
 
   "docs/Web/SVG/Element": {

--- a/macros/L10n-Slug.json
+++ b/macros/L10n-Slug.json
@@ -1,7 +1,7 @@
 {
   "docs/Web/HTML/Element": {
     "en-US": "docs/Web/HTML/Element",
-    "es"   : "docs/Web/HTML/Elemento",
+    "es"   : "docs/Web/HTML/Elemento"
   },
 
   "docs/Web/HTML/Global_attributes": {
@@ -34,12 +34,12 @@
 
   "docs/Web/SVG/Element": {
     "en-US": "docs/Web/SVG/Element",
-    "es"   : "docs/Web/SVG/Elemento",
+    "es"   : "docs/Web/SVG/Elemento"
   },
 
   "docs/Web/SVG/Attribut": {
     "en-US": "docs/Web/SVG/Attribut",
     "fr"   : "docs/Web/SVG/Attributs",
-    "pt-PT": "docs/Web/SVG/Atributo",
+    "pt-PT": "docs/Web/SVG/Atributo"
   }
 }

--- a/macros/L10n-Slug.json
+++ b/macros/L10n-Slug.json
@@ -14,7 +14,18 @@
   },
 
   "docs/Web/HTTP/Headers": {
-    "en-US": "docs/Web/HTTP/Headers"
+    "en-US": "docs/Web/HTTP/Headers",
+    "ru"   : "docs/Web/HTTP/Заголовки",
+    "uk"   : "docs/Web/HTTP/Заголовки"
+  },
+
+  "docs/Web/HTTP/Methods": {
+    "en-US": "docs/Web/HTTP/Methods",
+    "fr"   : "docs/HTTP/Méthode"
+  },
+
+  "docs/Web/HTTP/Status": {
+    "en-US": "docs/Web/HTTP/Status"
   },
 
   "docs/Web/JavaScript/Reference": {

--- a/macros/L10n-Slug.json
+++ b/macros/L10n-Slug.json
@@ -1,0 +1,45 @@
+{
+  "docs/Web/HTML/Element": {
+    "en-US": "docs/Web/HTML/Element",
+    "es"   : "docs/Web/HTML/Elemento",
+  },
+
+  "docs/Web/HTML/Global_attributes": {
+    "en-US": "docs/Web/HTML/Global_attributes",
+    "es"   : "docs/Web/HTML/Atributos_Globales",
+    "fr"   : "docs/Web/HTML/Attributs_universels",
+    "pt-PT": "docs/Web/HTML/Atributos_globais",
+    "ru"   : "docs/Web/HTML/Общие_атрибуты",
+    "uk"   : "docs/Web/HTML/Загальні_атрибути"
+  },
+
+  "docs/Web/HTTP/Headers": {
+    "en-US": "docs/Web/HTTP/Headers"
+  },
+
+  "docs/Web/JavaScript/Reference": {
+    "en-US": "docs/Web/JavaScript/Reference",
+    "es"   : "docs/Web/JavaScript/Referencia",
+    "ca"   : "docs/Web/JavaScript/Referencia",
+    "pl"   : "docs/Web/JavaScript/Referencje"
+  },
+
+  "docs/Web/JavaScript/Global_Objects": {
+    "en-US": "docs/Web/JavaScript/Global_Objects",
+    "ca"   : "docs/Web/JavaScript/Objectes_globals",
+    "es"   : "docs/Web/JavaScript/Objetos_globales",
+    "fr"   : "docs/Web/JavaScript/Objets_globaux",
+    "pl"   : "docs/Web/JavaScript/Obiekty"
+  },
+
+  "docs/Web/SVG/Element": {
+    "en-US": "docs/Web/SVG/Element",
+    "es"   : "docs/Web/SVG/Elemento",
+  },
+
+  "docs/Web/SVG/Attribut": {
+    "en-US": "docs/Web/SVG/Attribut",
+    "fr"   : "docs/Web/SVG/Attributs",
+    "pt-PT": "docs/Web/SVG/Atributo",
+  }
+}

--- a/macros/SVGAttr.ejs
+++ b/macros/SVGAttr.ejs
@@ -1,12 +1,23 @@
 <%
-/* one parameter: attribute name */
-var slug = mdn.localString({
-    "en-US": "Attribute",
-    "de"   : "Attribut",
-    "fr"   : "Attributs",
-    "pl"   : "Atrybut"
-});
+//    Outputs a link to an SVG Attribut's reference page.
+//
+//    Parameters:
+//        $0  SVG attribut name
 
-var URL = "/" + env.locale + "/docs/Web/SVG/" + slug + "/" + $0;
+var attrName     = $0;
+var slug         = string.deserialize(template("L10n:Slug"));
+var localStrings = string.deserialize(template("L10n:Common"));
+
+slug = mdn.getLocalString(slug, "docs/Web/SVG/Attribut");
+
+var URL = "/" + [env.locale, slug, attrName].join("/");
+
+// Gather the page summary
+var page = wiki.getPage(URL);
+var summary = mdn.getLocalString(localStrings, "summary");
+
+if (page && page.summary) {
+    summary = mdn.escapeQuotes(page.summary);
+}
 %>
-<code><a href="<%- URL %>"><%= $0 %></a></code>
+<a href="<%- URL %>" <%- wiki.pageExists(URL) ? '' : ' class="new"' %> title="<%-summary%>"><code><%= attrName %></code></a>

--- a/macros/SVGElement.ejs
+++ b/macros/SVGElement.ejs
@@ -1,30 +1,24 @@
 <%
 //    Outputs a link to an SVG element's reference page.
-//    
+//
 //    Parameters:
 //        $0  SVG element name
 
-var slug = {
-    'en-US': "Element"
-};
-
-var URL = "/" + env.locale + "/docs/Web/SVG/" + mdn.localString(slug) + "/" + $0;
+var elementName  = $0;
+var slug         = string.deserialize(template("L10n:Slug"));
 var localStrings = string.deserialize(template("L10n:Common"));
 
-// Gather the page summary
+slug = mdn.getLocalString(slug, "docs/Web/SVG/Element");
 
-var term = $0;
+var URL = "/" + [env.locale, slug, elementName].join("/");
+
+// Gather the page summary
 var page = wiki.getPage(URL);
-var summary = "";
+var summary = mdn.getLocalString(localStrings, "summary");
+
 if (page && page.summary) {
     summary = mdn.escapeQuotes(page.summary);
-} else {
-    switch(env.locale) {
-        default:
-            summary = mdn.getLocalString(localStrings, "summary");
-            break;
-    }
 }
 
 %>
-<a href="<%- URL %>" <%- wiki.pageExists(URL) ? '' : ' class="new"' %> title="<%-summary%>"><code>&lt;<%= term %>&gt;</code></a>
+<a href="<%- URL %>" <%- wiki.pageExists(URL) ? '' : ' class="new"' %> title="<%-summary%>"><code>&lt;<%= elementName %>&gt;</code></a>

--- a/macros/htmlattrxref.ejs
+++ b/macros/htmlattrxref.ejs
@@ -10,28 +10,25 @@
 // If the element isn't specified, the link is made to the Global Attributes
 // page.
 
-var lang = env.locale;
-var url = "";
+var text = $2 || $0;
+var hash = "#attr-" + $0.toLowerCase();
+var elementName = $1 || "";
 
-var globalAttrSlug = mdn.localString({
-    "en-US": "Global_attributes",
-    "fr"   : "Attributs_universels"
-});
-
-
-$0 = $0.toLowerCase();
-
-var text = ($2 && ($2!=undefined))?$2:$0;
-
-if ($1 && ($1 != undefined)) {
-    url = '/' + lang + '/docs/Web/HTML/Element/' + $1;
-} else {
-    url = '/' + lang + '/docs/Web/HTML/' + globalAttrSlug;
+if (!$3) {
+  text = ['<code>', text, '</code>'].join('');
 }
 
-var code    = !$3 ? '<code>'  : '';
-var endcode = !$3 ? '</code>' : '';
+var slug = string.deserialize(template("L10n:Slug"));
 
-var result = code + '<a href="' + url + '#attr-' + $0 +'">' + text + '</a>'+ endcode;
+var slugElement   = mdn.getLocalString(slug, 'docs/Web/HTML/Element');
+var slugAttribute = mdn.getLocalString(slug, 'docs/Web/HTML/Global_attributes');
+
+
+var url = "/" + [env.locale, slugAttribute].join("/");
+
+if (elementName) {
+    url = "/" + [env.locale, slugElement, elementName].join("/");
+}
+
 %>
-<%- result %>
+<a href="<%- url + hash %>"><%- text %></a>

--- a/macros/httpheader.ejs
+++ b/macros/httpheader.ejs
@@ -1,18 +1,36 @@
 <%
+// Insert a link to the specified HTTP code status
+//
+// PARAMETERS
+//  $0 - The code status to link
+//  $1 - An optional alternative text to display
+//  $2 - ?
+//  $3 - If set, do not put the text in <code></code>
 
-var lang = env.locale;
+// Set up input values
 var header = $0;
 var str = $1 || $0;
-var rtlLocales = ['ar', 'he', 'fa'];
-var localStrings = string.deserialize(template("L10n:Common"));
-var URL = "/" + lang + '/docs/Web/HTTP/Headers/' + header;
-var anch = '';
+var anch = "";
 
+/* What is this made for? What is the use case? */
 if ($2) {
   str = str + '.' + $2;
   anch = '#' + $2;
 }
 
+if (!$3) {
+  str = ['<code>', str, '</code>'].join("");
+}
+
+// Get L10n strings
+var localStrings = string.deserialize(template("L10n:Common"));
+var slug         = string.deserialize(template("L10n:Slug"));
+
+// Set up status URL
+slug = mdn.getLocalString(slug, "docs/Web/HTTP/Headers");
+var URL = "/" + [env.locale, slug, header].join("/");
+
+// Get target page summary
 var page = wiki.getPage(URL);
 var summary = "";
 
@@ -24,8 +42,4 @@ if (!$2) {
     }
 }
 
-var code = '';
-var endcode = '';
-if (!$3) { code = '<code>'; endcode = '</code>' }
-
-%><a href="<%- URL+anch %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>
+%><a href="<%- URL + anch %>" title="<%- summary %>"><%- str %></a>

--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -14,45 +14,49 @@
 //  {{jsxref("Global_Objects/Date/getNumber", "Date.prototype.getNumber()")}}
 //
 
-var jsl10n = string.deserialize(template('L10n:JavaScript'));
-var commonl10n = string.deserialize(template('L10n:Common'));
 
-var l10n = {
-    refslug: mdn.getLocalString(jsl10n, 'slug_reference'),
-    slug: mdn.getLocalString(jsl10n, 'slug_global_objects'),
-    summary: mdn.getLocalString(commonl10n, 'summary'),
-};
-
+// Set up input parameters
 var str = $1 || $0;
-
-var URL = "/" + env.locale + "/docs/Web/JavaScript/" + l10n.refslug + '/';
-
-var api  = $0.replace('()', '').replace('.prototype.', '.');
-
-var page = wiki.getPage(URL + $0);
-var objectPage = wiki.getPage(URL + l10n.slug + '/' +  $0);
-
-if ((api.indexOf("..") === -1) && (api.indexOf(".") !== -1)) { // Handle try...catch case
-    URL += l10n.slug + '/' + api.replace('.', '/');
-} else if (!page.slug && objectPage.slug) {
-    URL += l10n.slug + '/' + $0;
-} else {
-    URL += $0;
-}
-
-var summary = l10n.summary;
-page = wiki.getPage(URL);
-
-if (page && page.summary) {
-    summary = mdn.escapeQuotes(page.summary);
-}
-
+var api = $0.replace('()', '').replace('.prototype.', '.').replace('.', '/');
 var anchor = $2 || '';
-if (anchor && anchor[0] != '#') {
+
+if (anchor && anchor[0] !== '#') {
     anchor = "#" + anchor;
 }
 
-var code    = !$3 ? '<code>'  : '';
-var endcode = !$3 ? '</code>' : '';
+if (!$3) {
+  str = ['<code>', str, '</code>'].join('');
+}
 
-%><a href="<%- URL + anchor %>" title="<%-summary%>"><%- code %><%- str %><%- endcode %></a>
+// Get L10n strings
+var commonl10n = string.deserialize(template('L10n:Common'));
+var slug = string.deserialize(template('L10n:Slug'));
+
+var l10n = {
+    refslug: mdn.getLocalString(slug, 'docs/Web/JavaScript/Reference'),
+    objslug: mdn.getLocalString(slug, 'docs/Web/JavaScript/Reference/Global_Objects'),
+    summary: mdn.getLocalString(commonl10n, 'summary'),
+};
+
+// Set up document URL
+var URL_REF = "/" + [env.locale, l10n.refslug, api].join('/');
+var URL_OBJ = "/" + [env.locale, l10n.objslug, api].join('/');
+var URL = URL_REF;
+
+// Get target page summary
+var page       = wiki.getPage(URL_REF);
+var objectPage = wiki.getPage(URL_OBJ);
+
+var summary = l10n.summary;
+
+// If we get a Reference page we're good
+if (page && page.summary && page.slug) {
+    summary = mdn.escapeQuotes(page.summary);
+
+// Otherwise we look if we have a global object page
+} else if (objectPage && objectPage.summary) {
+    summary = mdn.escapeQuotes(objectPage.summary);
+    URL = URL_OBJ; // Change the target URL as it is a Global Object page
+}
+
+%><a href="<%- URL + anchor %>" title="<%- summary %>"><%- str %></a>

--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -17,8 +17,12 @@
 
 // Set up input parameters
 var str = $1 || $0;
-var api = $0.replace('()', '').replace('.prototype.', '.').replace('.', '/');
+var api = $0.replace('()', '').replace('.prototype.', '.')//.replace('.', '/');
 var anchor = $2 || '';
+
+if ((api.indexOf("..") === -1) && (api.indexOf(".") !== -1)) { // Handle try...catch case
+  api = api.replace('.', '/');
+}
 
 if (anchor && anchor[0] !== '#') {
     anchor = "#" + anchor;
@@ -41,7 +45,7 @@ var l10n = {
 // Set up document URL
 var URL_REF = "/" + [env.locale, l10n.refslug, api].join('/');
 var URL_OBJ = "/" + [env.locale, l10n.objslug, api].join('/');
-var URL = URL_REF;
+var URL = URL_OBJ; // By default we expect a global object url
 
 // Get target page summary
 var page       = wiki.getPage(URL_REF);
@@ -49,14 +53,14 @@ var objectPage = wiki.getPage(URL_OBJ);
 
 var summary = l10n.summary;
 
-// If we get a Reference page we're good
-if (page && page.summary && page.slug) {
-    summary = mdn.escapeQuotes(page.summary);
-
-// Otherwise we look if we have a global object page
-} else if (objectPage && objectPage.summary) {
+// If we get a global object page we're good
+if (objectPage && objectPage.summary) {
     summary = mdn.escapeQuotes(objectPage.summary);
-    URL = URL_OBJ; // Change the target URL as it is a Global Object page
+
+// Otherwise we look if we have another reference page
+} else if (page && page.summary) {
+    summary = mdn.escapeQuotes(page.summary);
+    URL = URL_REF;
 }
 
-%><a href="<%- URL + anchor %>" title="<%- summary %>"><%- str %></a>
+%><a href="<%- URL + anchor %>" title="<%-summary%>"><%- str %></a>

--- a/macros/jsxref.ejs
+++ b/macros/jsxref.ejs
@@ -17,10 +17,10 @@
 
 // Set up input parameters
 var str = $1 || $0;
-var api = $0.replace('()', '').replace('.prototype.', '.')//.replace('.', '/');
+var api = $0.replace('()', '').replace('.prototype.', '.');
 var anchor = $2 || '';
 
-if ((api.indexOf("..") === -1) && (api.indexOf(".") !== -1)) { // Handle try...catch case
+if (api.indexOf("..") === -1) { // Handle try...catch, for...in, etc.
   api = api.replace('.', '/');
 }
 


### PR DESCRIPTION
Hi!

This pull request is a proposal to have a dedicated, centralized, and simpler way to handle the localization of URL slugs.

It introduce the new L10n-slug.json file that will get our L10n URL slugs: It make things easier to localize but it also make easier any future change in our URL schema (if any) by centralizing the information around slugs.

I also updated/modernize a set of core macro to demonstrate how efficient it can be. The macro I updated are the following:

* htmlattrxref
* HTMLElement
* HTTPStatus
* HTTPMethod
* HTTPHeader
* jsxref
* SVGElement
* SVGAttr