### PR TITLE
Bug 1387454 - Add AudioContext options

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1796,6 +1796,7 @@
                             "AudioBuffer",
                             "AudioBufferSourceNode",
                             "AudioContext",
+                            "AudioContextOptions",
                             "AudioDestinationNode",
                             "AudioListener",
                             "AudioNode",


### PR DESCRIPTION
Adds the AudioContextOptions dictionary to the interfaces
list for Web Audio API. This is still our only way to
include these in the sidebar, so here it is.