### PR TITLE
removing caching compiled webassembly modules article from sidebar

### DIFF
--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -12,7 +12,6 @@ var text = mdn.localStringMap({
       'Text_format' : 'Understanding WebAssembly text format',
       'Text_format_to_wasm' : 'Converting WebAssembly text format to wasm',
       'Loading_and_running' : 'Loading and running WebAssembly code',
-      'Caching_modules' : 'Caching compiled WebAssembly modules',
       'Exported_functions' : 'Exported WebAssembly functions',
     'Object_reference' : 'Object reference'
   }
@@ -31,7 +30,6 @@ var text = mdn.localStringMap({
       <li><a href="<%=baseURL%>/Understanding_the_text_format"><%=text['Text_format']%></a></li>
       <li><a href="<%=baseURL%>/Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>
       <li><a href="<%=baseURL%>/Loading_and_running"><%=text['Loading_and_running']%></a></li>
-      <li><a href="<%=baseURL%>/Caching_modules"><%=text['Caching_modules']%></a></li>
       <li><a href="<%=baseURL%>/Exported_functions"><%=text['Exported_functions']%></a></li>
     </ol>
   </li>


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1469395