### PR TITLE
bug 1470589: fix CurrentGecko macro

### DIFF
--- a/macros/CurrentGecko.ejs
+++ b/macros/CurrentGecko.ejs
@@ -22,8 +22,6 @@ var channel = $0 || "release";
 channel = channel.toLowerCase();
 
 var versionID;
-var bumpToNightly = false;          // Set to true if we're pulling aurora version but need to increment it
-                                    // since nightly version isn't explicitly listed in the file
 
 switch(channel) {
     case 'release':
@@ -34,7 +32,8 @@ switch(channel) {
         break;
     case 'nightly':
     case 'central':
-        bumpToNightly = true;       // Flag that we'll need to increment, then fall through...
+        versionID = "FIREFOX_NIGHTLY";
+        break;
     case 'aurora':
         versionID = "FIREFOX_AURORA";
         break;
@@ -45,7 +44,7 @@ switch(channel) {
 
 // The URL to pull from
 
-var url = "http://svn.mozilla.org/libs/product-details/json/firefox_versions.json";
+var url = "https://product-details.mozilla.org/1.0/firefox_versions.json";
 
 // Fetch the versions JSON file from MXR.
 
@@ -54,12 +53,6 @@ var versionInfo = mdn.fetchJSONResource(url);
 // We now have a JSON object with the version information, so peel out the value we need
 
 var version = versionInfo[versionID];
-
-if (bumpToNightly) {
-    var major = parseInt(version, 10);  // Get major version number
-    major++;
-    version = major + version.slice(major.toString().length);
-}
 
 // Finally, remove the cruft at the end; we don't need beta numbers etc.
 

--- a/macros/CurrentGecko.ejs
+++ b/macros/CurrentGecko.ejs
@@ -28,18 +28,18 @@ switch(channel) {
         versionID = "LATEST_FIREFOX_VERSION";
         break;
     case 'beta':
+    case 'aurora':
         versionID = "LATEST_FIREFOX_DEVEL_VERSION";
         break;
     case 'nightly':
     case 'central':
         versionID = "FIREFOX_NIGHTLY";
         break;
-    case 'aurora':
-        versionID = "FIREFOX_AURORA";
-        break;
     case 'esr':
         versionID = "FIREFOX_ESR";
         break;
+    default:
+        return 'undefined';
 }
 
 // The URL to pull from

--- a/tests/macros/test-CurrentGecko.js
+++ b/tests/macros/test-CurrentGecko.js
@@ -1,0 +1,57 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    sinon = require('sinon'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro,
+    beforeEachMacro = utils.beforeEachMacro;
+
+const ffURL = 'https://product-details.mozilla.org/1.0/firefox_versions.json';
+
+// Let's add "eventually" to assert so we can work with promises.
+chai.use(chaiAsPromised);
+
+describeMacro('CurrentGecko', function () {
+    beforeEachMacro(function (macro) {
+        // Create a test fixture to mock the mdn.fetchJSONResource function.
+        const fetch_stub = sinon.stub();
+        fetch_stub.withArgs(ffURL).returns(
+            {
+                'FIREFOX_NIGHTLY': '65.0a1',
+                'FIREFOX_AURORA': '49',
+                'FIREFOX_ESR': '52.8.1esr',
+                'FIREFOX_ESR_NEXT': '60.0.2esr',
+                'LATEST_FIREFOX_DEVEL_VERSION': '61.0b14',
+                'FIREFOX_DEVEDITION': '64.0b2',
+                'LATEST_FIREFOX_OLDER_VERSION': '3.6.28',
+                'LATEST_FIREFOX_RELEASED_DEVEL_VERSION': '63.0b14',
+                'LATEST_FIREFOX_VERSION': '62.0.2'
+            }
+        );
+        macro.ctx.mdn.fetchJSONResource = fetch_stub;
+    });
+    itMacro('No arguments (release)', function (macro) {
+        return assert.eventually.equal(macro.call(), '62.0.2');
+    });
+    itMacro('Release', function (macro) {
+        return assert.eventually.equal(macro.call('Release'), '62.0.2');
+    });
+    itMacro('Beta', function (macro) {
+        return assert.eventually.equal(macro.call('beta'), '61');
+    });
+    itMacro('Nightly', function (macro) {
+        return assert.eventually.equal(macro.call('nighTLY'), '65');
+    });
+    itMacro('Central', function (macro) {
+        return assert.eventually.equal(macro.call('CENtral'), '65');
+    });
+    itMacro('Aurora', function (macro) {
+        return assert.eventually.equal(macro.call('aurora'), '49');
+    });
+    itMacro('ESR', function (macro) {
+        return assert.eventually.equal(macro.call('ESR'), '52.8.1');
+    });
+});

--- a/tests/macros/test-CurrentGecko.js
+++ b/tests/macros/test-CurrentGecko.js
@@ -1,15 +1,14 @@
 /* jshint node: true, mocha: true, esversion: 6 */
 
-var utils = require('./utils'),
-    chai = require('chai'),
-    chaiAsPromised = require('chai-as-promised'),
-    sinon = require('sinon'),
-    assert = chai.assert,
-    itMacro = utils.itMacro,
-    describeMacro = utils.describeMacro,
-    beforeEachMacro = utils.beforeEachMacro;
-
-const ffURL = 'https://product-details.mozilla.org/1.0/firefox_versions.json';
+const utils = require('./utils'),
+      chai = require('chai'),
+      chaiAsPromised = require('chai-as-promised'),
+      sinon = require('sinon'),
+      assert = chai.assert,
+      itMacro = utils.itMacro,
+      describeMacro = utils.describeMacro,
+      beforeEachMacro = utils.beforeEachMacro,
+      ffURL = 'https://product-details.mozilla.org/1.0/firefox_versions.json';
 
 // Let's add "eventually" to assert so we can work with promises.
 chai.use(chaiAsPromised);
@@ -21,7 +20,7 @@ describeMacro('CurrentGecko', function () {
         fetch_stub.withArgs(ffURL).returns(
             {
                 'FIREFOX_NIGHTLY': '65.0a1',
-                'FIREFOX_AURORA': '49',
+                'FIREFOX_AURORA': '',
                 'FIREFOX_ESR': '52.8.1esr',
                 'FIREFOX_ESR_NEXT': '60.0.2esr',
                 'LATEST_FIREFOX_DEVEL_VERSION': '61.0b14',
@@ -49,9 +48,12 @@ describeMacro('CurrentGecko', function () {
         return assert.eventually.equal(macro.call('CENtral'), '65');
     });
     itMacro('Aurora', function (macro) {
-        return assert.eventually.equal(macro.call('aurora'), '49');
+        return assert.eventually.equal(macro.call('aurora'), '61');
     });
     itMacro('ESR', function (macro) {
         return assert.eventually.equal(macro.call('ESR'), '52.8.1');
+    });
+    itMacro('nonsense', function (macro) {
+        return assert.eventually.equal(macro.call('nonsense'), 'undefined');
     });
 });


### PR DESCRIPTION
This PR fixes a bug in the `CurrentGecko` macro.
- stop using the stale URL (http://svn.mozilla.org/libs/product-details/json/firefox_versions.json) to get Firefox versions (it never responds, so requests eventually timeout)
- the new URL (https://product-details.mozilla.org/1.0/firefox_versions.json) supports "nightly" explicitly (so remove `bumpToNightly` code)
- add tests

Thanks to @jgmize for pointing me to the new URL!