### PR TITLE
Removing duplicate Introducing JavaScript objects menu entry

### DIFF
--- a/macros/JsSidebar.ejs
+++ b/macros/JsSidebar.ejs
@@ -34,8 +34,8 @@ var text = mdn.localStringMap({
     'Basics': 'JavaScript basics',
     'First_steps': 'JavaScript first steps',
     'Building_blocks': 'JavaScript building blocks',
-    'Intermediate': 'Intermediate',
     'Introducing_objects': 'Introducing JavaScript objects',
+    'Intermediate': 'Intermediate',
     'Client-side_APIs': 'Client-side web APIs',
     'Re-introduction': 'A re-introduction to JavaScript',
     'Data_structures': 'JavaScript data structures',
@@ -430,7 +430,6 @@ var text = mdn.localStringMap({
   </li>
   <li data-default-state="<%=state('Intermediate')%>"><a href="#"><%=text['Intermediate']%></a>
    <ol>
-    <li><a href="/<%=locale%>/docs/Learn/JavaScript/Objects"><%=text['Introducing_objects']%></a></li>
     <li><a href="/<%=locale%>/docs/Learn/JavaScript/Client-side_web_APIs"><%=text['Client-side_APIs']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/A_re-introduction_to_JavaScript"><%=text['Re-introduction']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/Data_structures"><%=text['Data_structures']%></a></li>


### PR DESCRIPTION
In the main JavaScript sidebar (e.g. see https://developer.mozilla.org/en-US/docs/Web/JavaScript), the "Introducing JavaScript Objects" article appears twice, one below "Complete beginners" and once below "Intermediate". This PR removes the latter.