### PR TITLE
Fix typo, MDNN -> MDN

### DIFF
--- a/macros/MDNSidebar.ejs
+++ b/macros/MDNSidebar.ejs
@@ -314,7 +314,7 @@ const text = mdn.localStringMap({
       "MDN_guide_for_readers": "MDN guide for readers",
       "Promote_MDN": "Promover a MDN",
       "Send_feedback_about_MDN": "Enviar feedback sobre a MDN",
-    "Get_started_on_MDN": "Primeiros passos na MDNN",
+    "Get_started_on_MDN": "Primeiros passos na MDN",
     "Help_improve_MDN": "Ajudar a melhorar a MDN",
       "Things_you_can_do": "O que pode fazer",
       "Localizing_MDN": "Localizando a MDN",


### PR DESCRIPTION
Fix a typo in the pt-BR localizations for the MDN sidebar.