### PR TITLE
Make EmbedInteractiveExamples mostly XSS‑proof

### DIFF
--- a/macros/EmbedInteractiveExample.ejs
+++ b/macros/EmbedInteractiveExample.ejs
@@ -27,7 +27,5 @@ if ($1) {
     iClass += " " + $1;
 }
 
-let str = `<iframe class="${iClass}" width="100%" height="250" frameborder="0" src="${url}" title="MDN Web Docs Interactive Example"></iframe>`;
-
 %>
-<%- str %>
+<iframe class="<%= iClass %>" width="100%" height="250" frameborder="0" src="<%= url %>" title="MDN Web Docs Interactive Example"></iframe>

--- a/tests/macros/test-EmbedInteractiveExample.js
+++ b/tests/macros/test-EmbedInteractiveExample.js
@@ -55,7 +55,7 @@ describeMacro('EmbedInteractiveExample', function () {
         macro.ctx.env.url = 'http://localhost:8000/en-US/docs/Web/HTTP/headers';
         return assert.eventually.equal(
             macro.call('pages/http/headers.html?foo=bar'),
-            `<iframe class="interactive" width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/http/headers.html?foo=bar&origin=http://localhost:8000" title="MDN Web Docs Interactive Example"></iframe>`
+            `<iframe class="interactive" width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/http/headers.html?foo=bar&amp;origin=http://localhost:8000" title="MDN Web Docs Interactive Example"></iframe>`
         );
     });
     itMacro('Javascript pages get an extra class by default', function (macro) {


### PR DESCRIPTION
This is the ``{{EmbedInteractiveExamples}}`` changes from #773, with tests.