### PR TITLE
Delete a11yRelationRef macro

### DIFF
--- a/macros/a11yRelationRef.ejs
+++ b/macros/a11yRelationRef.ejs
@@ -1,6 +1,0 @@
-<%
-/* Used in: en/Accessibility/AT-APIs/IA2/Relations */
-var lang = env.locale;
-var href = '/' + lang + '/docs/Web/Accessibility/AT-APIs/Gecko/Relations#' + $0;
-%>
-<a href="<%=href%>"><%=$0%></a>


### PR DESCRIPTION
Not used on pages: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=a11yRelationRef&topic=none

Not used in other macros: https://github.com/mdn/kumascript/search?q=a11yRelationRef