### PR TITLE
Delete minversion_header macro

### DIFF
--- a/macros/minversion_header.ejs
+++ b/macros/minversion_header.ejs
@@ -1,1 +1,0 @@
-<span lang='en' class='lang lang-en'>{{wiki.template('Template:Fx_minversion_header', args)}}</span><span lang='*' class='lang lang-*'>{{wiki.template('Template:Fx_minversion_header', args)}}</span>


### PR DESCRIPTION
Not used in pages: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=minversion_header&topic=none

Not used in other macros: https://github.com/mdn/kumascript/search?q=minversion_header