### PR TITLE
Delete XULElem-en macro

### DIFF
--- a/macros/XULElem-en.ejs
+++ b/macros/XULElem-en.ejs
@@ -1,5 +1,0 @@
-<%/*
-
-    for Portuguese
-
-*/%><a href="/en-US/docs/XUL/<%- $0 %>"><%- $0 %></a> (en-US)


### PR DESCRIPTION
Not used on pages: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=XULElem-en&topic=none

Not used in other macros: https://github.com/mdn/kumascript/search?q=XULElem-en