### PR TITLE
Fix ES8/ES2017 Links in SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -646,7 +646,7 @@
   },
   "ES2017": {
     "name": "ECMAScript 2017 (ECMA-262)",
-    "url": "https://tc39.github.io/ecma262/2017/",
+    "url": "https://www.ecma-international.org/ecma-262/8.0/",
     "status": "Standard"
   },
   "ESDraft": {


### PR DESCRIPTION
Issue:
https://discourse.mozilla.org/t/wrong-links-in-es8-varibales/27547/2

Fix wrong spec link.