### PR TITLE
update CSS Display Module Level 3 spec data

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -196,8 +196,8 @@
   },
   "CSS3 Display": {
     "name": "CSS Display Module Level&nbsp;3",
-    "url": "https://drafts.csswg.org/css-display/",
-    "status": "WD"
+    "url": "https://www.w3.org/TR/2018/CR-css-display-3-20180828/",
+    "status": "CR"
   },
   "CSS3 Environment Variables": {
     "name": "CSS Environment Variables Module Level&nbsp;1",


### PR DESCRIPTION
Looks like the status of the CSS Display Module Level 3 has changed https://www.w3.org/TR/2018/CR-css-display-3-20180828/

This PR updates the SpecData.json file to reflect those changes.

Please let me know if there's anything else I should be adding to this PR 👍