### PR TITLE
Change wording of vendor prefix note in compat table

### DIFF
--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -300,7 +300,7 @@
         "nl"   : "Voorgevoegd"
     },
     "bc_icon_title_prefix": {
-        "en-US": "Requires the vendor prefix: $1$",
+        "en-US": "Implemented with the vendor prefix: $1$",
         "de"   : "Benötigt das Herstellerpräfix: $1$",
         "es"   : "Requiere de un prefijo de vendedor : $1$",
         "fr"   : "Nécessite l'utilisation d'un préfixe&nbsp;: $1$",


### PR DESCRIPTION
From "Requires the vendor prefix: " to "Implemented with the vendor prefix:" Fixes #651.

I'm not sure if I should edit this file directly or not? :)