### PR TITLE
Tweak column sizes for WebExt examples table; add tests

### DIFF
--- a/macros/WebExtAllExamples.ejs
+++ b/macros/WebExtAllExamples.ejs
@@ -46,7 +46,7 @@ function writeAllExamples(examples) {
   output += `<tr>
                <th>${s_name}</th>
                <th>${s_desc}</th>
-               <th>${s_javascript_apis}</th>
+               <th style=\"width: 40%\">${s_javascript_apis}</th>
             </tr>`;
 
   for (let example of examples) {

--- a/tests/macros/test-webextallexamples.js
+++ b/tests/macros/test-webextallexamples.js
@@ -39,10 +39,10 @@ const testExamplesJson = [
         'name': 'example-one'
     },
     {
-        'description': 'An example WebExtension.',
+        'description': 'Another example WebExtension.',
         'javascript_apis': [
         ],
-        'name': 'example-one'
+        'name': 'example-two'
     }
 ];
 

--- a/tests/macros/test-webextallexamples.js
+++ b/tests/macros/test-webextallexamples.js
@@ -1,0 +1,122 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+const utils = require('./utils'),
+      sinon = require('sinon'),
+      chai = require('chai'),
+      jsdom = require('jsdom'),
+      assert = chai.assert,
+      itMacro = utils.itMacro,
+      beforeEachMacro = utils.beforeEachMacro,
+      describeMacro = utils.describeMacro;
+
+/*
+Locales dictionary is included for completeness,
+although this macro isn't localized yet.
+*/
+const locales = {
+  'en-US': {
+    'Description': 'Description',
+    'Name': 'Name',
+    'JavaScript_APIs': 'JavaScript APIs'
+  },
+  'fr': {
+    'Description': 'Description',
+    'Name': 'Name',
+    'JavaScript_APIs': 'JavaScript APIs'
+  }
+};
+
+const testExamplesJson = [
+    {
+        'description': 'An example WebExtension.',
+        'javascript_apis': [
+            'storage.local',
+            'tabs.onActivated',
+            'tabs.onUpdated',
+            'tabs.query',
+            'windows.getCurrent'
+        ],
+        'name': 'example-one'
+    },
+    {
+        'description': 'An example WebExtension.',
+        'javascript_apis': [
+        ],
+        'name': 'example-one'
+    }
+];
+
+const expectedExtensionBaseUrl = 'https://github.com/mdn/webextensions-examples/tree/master/';
+const expectedJsApiBaseUrl = '/Add-ons/WebExtensions/API/';
+
+function checkTableDom(dom, locale) {
+
+  // 1. check the table headers
+  let tableHeaders = dom.querySelectorAll('th');
+  assert.equal(tableHeaders.length, 3, 'Incorrect number of <th> elements');
+  // 1.1 name header
+  let nameHeader = tableHeaders[0];
+  assert.equal(nameHeader.textContent, locales[locale].Name, 'Incorrect name for Name table header');
+  // 1.2 description header
+  let descHeader = tableHeaders[1];
+  assert.equal(descHeader.textContent, locales[locale].Description, 'Incorrect name for Description table header');
+  // 1.3 JS APIs header
+  let jsAPIHeader = tableHeaders[2];
+  assert.equal(jsAPIHeader.textContent, locales[locale].JavaScript_APIs, 'Incorrect name for JS API table header');
+  assert.equal(jsAPIHeader.style.width, '40%', 'Incorrect or missing style for JS API table header');
+
+  let tableRows = dom.querySelectorAll('tr');
+  assert.equal(tableRows.length, 3, 'Incorrect number of <tr> elements');
+
+  // 2. check the first row
+  let row1Cells = tableRows[1].querySelectorAll('td');
+  assert.equal(row1Cells.length, 3, 'Incorrect number of <td> elements');
+
+  // 2.1 name cell
+  let name1 = row1Cells[0];
+  assert.equal(name1.textContent, 'example-one', 'Incorrect name for example 1');
+  let extensionLink = name1.querySelector('a');
+  assert.equal(extensionLink.href, `${expectedExtensionBaseUrl}example-one`, 'Incorrect link for example 1');
+
+  // 2.2 description cell
+  let description1 = row1Cells[1];
+  assert.equal(description1.textContent, 'An example WebExtension.', 'Incorrect description for example 1');
+
+  // 2.3 js APIs cell
+  let jsAPIs1 = row1Cells[2];
+  let jsAPIsLinks1 = jsAPIs1.querySelectorAll('a');
+  assert.equal(jsAPIsLinks1.length, 5, 'Incorrect number of API links for example 1');
+  assert.equal(jsAPIsLinks1[0].href, `/${locale}${expectedJsApiBaseUrl}storage/local`, 'Incorrect link for JS API');
+
+  // 3. check that the second example has an empty JS API cell
+  let row2Cells = tableRows[2].querySelectorAll('td');
+  let jsAPIs2 = row2Cells[2];
+  let jsAPIsLinks2 = jsAPIs2.querySelectorAll('a');
+  assert.equal(jsAPIsLinks2.length, 0, 'Incorrect number of API links for example 2');
+}
+
+describeMacro('WebExtAllExamples', function () {
+
+    beforeEachMacro(function (macro) {
+        macro.ctx.mdn.fetchJSONResource = sinon.stub();
+        macro.ctx.mdn.fetchJSONResource.returns(testExamplesJson);
+    });
+
+    itMacro('Creates an examples table for en-US', function (macro) {
+        macro.ctx.env.locale = 'en-US';
+        return macro.call().then(function(result) {
+            let dom = jsdom.JSDOM.fragment(result);
+            checkTableDom(dom, 'en-US');
+        });
+    });
+
+    itMacro('Creates an examples table for fr', function (macro) {
+        macro.ctx.env.locale = 'fr';
+        macro.ctx.allExamples = testExamplesJson;
+        return macro.call().then(function(result) {
+            let dom = jsdom.JSDOM.fragment(result);
+            checkTableDom(dom, 'fr');
+        });
+    });
+
+});


### PR DESCRIPTION
The "WebExtAllExamples" macro builds a table of links to example WebExtensions. One column lists the JS APIs that they call. This column isn't getting enough space, so the name of the APIs wrap, making it hard to scan:

<img width="1070" alt="screen shot 2018-07-25 at 3 44 18 pm" src="https://user-images.githubusercontent.com/432915/43231587-e0678122-9021-11e8-9f4d-0c2f4f6e35e9.png">

This PR gives the column a bit more space, so it should look all right even at narrower widths:

<img width="846" alt="screen shot 2018-07-25 at 3 46 48 pm" src="https://user-images.githubusercontent.com/432915/43231616-fe5b5e4c-9021-11e8-9747-a2c001a66d57.png">

I have also added some basic tests for this macro, because I think we should not accept PRs for macros that don't already have tests, unless the PR also includes some basic tests.

