### PR TITLE
bug 1482159: Get sample server from config for LiveSampleURL

### DIFF
--- a/lib/kumascript/conf.js
+++ b/lib/kumascript/conf.js
@@ -49,6 +49,9 @@ var DEFAULT_CONFIG = {
     },
     interactive_examples: {
         base_url: "https://interactive-examples.mdn.mozilla.net"
+    },
+    live_samples: {
+        base_url: "https://mdn.mozillademos.org"
     }
 };
 

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -324,10 +324,11 @@ var Server = ks_utils.Class({
                 env.revalidate_at = (new Date()).getTime();
             }
 
-            // Add a clone of the interactive-examples settings to "env".
+            // Add service base URLs to the environment
             env.interactive_examples = ks_conf.nconf.get(
                 'interactive_examples'
             );
+            env.live_samples = ks_conf.nconf.get('live_samples');
 
             var ctx = {
                 env: env,

--- a/macros/LiveSampleURL.ejs
+++ b/macros/LiveSampleURL.ejs
@@ -15,28 +15,11 @@ if ($1 && $1.length > 0) {
     base = $1;
 }
 
-base = base.replace('developer.mozilla.org', 'mdn.mozillademos.org');
-
-// HACK: This may be the result of server misconfiguration.
-// If we're on production, be sure we use https; otherwise,
-// use the same scheme as pageUrl.
-// TODO: make the sample base URL a kumascript config item
-
-if (pageUrl.indexOf("developer.mozilla.org") != -1) {
-  // Production
-  base = base.replace('http://', 'https://');
-} else if (pageUrl.indexOf("developer.allizom.org") != -1) {
-  // Staging
-  base = base.replace('http://', 'https://');
-  base = base.replace('https://developer.allizom.org',
-                      'https://stage-files.mdn.moz.works');
-} else {
-  // Not production - use the same scheme as the main site
-  if (pageUrl.indexOf("http://") != -1) {
-    base = base.replace('https://', 'http://');
-  } else {
-    base = base.replace('http://', 'https://');
-  }
-}
+let url = new kuma.url.URL(base);
+let liveSampleUrl = new kuma.url.URL(env.live_samples.base_url);
+url.host = liveSampleUrl.host;
+url.protocol = liveSampleUrl.protocol;
+url.pathname = url.pathname + '$samples/' + $0;
+url.search = 'revision=' + env.revision_id;
 %>
-<%= base + '$samples/' + $0 + '?revision=' + env.revision_id %>
+<%= url %>

--- a/tests/macros/test-EmbedLiveSample.js
+++ b/tests/macros/test-EmbedLiveSample.js
@@ -11,6 +11,7 @@ chai.use(chaiAsPromised);
 
 describeMacro('EmbedLiveSample', function () {
     itMacro('One argument: ID', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
@@ -23,6 +24,7 @@ describeMacro('EmbedLiveSample', function () {
     });
     itMacro('One argument: ID with HTML entities (bug?)', function (macro) {
         // Kuma doesn't serve the sample for the generated URL
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch';
         macro.ctx.env.revision_id = 1408880;
         return assert.eventually.equal(
@@ -34,7 +36,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('One argument: percent-encoded ID', function (macro) {
-        // Kuma doesn't serve the sample for the generated URL
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch';
         macro.ctx.env.revision_id = 1408886;
         return assert.eventually.equal(
@@ -46,18 +48,19 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('One argument: ID with percent-encoded page URL', function (macro) {
-        // Kuma doesn't serve the sample for the generated URL
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS';
         macro.ctx.env.revision_id = 1347968;
         return assert.eventually.equal(
             macro.call('Dégradés_linéaires_simples'),
             '<iframe class="live-sample-frame sample-code-frame"' +
             ' id="frame_Dégradés_linéaires_simples" frameborder="0"' +
-            ' src="https://mdn.mozillademos.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS$samples/Dégradés_linéaires_simples?revision=1347968">' +
+            ' src="https://mdn.mozillademos.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS$samples/D%C3%A9grad%C3%A9s_lin%C3%A9aires_simples?revision=1347968">' +
             '</iframe>'
         );
     });
     itMacro('Two arguments: ID, width', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width';
         macro.ctx.env.revision_id = 1352086;
         return assert.eventually.equal(
@@ -70,6 +73,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: ID, width, height', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
@@ -82,6 +86,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: unicode ID, width, height', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations';
         macro.ctx.env.revision_id = 1225673;
         return assert.eventually.equal(
@@ -89,11 +94,12 @@ describeMacro('EmbedLiveSample', function () {
             '<iframe class="live-sample-frame sample-code-frame"' +
             ' id="frame_增加关键帧" frameborder="0"' +
             ' width="100%" height="250"' +
-            ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations$samples/增加关键帧?revision=1225673">' +
+            ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations$samples/%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7?revision=1225673">' +
             '</iframe>'
         );
     });
     itMacro('Three arguments: url-encoded ID, width, height', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage';
         macro.ctx.env.revision_id = 1408763;
         return assert.eventually.equal(
@@ -106,6 +112,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Four arguments: ID, width, height, ""', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before';
         macro.ctx.env.revision_id = 1392665;
         return assert.eventually.equal(
@@ -118,6 +125,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Four arguments: ID, width, height, screenshot', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients';
         macro.ctx.env.revision_id = 1330830;
         return assert.eventually.equal(
@@ -144,6 +152,7 @@ describeMacro('EmbedLiveSample', function () {
         '</iframe>'
     );
     itMacro('Five arguments: ID, width, height, "", same slug', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap';
         macro.ctx.env.revision_id = 1367874;
         return assert.eventually.equal(
@@ -152,6 +161,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: ID, width, height (same as Five arg, same slug)', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap';
         macro.ctx.env.revision_id = 1367874;
         return assert.eventually.equal(
@@ -160,6 +170,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Five arguments: ID, "", "", "", other slug', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/Events/focus';
         macro.ctx.env.revision_id = 1348946;
         return assert.eventually.equal(
@@ -171,6 +182,7 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Six arguments: ID, width, height, "", "", class', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance';
         macro.ctx.env.revision_id = 1402877;
         return assert.eventually.equal(

--- a/tests/macros/test-EmbedLiveSample.js
+++ b/tests/macros/test-EmbedLiveSample.js
@@ -5,13 +5,16 @@ var utils = require('./utils'),
     chaiAsPromised = require('chai-as-promised'),
     assert = chai.assert,
     itMacro = utils.itMacro,
-    describeMacro = utils.describeMacro;
+    describeMacro = utils.describeMacro,
+    beforeEachMacro = utils.beforeEachMacro;
 
 chai.use(chaiAsPromised);
 
 describeMacro('EmbedLiveSample', function () {
-    itMacro('One argument: ID', function (macro) {
+    beforeEachMacro(function (macro) {
         macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
+    });
+    itMacro('One argument: ID', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
@@ -24,7 +27,6 @@ describeMacro('EmbedLiveSample', function () {
     });
     itMacro('One argument: ID with HTML entities (bug?)', function (macro) {
         // Kuma doesn't serve the sample for the generated URL
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch';
         macro.ctx.env.revision_id = 1408880;
         return assert.eventually.equal(
@@ -36,7 +38,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('One argument: percent-encoded ID', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch';
         macro.ctx.env.revision_id = 1408886;
         return assert.eventually.equal(
@@ -48,7 +49,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('One argument: ID with percent-encoded page URL', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS';
         macro.ctx.env.revision_id = 1347968;
         return assert.eventually.equal(
@@ -60,7 +60,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Two arguments: ID, width', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width';
         macro.ctx.env.revision_id = 1352086;
         return assert.eventually.equal(
@@ -73,7 +72,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: ID, width, height', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
@@ -86,7 +84,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: unicode ID, width, height', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations';
         macro.ctx.env.revision_id = 1225673;
         return assert.eventually.equal(
@@ -99,7 +96,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: url-encoded ID, width, height', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage';
         macro.ctx.env.revision_id = 1408763;
         return assert.eventually.equal(
@@ -112,7 +108,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Four arguments: ID, width, height, ""', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before';
         macro.ctx.env.revision_id = 1392665;
         return assert.eventually.equal(
@@ -125,7 +120,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Four arguments: ID, width, height, screenshot', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients';
         macro.ctx.env.revision_id = 1330830;
         return assert.eventually.equal(
@@ -152,7 +146,6 @@ describeMacro('EmbedLiveSample', function () {
         '</iframe>'
     );
     itMacro('Five arguments: ID, width, height, "", same slug', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap';
         macro.ctx.env.revision_id = 1367874;
         return assert.eventually.equal(
@@ -161,7 +154,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Three arguments: ID, width, height (same as Five arg, same slug)', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap';
         macro.ctx.env.revision_id = 1367874;
         return assert.eventually.equal(
@@ -170,7 +162,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Five arguments: ID, "", "", "", other slug', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/Events/focus';
         macro.ctx.env.revision_id = 1348946;
         return assert.eventually.equal(
@@ -182,7 +173,6 @@ describeMacro('EmbedLiveSample', function () {
         );
     });
     itMacro('Six arguments: ID, width, height, "", "", class', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance';
         macro.ctx.env.revision_id = 1402877;
         return assert.eventually.equal(

--- a/tests/macros/test-LiveSampleURL.js
+++ b/tests/macros/test-LiveSampleURL.js
@@ -11,6 +11,7 @@ chai.use(chaiAsPromised);
 
 describeMacro('LiveSampleURL', function () {
     itMacro('Production settings', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p';
         macro.ctx.env.revision_id = 1393227;
         return assert.eventually.equal(
@@ -19,6 +20,7 @@ describeMacro('LiveSampleURL', function () {
         );
     });
     itMacro('Override page URL', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets';
         macro.ctx.env.revision_id = 1351912;
         return assert.eventually.equal(
@@ -28,6 +30,7 @@ describeMacro('LiveSampleURL', function () {
         );
     });
     itMacro('Staging settings', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://stage-files.mdn.moz.works'};
         macro.ctx.env.url = 'https://developer.allizom.org/en-US/docs/Web/CSS/background-color';
         macro.ctx.env.revision_id = 1291055;
         return assert.eventually.equal(
@@ -36,6 +39,7 @@ describeMacro('LiveSampleURL', function () {
         );
     });
     itMacro('Development default settings', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'http://localhost:8000'};
         macro.ctx.env.url = 'http://localhost:8000/en-US/docs/Web/HTML/Element/p';
         macro.ctx.env.revision_id = 123;
         return assert.eventually.equal(
@@ -49,7 +53,16 @@ describeMacro('LiveSampleURL', function () {
         macro.ctx.env.revision_id = 1366760;
         return assert.eventually.equal(
             macro.call('例子'),
-            'https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/flex-direction$samples/例子?revision=1366760'
+            'https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/flex-direction$samples/%E4%BE%8B%E5%AD%90?revision=1366760'
+        );
+    });
+    itMacro('Development demo settings', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'http://demos:8000'};
+        macro.ctx.env.url = 'http://localhost:8000/en-US/docs/Web/HTML/Element/p';
+        macro.ctx.env.revision_id = 123;
+        return assert.eventually.equal(
+            macro.call('Example'),
+            'http://demos:8000/en-US/docs/Web/HTML/Element/p$samples/Example?revision=123'
         );
     });
 });

--- a/tests/macros/test-LiveSampleURL.js
+++ b/tests/macros/test-LiveSampleURL.js
@@ -1,0 +1,55 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+var utils = require('./utils'),
+    chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
+    assert = chai.assert,
+    itMacro = utils.itMacro,
+    describeMacro = utils.describeMacro;
+
+chai.use(chaiAsPromised);
+
+describeMacro('LiveSampleURL', function () {
+    itMacro('Production settings', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p';
+        macro.ctx.env.revision_id = 1393227;
+        return assert.eventually.equal(
+            macro.call('Example'),
+            'https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/p$samples/Example?revision=1393227'
+        );
+    });
+    itMacro('Override page URL', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets';
+        macro.ctx.env.revision_id = 1351912;
+        return assert.eventually.equal(
+            macro.call('No_JS',
+                       'https://developer.mozilla.org/en-US/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_2'),
+            'https://mdn.mozillademos.org/en-US/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_2$samples/No_JS?revision=1351912'
+        );
+    });
+    itMacro('Staging settings', function (macro) {
+        macro.ctx.env.url = 'https://developer.allizom.org/en-US/docs/Web/CSS/background-color';
+        macro.ctx.env.revision_id = 1291055;
+        return assert.eventually.equal(
+            macro.call('Examples'),
+            'https://stage-files.mdn.moz.works/en-US/docs/Web/CSS/background-color$samples/Examples?revision=1291055'
+        );
+    });
+    itMacro('Development default settings', function (macro) {
+        macro.ctx.env.url = 'http://localhost:8000/en-US/docs/Web/HTML/Element/p';
+        macro.ctx.env.revision_id = 123;
+        return assert.eventually.equal(
+            macro.call('Example'),
+            'http://localhost:8000/en-US/docs/Web/HTML/Element/p$samples/Example?revision=123'
+        );
+    });
+    itMacro('Unicode ID', function (macro) {
+        macro.ctx.env.live_samples = {'base_url': 'https://mdn.mozillademos.org'};
+        macro.ctx.env.url = 'https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex-direction';
+        macro.ctx.env.revision_id = 1366760;
+        return assert.eventually.equal(
+            macro.call('例子'),
+            'https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/flex-direction$samples/例子?revision=1366760'
+        );
+    });
+});


### PR DESCRIPTION
Instead of guessing the sample server domain and protocol from the requesting domain, add a new config item ``live_samples.base_url`` and use it to construct the sample URL, using the [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api). Plus tests!

I need to use a different sample server domain in local dev to reproduce the issue in [bug 1482159](https://bugzilla.mozilla.org/show_bug.cgi?id=1482159).