### PR TITLE
added Media Capabilities API

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -986,6 +986,22 @@
             "properties": [],
             "events":      []
         },
+        "Media Capabilities API": {
+            "overview":   [ "Media Capabilities API" ],
+            "interfaces": [ "MediaCapabilities",
+                            "ScreenLuminance",
+                            "Screen",
+                            "MediaCapabilitiesInfo" ],
+            "methods":    [ "mediaCapabilities.decodingInfo()",
+                            "mediaCapabilities.encodingInfo()"],
+            "properties": [],
+            "events":     [],
+            "dictionaries": ["MediaConfiguration",
+                            "VideoConfiguration",
+                            "AudioConfiguration",
+                            "MediaDecodingConfiguration",
+                            "MediaEncodingConfiguration"]
+        },
         "Media Capture and Streams": {
             "overview":   [ "Media Streams API" ],
             "guides":     [ { "url":   "/en-US/docs/Web/API/Media_Streams_API/Constraints",


### PR DESCRIPTION
Note: I added a section called "dictionaries". More often now, new APIs seem to have more  dictionaries defined then they do interfaces. For example, mediaCapabilities is really the only interface fully supported in this spec, but it has 5 dictionaries plus sum enums / enumerated values. If this is not appropriate, please let me know and i can remove the dictionaries part. They do each have their own MDN doc page. 