### PR TITLE
Delete ARIAState macro

### DIFF
--- a/macros/ARIAState.ejs
+++ b/macros/ARIAState.ejs
@@ -1,9 +1,0 @@
-<%
-// Inserts a link to the specified ARIA state's specification on the W3C site.
-//
-//  $0 - ARIA state's name
-
-var link = 'http://www.w3.org/TR/wai-aria/states_and_properties#aria-' + $0;
-var linktext = 'aria-' + $0;
-%>
-<a href="<%=link%>" class="external"><code><%=linktext%></code></a>


### PR DESCRIPTION
Not used on pages: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=ARIAState&topic=none

Not used in other macros: https://github.com/mdn/kumascript/search?q=ARIAState