### PR TITLE
removing web components overview subproperty, as the generated link...

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1842,7 +1842,6 @@
             "events":     []
         },
         "Web Components": {
-            "overview":     [ "Web Components" ],
             "guides":       [
                               { "url":   "/docs/Web/Web_Components/Using_custom_elements",
                                 "title": "Using custom elements" },


### PR DESCRIPTION
doesn't work.

As reported in https://bugzilla.mozilla.org/show_bug.cgi?id=1457502

This is right — when you generate an API sidebar, the overview link is constructed by taking the overview property and putting that string on the end of docs/Web/API. But web components is inside docs/Web/Web_components.

Because I don't have time to fix this properly right now, I am electing for just removing the broken link from the sidebar for now.