### PR TITLE
Bug 1492018: Prefer `.blockIndicator` for styling block indicators

### DIFF
--- a/macros/B2GOnlyHeader2.ejs
+++ b/macros/B2GOnlyHeader2.ejs
@@ -67,6 +67,6 @@ var secLevel = $0 && $0.toLowerCase() || 'certified';
 if ( !(secLevel in secString) ) secLevel = 'certified';
 
 
-%><div class="warning">
+%><div class="blockIndicator warning">
     <p style="text-align:center"><%- secString[secLevel] %></p>
 </div>

--- a/macros/CommunityBox.ejs
+++ b/macros/CommunityBox.ejs
@@ -190,7 +190,7 @@ if (haveExtra || ircLink.length) {
 }
 
 %>
-<div class="overheadIndicator communitybox" <%- needDir?'dir="' + needDir + '"':''%>>
+<div class="blockIndicator communitybox" <%- needDir?'dir="' + needDir + '"':''%>>
 
     <div class="column-container">
         <h2 id="Join_the_community"><%=headingStr%></h2>

--- a/macros/CompatibilityTable.ejs
+++ b/macros/CompatibilityTable.ejs
@@ -37,7 +37,7 @@ var cta = mdn.localString({
 
 %>
 
-<p class="warning"><%-cta%></p>
+<div class="blockIndicator warning"><%-cta%></div>
 
 <div class="htab">
     <a id="AutoCompatibilityTable" name="AutoCompatibilityTable"></a>

--- a/macros/LegacyAddonsNotice.ejs
+++ b/macros/LegacyAddonsNotice.ejs
@@ -1,7 +1,7 @@
 <%
 
 var output = mdn.localString({
-    'en-US': '<div class="warning">' +
+    'en-US': '<div class="blockIndicator warning">' +
         '<p>Add-ons using the techniques described in this document are considered a legacy technology in Firefox. ' +
         'Don\'t use these techniques to develop new add-ons. Use ' +
         '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead. ' +
@@ -9,7 +9,7 @@ var output = mdn.localString({
         'WebExtensions.</p>' +
         '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a>, no new legacy add-ons will be accepted on addons.mozilla.org (AMO) for desktop Firefox and Firefox for Android.</strong></p>' +
         '<p><strong>Starting from <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a>, only extensions developed using WebExtensions APIs will be supported ' +
-        'on Desktop Firefox and Firefox for Android. </strong></p>' + 
+        'on Desktop Firefox and Firefox for Android. </strong></p>' +
         '<p>Even before Firefox 57, changes coming up in the Firefox platform will break many legacy extensions. ' +
         'These changes include multiprocess Firefox (e10s), sandboxing, and multiple content processes. ' +
         'Legacy extensions that are affected by these changes should migrate to use WebExtensions APIs if they can. ' +
@@ -18,7 +18,7 @@ var output = mdn.localString({
         'resources, migration paths, office hours, and more</a>, '+
         'is available to help developers transition to the new technologies.</p>' +
         '</div>',
-    'zh-CN': '<div class="warning">' +
+    'zh-CN': '<div class="blockIndicator warning">' +
         '<p>我们即将放弃这篇文档中描述的 Firefox 附加组件技术。</p>' +
         '<p>请勿使用下列技术开发新的附加组件。请改用 ' +
         '<a href="/zh-CN/Add-ons/WebExtensions">WebExtension</a> 代替。' +
@@ -30,7 +30,7 @@ var output = mdn.localString({
         'href="/zh-CN/Add-ons/Working_with_multiprocess_Firefox">制作多进程兼容的附加组件</a>的文档，但迁移到 WebExtension 是更加着眼于未来的选择。</p>' +
         '<p>有关的 wiki 页面写有协助开发人员过渡到新技术的<a href="https://wiki.mozilla.org/Add-ons/developer/communication">有关资源、迁移路径、办公时间等信息</a>'+
         '。</div>',
-    'fr': '<div class="warning">' +
+    'fr': '<div class="blockIndicator warning">' +
         '<p>Les modules complémentaires utilisant les techniques décrites dans ce document sont considérés comme une ancienne technologie dans Firefox. ' +
         'N\'utilisez pas ces techniques pour developper de nouveaux modules complémentaires. Utilisez plutôt ' +
         '<a href="/fr/Add-ons/WebExtensions">les WebExtensions</a>. ' +
@@ -38,7 +38,7 @@ var output = mdn.localString({
         'les WebExtensions.</p>' +
         '<p><strong>À partir de <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 53</a>, plus aucun ancien module complémentaire ne sera accepté sur addons.mozilla.org (AMO) pour Firefox pour les ordinateurs et Firefox pour Android.</strong></p>' +
         '<p><strong>À partir de <a href="https://wiki.mozilla.org/RapidRelease/Calendar">Firefox 57</a>, seules les extensions développées avec l\'API des WebExtensions seront prises en charge ' +
-        'sur Firefox pour les ordinateurs et Firefox pour Android. </strong></p>' + 
+        'sur Firefox pour les ordinateurs et Firefox pour Android. </strong></p>' +
         '<p>Même avant Firefox 57, les changements qui arrivent dans la plateforme Firefox vont rendre beaucoup d\'anciennes extensions inutilisables. ' +
         'Ces changements incluent Firefox multiprocessus (e10s), le sandboxing, et les processus de contenu multiple. ' +
         'Les extensions héritées qui sont touchées par ces changements devraient migrer vers l\'API des WebExtensions si possible. ' +

--- a/macros/NoteStart.ejs
+++ b/macros/NoteStart.ejs
@@ -20,4 +20,4 @@ var note = mdn.localString({
     "zh-TW": "註："
 });
 
-%><div class="note"><strong><%-note%></strong>&nbsp;
+%><div class="blockIndicator note"><strong><%-note%></strong>&nbsp;

--- a/macros/SeeCompatTable.ejs
+++ b/macros/SeeCompatTable.ejs
@@ -12,7 +12,6 @@ var str = mdn.localString({
     "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#Browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
 });
 
-
-%><div class="notice overheadIndicator experimental">
+%><div class="blockIndicator notice experimental">
     <p><%-template("ExperimentalBadge", [1])%> <%- str %></p>
 </div>

--- a/macros/SeeCompatTable.ejs
+++ b/macros/SeeCompatTable.ejs
@@ -12,6 +12,6 @@ var str = mdn.localString({
     "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#Browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
 });
 
-%><div class="blockIndicator notice experimental">
+%><div class="blockIndicator experimental indicator-warning">
     <p><%-template("ExperimentalBadge", [1])%> <%- str %></p>
 </div>

--- a/macros/SimpleBadge.ejs
+++ b/macros/SimpleBadge.ejs
@@ -5,4 +5,4 @@
         $1 - Class name for custom style
         $2 - Tooltip text (optional)
 
-*/%><span class="badge <%= $1 %>" title="<%= $2 %>"><span class="badgeText"><%- $0 %></span></span>
+*/%><span class="inlineIndicator <%= $1 %>" title="<%= $2 %>"><span class="badgeText"><%- $0 %></span></span>

--- a/macros/SimpleBanner.ejs
+++ b/macros/SimpleBanner.ejs
@@ -6,7 +6,7 @@
         $2 - Additional text to display
 
 */%>
-<div class="banner <%= $1 %>">
+<div class="blockIndicator <%= $1 %>">
 <div class="bannerHeading"><%- $0 %></div>
 <div class="bannerText"><%- $2 %></div>
 </div>

--- a/macros/TopicBox.ejs
+++ b/macros/TopicBox.ejs
@@ -99,7 +99,7 @@ switch(env.locale) {
 }
 %>
 
-<div class="overheadIndicator communitybox">
+<div class="blockIndicator communitybox">
     <div class="column-container">
         <div class="communitysubhead" id="Help_topic"><%=headingStr%></div>
         <div class="communitycontact"><%-topicDriverStr%></div>

--- a/macros/deprecatedGeneric.ejs
+++ b/macros/deprecatedGeneric.ejs
@@ -35,11 +35,11 @@ if ($1) {
         ver = "CSS ";
     } else if (string.startswith(t, "html")) {
         n = string.trim(string.substr(t, 4));
-        
-        var N = (n[0] === "4") ? "" : n; 
-        
+
+        var N = (n[0] === "4") ? "" : n;
+
         ver = "HTML";
-        
+
         if (string.length(N) > 0) {
             if(wiki.pageExists('/' + lang + '/docs/HTML/HTML' + N)) {
                 link = '/' + lang + '/docs/HTML/HTML' + N;
@@ -61,7 +61,7 @@ if ($1) {
         ver = "Gecko ";
         tip = template("geckoRelease", [n]);
     }
-    
+
     n = string.trim(n);
     ver = (string.length(n) > 0) ? ver + n : "";
 }
@@ -136,7 +136,7 @@ switch($0) {
         break;
     case 'header':
         if (tip.length) { str = str + " " + tip; }
-        %><div class="overheadIndicator deprecated deprecatedHeader">
+        %><div class="blockIndicator deprecated deprecatedHeader">
             <p><strong><%-template("ObsoleteBadge", [1])%> <%-str%></strong><br/><%-str_desc%></p>
         </div><%
         break;

--- a/macros/draft.ejs
+++ b/macros/draft.ejs
@@ -22,9 +22,9 @@ var s_details = '';
 
 if ($0) {
     s_details = $0;
-    
+
     var pattern = /~~(\w+)(\W)/ig;
-    
+
     s_details = "<em>" + s_details.replace(pattern, function replacer(match, username, endchar) {
         return "<a href='https://developer.mozilla.org/profiles/" + username + "'>" + username + "</a>" + endchar;
     }) + "</em>";
@@ -71,7 +71,7 @@ switch (env.locale) {
         s_draft = 'Черновик';
         s_not_complete = 'Эта страница не завершена.';
 }
-%><div class="overheadIndicator draft">
+%><div class="blockIndicator draft">
     <p><strong><%=s_draft%></strong><br/>
     <%=s_not_complete%></p>
     <%-s_details%>

--- a/macros/es7.ejs
+++ b/macros/es7.ejs
@@ -18,6 +18,6 @@ var s = mdn.localString({
 });
 %>
 
-<div class="overheadIndicator" style="background:#9CF49C;">
+<div class="blockIndicator" style="background:#9CF49C;">
   <p><%- s %></p>
 </div>

--- a/macros/es7.ejs
+++ b/macros/es7.ejs
@@ -18,6 +18,6 @@ var s = mdn.localString({
 });
 %>
 
-<div class="blockIndicator" style="background:#9CF49C;">
+<div class="blockIndicator esHarmony">
   <p><%- s %></p>
 </div>

--- a/macros/es7.ejs
+++ b/macros/es7.ejs
@@ -18,6 +18,6 @@ var s = mdn.localString({
 });
 %>
 
-<div class="blockIndicator esHarmony">
+<div class="blockIndicator experimental indicator-warning">
   <p><%- s %></p>
 </div>

--- a/macros/gecko_minversion_note.ejs
+++ b/macros/gecko_minversion_note.ejs
@@ -19,7 +19,7 @@ switch(lang) {
 }
 %>
 
-<div class="blockIndicator geckoMinVer standardNote standardNoteBlock">
+<div class="blockIndicator geckoMinVer standardNote">
   <div style="text-align:center; font-weight:bold; padding-bottom: 0.5em;"><%- str %></div>
   <div><%- $1 %></div>
 </div>

--- a/macros/jsOverrides.ejs
+++ b/macros/jsOverrides.ejs
@@ -1,4 +1,4 @@
-<div class="inheritsbox template-jsOverrides" style="border: 5px solid #D1D1FF; background: #f5f5ff; padding: 2px 10px; margin: 25px 0; overflow: hidden;">
+<div class="blockIndicator inheritsbox template-jsOverrides" style="border: 5px solid #D1D1FF; background: #f5f5ff; padding: 2px 10px; margin: 25px 0; overflow: hidden;">
 <%
 /**
  * Given an object and a list of properties or

--- a/macros/jsOverrides.ejs
+++ b/macros/jsOverrides.ejs
@@ -1,4 +1,4 @@
-<div class="blockIndicator inheritsbox template-jsOverrides" style="border: 5px solid #D1D1FF; background: #f5f5ff; padding: 2px 10px; margin: 25px 0; overflow: hidden;">
+<div class="blockIndicator inheritsbox template-jsOverrides">
 <%
 /**
  * Given an object and a list of properties or

--- a/macros/jsapi_maxversion_inline.ejs
+++ b/macros/jsapi_maxversion_inline.ejs
@@ -3,7 +3,7 @@
 /* get the page language */
 var lang = env.locale;
 var str = "";
- 
+
 switch(lang) {
     case "ja":
         str = "JSAPI " + $0 + " まで";
@@ -17,4 +17,4 @@ switch(lang) {
 }
 
 
-%><span class="standardNoteInline"><%=str%></span>
+%><span class="inlineIndicator standardNote"><%=str%></span>

--- a/macros/jsapi_minversion_header.ejs
+++ b/macros/jsapi_minversion_header.ejs
@@ -1,10 +1,10 @@
 <%
 /* one parameter: SpiderMonkey version */
- 
+
 /* get the page language */
 var lang = env.locale;
 var link = '';
- 
+
 /* check if page exists, English for fall back */
 if(wiki.pageExists(lang + '/docs/SpiderMonkey/' + $0)) {
     link = web.link(wiki.uri(lang + '/docs/SpiderMonkey/' + $0), 'SpiderMonkey ' + $0);
@@ -26,6 +26,6 @@ switch(lang) {
 }
 
 
-%><div class="overheadIndicator jsMinVer jsMinVerHeader">
+%><div class="blockIndicator jsMinVer jsMinVerHeader">
     <p><%- str %></p>
 </div>

--- a/macros/minversionGeneric.ejs
+++ b/macros/minversionGeneric.ejs
@@ -76,18 +76,18 @@ switch(lang) {
         break;
     default: break;
 }
- 
+
 switch($0) {
     case 'inline':
-        %><span class="inlineIndicator standardNote standardNoteInline"><%=newIn%><%- web.link(wiki.uri(link), productVersion) %></span><%
+        %><span class="inlineIndicator standardNote"><%=newIn%><%- web.link(wiki.uri(link), productVersion) %></span><%
         break;
     case 'header':
-        %><div class="overheadIndicator standardNote standardNoteBlock">
+        %><div class="blockIndicator standardNote">
 <p><%-text%></p>
 </div><%
         break;
     case 'note':
-        %><div class="blockIndicator standardNote standardNoteBlock">
+        %><div class="blockIndicator standardNote">
     <p><%- web.link(wiki.uri(link), note) %></p>
     <p style="font-weight:400;"><%-$3%></p>
 </div><%

--- a/macros/non-standardGeneric.ejs
+++ b/macros/non-standardGeneric.ejs
@@ -40,7 +40,7 @@ for (i = 0 ; i <= env.tags.length-1 ; i++) {
     if (env.tags[i] == "Firefox OS") {
       fxosCheck = 1;
       break;        // we can break out now, to save some time
-    } 
+    }
 }
 
 if (fxosCheck == 0) {
@@ -50,7 +50,7 @@ switch($0) {
     %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
     break;
   case 'header':
-    %><div class="overheadIndicator nonStandard nonStandardHeader">
+    %><div class="blockIndicator nonStandard nonStandardHeader">
       <p><strong><%-template("NonStandardBadge", [1])%> <%-str_inline%></strong><br/>
       <%-str_long%></p>
       </div><%
@@ -64,7 +64,7 @@ switch($0) {
     %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
     break;
   case 'header':
-    %><div class="overheadIndicator nonStandard nonStandardHeader">
+    %><div class="blockIndicator nonStandard nonStandardHeader">
       <p><strong><%-template("NonStandardBadge", [1])%> <%-str_inline%></strong><br/>
       <%-str_fxos_long%></p>
       </div><%

--- a/macros/obsoleteGeneric.ejs
+++ b/macros/obsoleteGeneric.ejs
@@ -16,7 +16,7 @@ var tip = "";
 if ($1) {
     var t = string.tolower($1);
     var n = "";
-    
+
     if (string.startswith(t, "jsapi")) {
         n = string.trim(string.substr(t, 5));
         ver = "JSAPI ";
@@ -54,7 +54,7 @@ if ($1) {
         ver = "Gecko ";
         tip = template('geckoRelease', [n]);
     }
-    
+
     n = string.trim(n);
 
     ver = (string.length(n) > 0) ? ver + n: "";
@@ -119,7 +119,7 @@ switch($0) {
         break;
     case 'header':
         if (string.length(tip)) { str = str + " " + tip; }
-        %><div class="overheadIndicator obsolete obsoleteHeader"><p><strong><%-template("ObsoleteBadge", [1])%> <%-str%></strong><br/><%-str_desc%></p></div><%
+        %><div class="blockIndicator obsolete obsoleteHeader"><p><strong><%-template("ObsoleteBadge", [1])%> <%-str%></strong><br/><%-str_desc%></p></div><%
         break;
     case 'method':
         if (string.length(tip)) { str = str + " " + tip; }

--- a/macros/secureContextGeneric.ejs
+++ b/macros/secureContextGeneric.ejs
@@ -26,7 +26,7 @@ var str_desc = mdn.localString({
 if($0 === 'inline') {
   result = "<span class='inlineIndicator secureContexts' title='" + str_tooltip + "'>" + str_title + "</span>";
 } else if($0 === 'header') {
-  result = "<div class='overheadIndicator secureContexts'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
+  result = "<div class='blockIndicator secureContexts'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
 }
 %>
 

--- a/macros/unimplementedGeneric.ejs
+++ b/macros/unimplementedGeneric.ejs
@@ -63,7 +63,7 @@ switch($0) {
     %><span class="inlineIndicator unimplemented unimplementedInline"><%-str%></span><%
     break;
   case 'header':
-    %><div class="overheadIndicator unimplemented unimplementedHeader">
+    %><div class="blockIndicator unimplemented unimplementedHeader">
       <p><%-str%></p>
       </div><%
     break;

--- a/macros/warning.ejs
+++ b/macros/warning.ejs
@@ -15,6 +15,6 @@ var s_warning = mdn.localString({
     "zh-CN": "Warning:"
 });
 
-%><div class="warning warningHeader">
+%><div class="blockIndicator warning">
     <p><strong><%=s_warning%></strong> <%- $0 %></p>
 </div>

--- a/tests/macros/test-draft.js
+++ b/tests/macros/test-draft.js
@@ -14,89 +14,89 @@ describeMacro('draft', function () {
     itMacro('No arguments (en-US)', function (macro) {
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (es)', function (macro) {
         macro.ctx.env.locale = 'es';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (fr)', function (macro) {
         macro.ctx.env.locale = 'fr';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (ja)', function (macro) {
         macro.ctx.env.locale = 'ja';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (ko)', function (macro) {
         macro.ctx.env.locale = 'ko';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (pl)', function (macro) {
         macro.ctx.env.locale = 'pl';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (zh-CN)', function (macro) {
         macro.ctx.env.locale = 'zh-CN';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (zh-TW)', function (macro) {
         macro.ctx.env.locale = 'zh-TW';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (pt-PT)', function (macro) {
         macro.ctx.env.locale = 'pt-PT';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (pt-BR)', function (macro) {
         macro.ctx.env.locale = 'pt-BR';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
         );
     });
     itMacro('No arguments (ru)', function (macro) {
         macro.ctx.env.locale = 'ru';
         return assert.eventually.equal(
             macro.call(),
-            `<div class="overheadIndicator draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
         );
     });
     itMacro('One argument (en-US)', function (macro) {
         return assert.eventually.equal(
             macro.call('The reason is shrouded in mystery (escattone).'),
-            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
         );
     });
     itMacro('One argument with embedded user profile (en-US)', function (macro) {
         return assert.eventually.equal(
             macro.call('The reason is shrouded in mystery (~~escattone).'),
-            `<div class="overheadIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (<a href=\'https://developer.mozilla.org/profiles/escattone\'>escattone</a>).</em>\n</div>`
+            `<div class="blockIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (<a href=\'https://developer.mozilla.org/profiles/escattone\'>escattone</a>).</em>\n</div>`
         );
     });
 });


### PR DESCRIPTION
See [bug 1492018](https://bugzil.la/1492018) for details.

Depends on https://github.com/mozilla/kuma/pull/4979 and ~~https://github.com/mozilla/kuma/pull/4962~~.

review?(@Elchi3, @jwhitlock, @wbamberg, @escattone)