### PR TITLE
EmbedLiveSample: Avoid XSS, and add allow= parameter

### DIFF
--- a/macros/EmbedLiveSample.ejs
+++ b/macros/EmbedLiveSample.ejs
@@ -12,39 +12,45 @@
 //  then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
 //
 // See also : LiveSampleLink
- 
-var str = "";
+
+var sampleId = $0;
+var width = $1;
+var height = $2;
+var screenshotUrl = $3;
+var sampleSlug = $4;
+var className = $5 || "sample-code-frame";
+
+var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
+
 var sampleUrl = "";
-
-var className = $5|| "sample-code-frame";
-
-if ($4) {
+if (sampleSlug) {
     sampleUrl = "https://developer.mozilla.org/" + env.locale + "/docs";
-    if ($4.charAt(0) != "/") {
+    if (sampleSlug.charAt(0) != "/") {
         sampleUrl += "/";
     }
-    sampleUrl += $4;
+    sampleUrl += sampleSlug;
 }
+var url = template('LiveSampleURL', [sampleId, sampleUrl]);
 
-var widthHeight = "";
-if ($1) {
-    widthHeight = 'width="' + $1 + '" ';
-}
-if ($2) {
-    widthHeight += 'height="' + $2 + '" ';
-}
-
-var liveSample = '<iframe class="live-sample-frame ' + className +'" id="frame_'+ $0 +'" frameborder="0" ' + widthHeight + 'src="' + template('LiveSampleURL', [$0, sampleUrl]) + '"></iframe>';
-if ($3 && ($3.length > 0)) {
-    str += '<table class="sample-code-table"><thead><tr>';
-    str += '<th scope="col" style="text-align: center;">Screenshot</th>';
-    str += '<th scope="col" style="text-align: center;">Live sample</th>';
-    str += '</tr></thead><tbody><tr>';
-    str += '<td><img alt="" class="internal" src="' + $3 + '" /></td>';
-    str += '<td>' + liveSample + '</td>';
-    str += '</tr></tbody></table>';
-} else {
-    str += liveSample;
-}
-%>
-<%- str %>
+if (hasScreenshot) {
+%><table class="sample-code-table"><%
+  %><thead><%
+    %><tr><%
+      %><th scope="col" style="text-align: center;">Screenshot</th><%
+      %><th scope="col" style="text-align: center;">Live sample</th><%
+    %></tr><%
+  %></thead><%
+  %><tbody><%
+    %><tr><%
+      %><td><%
+        %><img alt="" class="internal" src="<%= screenshotUrl %>" /><%
+      %></td><%
+      %><td><%
+} // end hasScreenshot
+%><iframe class="live-sample-frame <%= className %>"<%
+%> id="frame_<%= sampleId %>"<%
+%> frameborder="0"<%
+if (width) { %> width="<%= width %>"<% }
+if (height) { %> height="<%= height %>"<% }
+%> src="<%- url %>"></iframe><%
+if (hasScreenshot) { %></td></tr></tbody></table><% } %>

--- a/macros/EmbedLiveSample.ejs
+++ b/macros/EmbedLiveSample.ejs
@@ -8,8 +8,9 @@
 //  $3 - The url of a screenshot of the sample working as intended (optional)
 //  $4 - The slug from which to load the sample (optional; current page used if not provided)
 //  $5 - The class name of the frame; defaults to "sample-code-frame". If you
-//  pass this parameter and give it a value other than "sample-code-frame",
-//  then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
+//       pass this parameter and give it a value other than "sample-code-frame",
+//       then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
+//  $6 - Allowed features, separated by semicolons (optional)
 //
 // See also : LiveSampleLink
 
@@ -19,6 +20,7 @@ var height = $2;
 var screenshotUrl = $3;
 var sampleSlug = $4;
 var className = $5 || "sample-code-frame";
+var allowedFeatures = $6;
 
 var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
 
@@ -52,5 +54,7 @@ if (hasScreenshot) {
 %> frameborder="0"<%
 if (width) { %> width="<%= width %>"<% }
 if (height) { %> height="<%= height %>"<% }
-%> src="<%- url %>"></iframe><%
+%> src="<%- url %>"<%
+if (allowedFeatures) { %> allow="<%= allowedFeatures %>"<% }
+%>></iframe><%
 if (hasScreenshot) { %></td></tr></tbody></table><% } %>

--- a/tests/macros/test-EmbedLiveSample.js
+++ b/tests/macros/test-EmbedLiveSample.js
@@ -59,6 +59,17 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
+    itMacro('One argument: XSS attempt (success)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
+        macro.ctx.env.revision_id = 1397983;
+        return assert.eventually.equal(
+            macro.call('"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_"><script>alert("XSS");</script>" frameborder="0"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure$samples/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E?revision=1397983">' +
+            '</iframe>'
+        );
+    });
     itMacro('Two arguments: ID, width', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width';
         macro.ctx.env.revision_id = 1352086;
@@ -67,6 +78,18 @@ describeMacro('EmbedLiveSample', function () {
             '<iframe class="live-sample-frame sample-code-frame"' +
             ' id="frame_Example" frameborder="0"' +
             ' width="100%"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width$samples/Example?revision=1352086">' +
+            '</iframe>'
+        );
+    });
+    itMacro('Two arguments: ID, XSS attempt (success)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width';
+        macro.ctx.env.revision_id = 1352086;
+        return assert.eventually.equal(
+            macro.call('Example', '"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_Example" frameborder="0"' +
+            ' width=""><script>alert("XSS");</script>"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width$samples/Example?revision=1352086">' +
             '</iframe>'
         );
@@ -107,6 +130,18 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
+    itMacro('Three arguments: ID, width, XSS attempt (success)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
+        macro.ctx.env.revision_id = 1397983;
+        return assert.eventually.equal(
+            macro.call("Images", "100%", '"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_Images" frameborder="0"' +
+            ' width="100%" height=""><script>alert("XSS");</script>"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure$samples/Images?revision=1397983">' +
+            '</iframe>'
+        );
+    });
     itMacro('Four arguments: ID, width, height, ""', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/::before';
         macro.ctx.env.revision_id = 1392665;
@@ -130,6 +165,25 @@ describeMacro('EmbedLiveSample', function () {
             '</tr></thead>' +
             '<tbody><tr><td>' +
             '<img alt="" class="internal" src="/files/722/SVG_Linear_Gradient_Example.png" />' +
+            '</td><td>' +
+            '<iframe class="live-sample-frame sample-code-frame" ' +
+            'id="frame_SVGLinearGradient" frameborder="0"' +
+            ' width="120" height="240"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Tutorial/Gradients$samples/SVGLinearGradient?revision=1330830">' +
+            '</iframe></td></tr></tbody></table>'
+        );
+    });
+    itMacro('Four arguments: ID, width, height, XSS attempt (success)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients';
+        macro.ctx.env.revision_id = 1330830;
+        return assert.eventually.equal(
+            macro.call('SVGLinearGradient','120','240','"><script>alert("XSS");</script>'),
+            '<table class="sample-code-table"><thead><tr>' +
+            '<th scope="col" style="text-align: center;">Screenshot</th>' +
+            '<th scope="col" style="text-align: center;">Live sample</th>' +
+            '</tr></thead>' +
+            '<tbody><tr><td>' +
+            '<img alt="" class="internal" src=""><script>alert("XSS");</script>" />' +
             '</td><td>' +
             '<iframe class="live-sample-frame sample-code-frame" ' +
             'id="frame_SVGLinearGradient" frameborder="0"' +
@@ -172,12 +226,35 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
+    itMacro('Five arguments: ID, "", "", "", XSS Attempt (failed)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/Events/focus';
+        macro.ctx.env.revision_id = 1348946;
+        return assert.eventually.equal(
+            macro.call('Event_delegation', '', '', '', '"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_Event_delegation" frameborder="0"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E$samples/Event_delegation?revision=1348946">' +
+            '</iframe>'
+        );
+    });
     itMacro('Six arguments: ID, width, height, "", "", class', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance';
         macro.ctx.env.revision_id = 1402877;
         return assert.eventually.equal(
             macro.call("sampleNone",100,50,"","", "nobutton"),
             '<iframe class="live-sample-frame nobutton"' +
+            ' id="frame_sampleNone" frameborder="0"' +
+            ' width="100" height="50"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance$samples/sampleNone?revision=1402877">' +
+            '</iframe>'
+        );
+    });
+    itMacro('Six arguments: ID, width, height, "", "", XSS attempt (success)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance';
+        macro.ctx.env.revision_id = 1402877;
+        return assert.eventually.equal(
+            macro.call("sampleNone",100,50,"","", '"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame "><script>alert("XSS");</script>"' +
             ' id="frame_sampleNone" frameborder="0"' +
             ' width="100" height="50"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance$samples/sampleNone?revision=1402877">' +

--- a/tests/macros/test-EmbedLiveSample.js
+++ b/tests/macros/test-EmbedLiveSample.js
@@ -32,7 +32,7 @@ describeMacro('EmbedLiveSample', function () {
         return assert.eventually.equal(
             macro.call('SVG_&lt;switch&gt;_example'),
             '<iframe class="live-sample-frame sample-code-frame"' +
-            ' id="frame_SVG_&lt;switch&gt;_example" frameborder="0"' +
+            ' id="frame_SVG_&amp;lt;switch&amp;gt;_example" frameborder="0"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Element/switch$samples/SVG_&amp;lt;switch&amp;gt;_example?revision=1408880">' +
             '</iframe>'
         );
@@ -59,13 +59,13 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
-    itMacro('One argument: XSS attempt (success)', function (macro) {
+    itMacro('One argument: XSS attempt (failed)', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
             macro.call('"><script>alert("XSS");</script>'),
             '<iframe class="live-sample-frame sample-code-frame"' +
-            ' id="frame_"><script>alert("XSS");</script>" frameborder="0"' +
+            ' id="frame_&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" frameborder="0"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure$samples/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E?revision=1397983">' +
             '</iframe>'
         );
@@ -82,14 +82,14 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
-    itMacro('Two arguments: ID, XSS attempt (success)', function (macro) {
+    itMacro('Two arguments: ID, XSS attempt (failed)', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width';
         macro.ctx.env.revision_id = 1352086;
         return assert.eventually.equal(
             macro.call('Example', '"><script>alert("XSS");</script>'),
             '<iframe class="live-sample-frame sample-code-frame"' +
             ' id="frame_Example" frameborder="0"' +
-            ' width=""><script>alert("XSS");</script>"' +
+            ' width="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width$samples/Example?revision=1352086">' +
             '</iframe>'
         );
@@ -130,14 +130,14 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
-    itMacro('Three arguments: ID, width, XSS attempt (success)', function (macro) {
+    itMacro('Three arguments: ID, width, XSS attempt (failed)', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure';
         macro.ctx.env.revision_id = 1397983;
         return assert.eventually.equal(
             macro.call("Images", "100%", '"><script>alert("XSS");</script>'),
             '<iframe class="live-sample-frame sample-code-frame"' +
             ' id="frame_Images" frameborder="0"' +
-            ' width="100%" height=""><script>alert("XSS");</script>"' +
+            ' width="100%" height="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure$samples/Images?revision=1397983">' +
             '</iframe>'
         );
@@ -173,7 +173,7 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe></td></tr></tbody></table>'
         );
     });
-    itMacro('Four arguments: ID, width, height, XSS attempt (success)', function (macro) {
+    itMacro('Four arguments: ID, width, height, XSS attempt (failed)', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Gradients';
         macro.ctx.env.revision_id = 1330830;
         return assert.eventually.equal(
@@ -183,7 +183,7 @@ describeMacro('EmbedLiveSample', function () {
             '<th scope="col" style="text-align: center;">Live sample</th>' +
             '</tr></thead>' +
             '<tbody><tr><td>' +
-            '<img alt="" class="internal" src=""><script>alert("XSS");</script>" />' +
+            '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" />' +
             '</td><td>' +
             '<iframe class="live-sample-frame sample-code-frame" ' +
             'id="frame_SVGLinearGradient" frameborder="0"' +
@@ -249,12 +249,12 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
-    itMacro('Six arguments: ID, width, height, "", "", XSS attempt (success)', function (macro) {
+    itMacro('Six arguments: ID, width, height, "", "", XSS attempt (failed)', function (macro) {
         macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-appearance';
         macro.ctx.env.revision_id = 1402877;
         return assert.eventually.equal(
             macro.call("sampleNone",100,50,"","", '"><script>alert("XSS");</script>'),
-            '<iframe class="live-sample-frame "><script>alert("XSS");</script>"' +
+            '<iframe class="live-sample-frame &#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
             ' id="frame_sampleNone" frameborder="0"' +
             ' width="100" height="50"' +
             ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance$samples/sampleNone?revision=1402877">' +

--- a/tests/macros/test-EmbedLiveSample.js
+++ b/tests/macros/test-EmbedLiveSample.js
@@ -261,4 +261,30 @@ describeMacro('EmbedLiveSample', function () {
             '</iframe>'
         );
     });
+    itMacro('Seven arguments: ID, width, height, "", "", "", features', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints';
+        macro.ctx.env.revision_id = 1401022;
+        return assert.eventually.equal(
+            macro.call("Example_Constraint_exerciser", 650, 800, "", "", "", "video; microphone"),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_Example_Constraint_exerciser" frameborder="0"' +
+            ' width="650" height="800"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints$samples/Example_Constraint_exerciser?revision=1401022"' +
+            ' allow="video; microphone">' +
+            '</iframe>'
+        );
+    });
+    itMacro('Seven arguments: ID, width, height, "", "", "", XSS Attempt (failed)', function (macro) {
+        macro.ctx.env.url = 'https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints';
+        macro.ctx.env.revision_id = 1401022;
+        return assert.eventually.equal(
+            macro.call("Example_Constraint_exerciser", 650, 800, "", "", "", '"><script>alert("XSS");</script>'),
+            '<iframe class="live-sample-frame sample-code-frame"' +
+            ' id="frame_Example_Constraint_exerciser" frameborder="0"' +
+            ' width="650" height="800"' +
+            ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints$samples/Example_Constraint_exerciser?revision=1401022"' +
+            ' allow="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;">' +
+            '</iframe>'
+        );
+    });
 });


### PR DESCRIPTION
Refactor ``{{EmbedLiveSample}}`` to avoid some cross-site scripting (XSS) vectors, including some before-and-after tests. Kuma should bleach these away, but I'd like to start making these templates more XSS-aware, and @ExE-Boss triggered my imagination with PR #773.

Add a seventh optional parameter 😮 that sets an ``allow="<features>"`` attribute for the ``<iframe>``, so that live samples using restricted features can continue working in Chrome and Safari (see [bug 1482159](https://bugzilla.mozilla.org/show_bug.cgi?id=1482159)).

This builds on and includes PR #777 and PR #785, which may be easier to review first.