### PR TITLE
Add "CORS errors" to HTTP sidebar

### DIFF
--- a/macros/HTTPSidebar.ejs
+++ b/macros/HTTPSidebar.ejs
@@ -156,7 +156,7 @@ var text = mdn.localStringMap({
     <li data-default-state="<%=state('Web/HTTP/Headers/Content-Security-Policy')%>"><a href="/<%=locale%>/docs/Web/HTTP/Headers/Content-Security-Policy"><%=text['CSPDirectives']%></a>
       <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTTP/Headers/Content-Security-Policy'])%>
     </li>
-    <li data-default-state="<%=state('Web/HTTP/CORS/Errors')%>"><a href="/<%=locale%>/docs/Web/CORS/Errors"><%=text['CORS_errors']%></a>
+    <li data-default-state="<%=state('Web/HTTP/CORS/Errors')%>"><a href="/<%=locale%>/docs/Web/HTTP/CORS/Errors"><%=text['CORS_errors']%></a>
       <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTTP/CORS/Errors', 1])%>
     </li>
   </ol>

--- a/macros/HTTPSidebar.ejs
+++ b/macros/HTTPSidebar.ejs
@@ -45,6 +45,7 @@ var text = mdn.localStringMap({
     'Methods': 'HTTP request methods',
     'Status': 'HTTP response status codes',
     'CSPDirectives': 'CSP directives',
+    'CORS_errors': 'CORS errors',
     'Security': 'HTTP security',
     'Authentication': 'HTTP authentication',
     'ProtocolUpgradeMech': 'Protocol upgrade mechanism'
@@ -154,6 +155,9 @@ var text = mdn.localStringMap({
     </li>
     <li data-default-state="<%=state('Web/HTTP/Headers/Content-Security-Policy')%>"><a href="/<%=locale%>/docs/Web/HTTP/Headers/Content-Security-Policy"><%=text['CSPDirectives']%></a>
       <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTTP/Headers/Content-Security-Policy'])%>
+    </li>
+    <li data-default-state="<%=state('Web/HTTP/CORS/Errors')%>"><a href="/<%=locale%>/docs/Web/CORS/Errors"><%=text['CORS_errors']%></a>
+      <%-template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTTP/CORS/Errors', 1])%>
     </li>
   </ol>
 </section>


### PR DESCRIPTION
Added "CORS errors" to the "References" section in the
HTTPSidebar macro.