### PR TITLE
Add quicklinks sidebar for the Games zone

### DIFF
--- a/macros/GamesSidebar.ejs
+++ b/macros/GamesSidebar.ejs
@@ -1,0 +1,149 @@
+<%
+
+const locale = env.locale;
+
+const baseURL = `/${locale}/docs/Games/`;
+const webURL = `/${locale}/docs/Web/`;
+const appsURL = `/${locale}/docs/Web/Apps/`;
+
+const text = mdn.localStringMap({
+  "en-US": {
+    "Introduction": "Introduction",
+      "Anatomy": "Anatomy",
+      "Examples": "Examples",
+    "APIs_for_game_development": "APIs for game development",
+      "Canvas": "Canvas",
+      "CSS": "CSS",
+      "Full_Screen": "Full screen",
+      "Gamepad": "Gamepad",
+      "IndexedDB": "IndexedDB",
+      "JavaScript": "JavaScript",
+      "Pointer_Lock": "Pointer Lock",
+      "SVG": "SVG",
+      "Typed_Arrays": "TypedArray",
+      "Web_Audio": "Web Audio",
+      "WebGL": "WebGL",
+      "WebRTC": "WebRTC",
+      "Web_Sockets": "WebSockets",
+      "WebVR": "WebVR",
+      "Web_Workers": "Web Workers",
+      "XMLHttpRequest": "XMLHttpRequest",
+    "Basic_Techniques": "Basic Techniques",
+      "Using_async_scripts_for_asm.js": "Using async scripts for asm.js",
+      "Optimizing_startup_performance": "Optimizing startup performance",
+      "Using_WebRTC_peer-to-peer_data_channels": "Using WebRTC peer-to-peer data channels",
+      "Efficient_animation_for_web_games": "Efficient animation for web games",
+      "Audio_for_Web_Games": "Audio for Web Games",
+      "2D_collision_detection": "2D collision detection",
+      "Tiles_and_tilemaps_overview": "Tiles and tilemaps overview",
+    "3D_games_on_the_Web": "3D games on the Web",
+      "3D_games_on_the_Web_overview": "3D games on the Web overview",
+      "Explaining_basic_3D_theory": "Explaining basic 3D theory",
+      "Building_up_a_basic_demo_with_A-Frame": "Building up a basic demo with A-Frame",
+      "Building_up_a_basic_demo_with_Babylon.js": "Building up a basic demo with Babylon.js",
+      "Building_up_a_basic_demo_with_PlayCanvas": "Building up a basic demo with PlayCanvas",
+      "Building_up_a_basic_demo_with_Three.js": "Building up a basic demo with Three.js",
+      "WebVR": "WebVR",
+      "3D_collision_detection": "3D collision detection",
+      "Bounding_volume_collision_detection_with_THREE.js": "Bounding volume collision detection with THREE.js",
+    "Implementing_game_control_mechanisms": "Implementing game control mechanisms",
+      "Control_mechanisms": "Control mechanisms",
+      "Mobile_touch": "Mobile touch",
+      "Desktop_with_mouse_and_keyboard": "Desktop with mouse and keyboard",
+      "Desktop_with_gamepad": "Desktop with gamepad",
+      "Other": "Other",
+    "Tutorials": "Tutorials",
+      "2D_breakout_game_using_pure_JavaScript": "2D breakout game using pure JavaScript",
+      "2D_breakout_game_using_Phaser": "2D breakout game using Phaser",
+      "2D_maze_game_with_device_orientation": "2D maze_game with device orientation",
+      "2D_platform_game_using_Phaser": "2D platform game using Phaser",
+    "Publishing_games": "Publishing games",
+      "Publishing_games_overview": "Publishing games overview",
+      "Game_distribution": "Game distribution",
+      "Game_promotion": "Game promotion",
+      "Game_monetization": "Game monetization"
+  }
+});
+
+%>
+
+<section class="Quick_links" id="Quick_Links">
+  <ol>
+    <li><a href="#"><%=text["Introduction"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Introduction"><%=text["Introduction"]%></a></li>
+        <li><a href="<%=baseURL%>Anatomy"><%=text["Anatomy"]%></a></li>
+        <li><a href="<%=baseURL%>Examples"><%=text["Examples"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["APIs_for_game_development"]%></a>
+      <ol>
+        <li><a href="<%=webURL%>API/Canvas_API"><%=text["Canvas"]%></a></li>
+        <li><a href="<%=webURL%>CSS"><%=text["CSS"]%></a></li>
+        <li><a href="<%=appsURL%>Fundamentals/User_notifications/Full_screen_api"><%=text["Full_Screen"]%></a></li>
+        <li><a href="<%=webURL%>API/Gamepad_API"><%=text["Gamepad"]%></a></li>
+        <li><a href="<%=webURL%>API/IndexedDB_API"><%=text["IndexedDB"]%></a></li>
+        <li><a href="<%=webURL%>JavaScript"><%=text["JavaScript"]%></a></li>
+        <li><a href="<%=webURL%>API/Pointer_Lock_API"><%=text["Pointer_Lock"]%></a></li>
+        <li><a href="<%=webURL%>SVG"><%=text["SVG"]%></a></li>
+        <li><a href="<%=webURL%>JavaScript/Reference/Global_Objects/TypedArray"><%=text["Typed_Arrays"]%></a></li>
+        <li><a href="<%=webURL%>API/Web_Audio_API"><%=text["Web_Audio"]%></a></li>
+        <li><a href="<%=webURL%>API/WebGL_API"><%=text["WebGL"]%></a></li>
+        <li><a href="<%=webURL%>API/WebRTC_API"><%=text["WebRTC"]%></a></li>
+        <li><a href="<%=webURL%>API/WebSockets_API"><%=text["Web_Sockets"]%></a></li>
+        <li><a href="<%=webURL%>API/WebVR_API"><%=text["WebVR"]%></a></li>
+        <li><a href="<%=webURL%>API/Web_Workers_API"><%=text["Web_Workers"]%></a></li>
+        <li><a href="<%=webURL%>API/XMLHttpRequest"><%=text["XMLHttpRequest"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["Basic_Techniques"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Techniques/Async_scripts"><%=text["Using_async_scripts_for_asm.js"]%></a></li>
+        <li><a href="<%=appsURL%>Developing/Optimizing_startup_performance"><%=text["Optimizing_startup_performance"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/WebRTC_data_channels"><%=text["Using_WebRTC_peer-to-peer_data_channels"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Efficient_animation_for_web_games"><%=text["Efficient_animation_for_web_games"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Audio_for_Web_Games"><%=text["Audio_for_Web_Games"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/2D_collision_detection"><%=text["2D_collision_detection"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Tilemaps"><%=text["Tiles_and_tilemaps_overview"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["3D_games_on_the_Web"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web"><%=text["3D_games_on_the_Web_overview"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/Basic_theory"><%=text["Explaining_basic_3D_theory"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/Building_up_a_basic_demo_with_A-Frame"><%=text["Building_up_a_basic_demo_with_A-Frame"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Babylon.js"><%=text["Building_up_a_basic_demo_with_Babylon.js"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas"><%=text["Building_up_a_basic_demo_with_PlayCanvas"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js"><%=text["Building_up_a_basic_demo_with_Three.js"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_on_the_web/WebVR"><%=text["WebVR"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_collision_detection"><%=text["3D_collision_detection"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/3D_collision_detection/Bounding_volume_collision_detection_with_THREE.js"><%=text["Bounding_volume_collision_detection_with_THREE.js"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["Implementing_game_control_mechanisms"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Techniques/Control_mechanisms"><%=text["Control_mechanisms"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Control_mechanisms/Mobile_touch"><%=text["Mobile_touch"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard"><%=text["Desktop_with_mouse_and_keyboard"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Control_mechanisms/Desktop_with_gamepad"><%=text["Desktop_with_gamepad"]%></a></li>
+        <li><a href="<%=baseURL%>Techniques/Control_mechanisms/Other"><%=text["Other"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["Tutorials"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Tutorials/2D_Breakout_game_pure_JavaScript"><%=text["2D_breakout_game_using_pure_JavaScript"]%></a></li>
+        <li><a href="<%=baseURL%>Tutorials/2D_breakout_game_Phaser"><%=text["2D_breakout_game_using_Phaser"]%></a></li>
+        <li><a href="<%=baseURL%>Tutorials/HTML5_Gamedev_Phaser_Device_Orientation"><%=text["2D_maze_game_with_device_orientation"]%></a></li>
+        <li><a href="https://mozdevs.github.io/html5-games-workshop/en/guides/platformer/start-here/"><%=text["2D_platform_game_using_Phaser"]%></a></li>
+      </ol>
+    </li>
+    <li><a href="#"><%=text["Publishing_games"]%></a>
+      <ol>
+        <li><a href="<%=baseURL%>Publishing_games"><%=text["Publishing_games_overview"]%></a></li>
+        <li><a href="<%=baseURL%>Publishing_games/Game_distribution"><%=text["Game_distribution"]%></a></li>
+        <li><a href="<%=baseURL%>Publishing_games/Game_promotion"><%=text["Game_promotion"]%></a></li>
+        <li><a href="<%=baseURL%>Publishing_games/Game_monetization"><%=text["Game_monetization"]%></a></li>
+      </ol>
+    </li>
+  </ol>
+</section>


### PR DESCRIPTION
This is part of the zone removal work.

It's not ready to merge because it only has the en-US version, and it has no tests. But I'd like feedback on whether this is a sane organization of the sidebar.

I've been pretty conservative but have changed things a bit because quicklinks sidebars can't do multiple levels of indentation.

In particular I've changed the "Techniques" section, renaming it "Basic techniques" and splitting out the 3D games and games controls bits into their own sections. (tbh that section in the existing Games sidebar is a bit of a mess anyway)
