### PR TITLE
adding new existing c to wasm article to webassembly sidebar

### DIFF
--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -8,6 +8,7 @@ var text = mdn.localStringMap({
     'Tutorials' : 'Tutorials',
       'WebAssembly_concepts' : 'WebAssembly concepts',
       'Compiling_to_wasm' : 'Compiling from C/C++ to WebAssembly',
+      'Existing_C_to_wasm' : 'Compiling an Existing C Module to WebAssembly'
       'JavaScript_API' : 'Using the WebAssembly JavaScript API',
       'Text_format' : 'Understanding WebAssembly text format',
       'Text_format_to_wasm' : 'Converting WebAssembly text format to wasm',
@@ -27,6 +28,7 @@ var text = mdn.localStringMap({
     <ol>
       <li><a href="<%=baseURL%>/Concepts"><%=text['WebAssembly_concepts']%></a></li>
       <li><a href="<%=baseURL%>/C_to_wasm"><%=text['Compiling_to_wasm']%></a></li>
+      <li><a href="<%=baseURL%>/existing_C_to_wasm"><%=text['Existing_C_to_wasm']%></a></li>
       <li><a href="<%=baseURL%>/Using_the_JavaScript_API"><%=text['JavaScript_API']%></a></li>
       <li><a href="<%=baseURL%>/Understanding_the_text_format"><%=text['Text_format']%></a></li>
       <li><a href="<%=baseURL%>/Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>

--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -8,7 +8,7 @@ var text = mdn.localStringMap({
     'Tutorials' : 'Tutorials',
       'WebAssembly_concepts' : 'WebAssembly concepts',
       'Compiling_to_wasm' : 'Compiling from C/C++ to WebAssembly',
-      'Existing_C_to_wasm' : 'Compiling an Existing C Module to WebAssembly'
+      'Existing_C_to_wasm' : 'Compiling an Existing C Module to WebAssembly',
       'JavaScript_API' : 'Using the WebAssembly JavaScript API',
       'Text_format' : 'Understanding WebAssembly text format',
       'Text_format_to_wasm' : 'Converting WebAssembly text format to wasm',


### PR DESCRIPTION
Nice article, added by the google folks: https://developer.mozilla.org/en-US/docs/WebAssembly/existing_C_to_wasm