### PR TITLE
Remove SIMD

### DIFF
--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -49,7 +49,6 @@ var inheritanceData = {
     "arguments": [],
     "Reflect": ["Object"],
     "Proxy": [],
-    "SIMD": ["Object"],
     "Atomics": ["Object"],
     "WebAssembly": ["Object"],
 };
@@ -64,8 +63,6 @@ var groupData = {
     "TypedArray": ["TypedArray", "Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
                    "Int32Array", "Uint32Array", "Float32Array", "Float64Array"],
     "Proxy": ["Proxy", "handler"],
-    "SIMD": ["SIMD", "Float32x4", "Float64x2", "Int8x16", "Int16x8", "Int32x4", "Uint8x16", "Uint16x8", "Uint32x4",
-             "Bool8x16", "Bool16x8", "Bool32x4", "Bool64x2"],
     "WebAssembly": ["WebAssembly", "WebAssembly.Module", "WebAssembly.Global", "WebAssembly.Instance", "WebAssembly.Memory",
                     "WebAssembly.Table", "WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError"],
 };
@@ -74,7 +71,6 @@ var groupData = {
 if (groupData["TypedArray"].indexOf(mainObj) != -1) { mainObj = "TypedArray"; }
 if (groupData["Error"].indexOf(mainObj) != -1) { mainObj = "Error"; }
 if (groupData["Proxy"].indexOf(mainObj) != -1) { mainObj = "Proxy/handler"; }
-if (groupData["SIMD"].indexOf(mainObj) != -1) { mainObj = "SIMD"; }
 
 // Get related pages from groups and exclude self
 var group = [];

--- a/macros/JsSidebar.ejs
+++ b/macros/JsSidebar.ejs
@@ -45,7 +45,6 @@ var text = mdn.localStringMap({
     'Inheritance': 'Inheritance and the prototype chain',
     'Strict_mode': 'Strict mode',
     'Typed_arrays': 'JavaScript typed arrays',
-    'SIMD_types': 'SIMD types',
     'Memory_Management': 'Memory Management',
     'Event_Loop': 'Concurrency model and Event Loop',
     'Reference': 'References:',
@@ -109,7 +108,6 @@ var text = mdn.localStringMap({
     'Inheritance': 'Наследование и цепочка прототипов',
     'Strict_mode': 'Строгий режим',
     'Typed_arrays': 'Типизированные массивы JavaScript',
-    'SIMD_types': 'SIMD типы',
     'Memory_Management': 'Управление памятью',
     'Event_Loop': 'Модель совпадения и циклы событий',
     'Reference': 'Справочная информация:',
@@ -173,7 +171,6 @@ var text = mdn.localStringMap({
     'Inheritance': 'Héritage et la chaîne de prototypes',
     'Strict_mode': 'Mode strict',
     'Typed_arrays': 'Tableaux typés en JavaScript',
-    'SIMD_types': 'SIMD types',
     'Memory_Management': 'Gestion de la mémoire',
     'Event_Loop': 'Concurrence et boucle des événements',
     'Reference': 'Références\xa0:',
@@ -237,7 +234,6 @@ var text = mdn.localStringMap({
     'Inheritance': '继承和原型链',
     'Strict_mode': '严格模式',
     'Typed_arrays': 'JavaScript 类型化数组',
-    'SIMD_types': 'SIMD types',
     'Memory_Management': '内存管理',
     'Event_Loop': 'Concurrency model and Event Loop',
     'Reference': '引用:',
@@ -301,7 +297,6 @@ var text = mdn.localStringMap({
     'Inheritance': 'Vererbung und Prototypenkette',
     'Strict_mode': 'Strict Modus',
     'Typed_arrays': 'JavaScript Typed-Arrays',
-    'SIMD_types': 'SIMD-Typen',
     'Memory_Management': 'Memory Management',
     'Event_Loop': 'Laufzeitmodell und Event-Loop',
     'Reference': 'Referenzen:',
@@ -365,7 +360,6 @@ var text = mdn.localStringMap({
     'Inheritance': '継承とプロトタイプチェーン',
     'Strict_mode': 'Strict モード',
     'Typed_arrays': 'JavaScript 型付き配列',
-    'SIMD_types': 'SIMD 型',
     'Memory_Management': 'メモリ管理',
     'Event_Loop': '並列モデルとイベントループ',
     'Reference': 'リファレンス:',
@@ -443,7 +437,6 @@ var text = mdn.localStringMap({
     <li><a href="/<%=locale%>/docs/Web/JavaScript/Inheritance_and_the_prototype_chain"><%=text['Inheritance']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Strict_mode"><%=text['Strict_mode']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/Typed_arrays"><%=text['Typed_arrays']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/JavaScript/SIMD_types"><%=text['SIMD_types']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/Memory_Management"><%=text['Memory_Management']%></a></li>
     <li><a href="/<%=locale%>/docs/Web/JavaScript/EventLoop"><%=text['Event_Loop']%></a></li>
    </ol>

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1104,11 +1104,6 @@
     "url": "https://wicg.github.io/shape-detection-api/",
     "status": "Draft"
   },
-  "SIMD": {
-    "name": "SIMD",
-    "url": "https://tc39.github.io/ecmascript_simd/",
-    "status": "Obsolete"
-  },
   "Static Range": {
     "name": "Static Range",
     "url": "https://w3c.github.io/staticrange/index.html",


### PR DESCRIPTION
I'll entirely delete the SIMD docs from MDN. SIMD has never made it into a released browser and the spec has never been stable. It's going to be removed from Nightly per https://bugzilla.mozilla.org/show_bug.cgi?id=1416723

(The MDN pages had a banner saying that this is obsolete and will be gone soon for the last 6 months.)