### PR TITLE
Remove 'HTML' macro

### DIFF
--- a/macros/HTML.ejs
+++ b/macros/HTML.ejs
@@ -1,1 +1,0 @@
-<%- template('Template:HTML:Element_Navigation', arguments) %>


### PR DESCRIPTION
This macro is broken, since it calls a nonexistent macro. It didn't show an error in the pages that included it, because KS throws away errors when a macro calls another macro. Bu removing this macro would then trigger errors.

So I've gone through the pages that called it replacing it with `{{htmlelement}}` which seems to be the correct one to use, and there are now no instances of this macro listed in https://developer.mozilla.org/en-US/dashboards/macros.