### PR TITLE
Update the URL of Web Speech API

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1461,7 +1461,7 @@
   },
   "Web Speech API": {
     "name": "Web Speech API",
-    "url": "https://dvcs.w3.org/hg/speech-api/raw-file/tip/webspeechapi.html",
+    "url": "https://w3c.github.io/speech-api/",
     "status": "Draft"
   },
   "Web Telephony": {


### PR DESCRIPTION
The spec is now in https://github.com/w3c/speech-api.