### PR TITLE
bug 1445641, bug 1464892: fix recording of deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,15 +108,21 @@ node {
         }
 
         stage('Push') {
-          dir('infra/apps/mdn/mdn-aws/k8s') {
-            def current_revision_hash = utils.get_revision_hash()
-            withEnv(["FROM_REVISION_HASH=${current_revision_hash}"]) {
-              // Start a rolling update of the Kumascript-based deployments.
-              utils.rollout()
-              // Monitor the rollout until it has completed.
-              utils.monitor_rollout()
-              // Record the rollout in external services like New-Relic.
-              utils.record_rollout()
+          def kuma_image_tag = sh(
+            returnStdout: true,
+            script: 'git rev-parse --short=7 HEAD'
+          ).trim()
+          withEnv(["KUMA_IMAGE_TAG=${kuma_image_tag}"]) {
+            dir('infra/apps/mdn/mdn-aws/k8s') {
+              def current_revision_hash = utils.get_revision_hash()
+              withEnv(["FROM_REVISION_HASH=${current_revision_hash}"]) {
+                // Start a rolling update of the Kumascript-based deployments.
+                utils.rollout()
+                // Monitor the rollout until it has completed.
+                utils.monitor_rollout()
+                // Record the rollout in external services like New-Relic.
+                utils.record_rollout()
+              }
             }
           }
         }


### PR DESCRIPTION
This depends on https://github.com/mdn/infra/pull/17.

This fixes a problem when running `utils.record_rollout()` for `kumascript` where the `KUMA_IMAGE_TAG` is not set with the latest value from the repo environment, but instead with the [ancient value within the regional configuration script](https://github.com/mdn/infra/blob/0b53ff544687ec280dbaa026b30166d59bd905c0/apps/mdn/mdn-aws/k8s/regions/portland/stage.sh#L100). The `make k8s-kumascript-record-deployment-job` command needs the latest value of `KUMA_IMAGE_TAG` for the [`mdn-record-deployment-job`](https://github.com/mdn/infra/blob/master/apps/mdn/mdn-aws/k8s/mdn-record-deployment-job.yaml.j2).