### PR TITLE
fix(macros.AddonSidebar): Correct broken <a> and <strong> DOM hierarchy

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -405,7 +405,7 @@ var text = mdn.localStringMap({
       </ol>
     </li>
 
-    <li><a href="https://discourse.mozilla.org/c/add-ons"><strong><%=text['Community_and_Support']%></a></strong></li>
+    <li><a href="https://discourse.mozilla.org/c/add-ons"><strong><%=text['Community_and_Support']%></strong></a></li>
     <li><a href="#"><%=text['Channels']%></a>
       <ol>
         <li><a href="https://blog.mozilla.org/addons"><%=text['Blog']%></a></li>


### PR DESCRIPTION
Follow‑up to #768 and #755.

See also #769.

review?(@SphinxKnight)