### PR TITLE
Fixing markup issue (all article is <strong>)

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -382,7 +382,7 @@ var text = mdn.localStringMap({
       </ol>
     </li>
 
-    <li><a href="<%=baseURL%>Distribution"><strong><%=text['Distribution']%><strong></a></li>
+    <li><a href="<%=baseURL%>Distribution"><strong><%=text['Distribution']%></strong></a></li>
     <li><a href="<%=baseURL%>Distribution"><%=text['Distribution/Publishing']%></a>
       <ol>
         <li><a href="<%=baseURL%>Distribution"><%=text['Distribution/Signing']%></a></li>


### PR DESCRIPTION
As detected in https://discourse.mozilla.org/t/why-is-all-normal-text-bold-now/31038
This fixes markup issues introduced by commit 282615b (cf. [L385](https://github.com/mdn/kumascript/blame/master/macros/AddonSidebar.ejs#L385) )
