### PR TITLE
Update WebVR 1.1 spec URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1491,7 +1491,7 @@
   },
   "WebVR 1.1": {
     "name": "WebVR 1.1",
-    "url": "https://w3c.github.io/webvr/spec/1.1/",
+    "url": "https://immersive-web.github.io/webvr/spec/1.1/",
     "status": "Draft"
   },
   "WebVTT": {


### PR DESCRIPTION
The WebVR spec got moved as they work on deprecating it in favor of WebXR.