### PR TITLE
fix(macros): Add the `overheadIndicator` class to {{SeeCompatTable}}

### DIFF
--- a/macros/SeeCompatTable.ejs
+++ b/macros/SeeCompatTable.ejs
@@ -13,6 +13,6 @@ var str = mdn.localString({
 });
 
 
-%><div class="notice experimental">
+%><div class="notice overheadIndicator experimental">
     <p><%-template("ExperimentalBadge", [1])%> <%- str %></p>
 </div>


### PR DESCRIPTION
This adds the `overheadIndiator` class to `{{SeeCompatTable}}` in order to add support for indicator snugging (see also mozilla/kuma#4884).