### PR TITLE
Add the Priority Hints spec to SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1039,6 +1039,11 @@
     "url": "https://w3c.github.io/presentation-api/",
     "status": "CR"
   },
+  "Priority Hints": {
+    "name": "Priority Hints",
+    "url": "https://wicg.github.io/priority-hints/",
+    "status": "Draft"
+  },
   "Proximity Events": {
     "name": "Proximity Sensor",
     "url": "https://w3c.github.io/proximity/",


### PR DESCRIPTION
The Priority Hints spec defines a new `importance` attribute for the `<script>` element and some other elements, and it was added (with the experimental flag) in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script$revision/1411177 to the MDN `<script>` article — and in similar changes to articles for the other elements with which it can be used — but without a spec reference (because the Priority Hints spec wasn’t in SpecData.json yet...)