### PR TITLE
bug 1483072: set TO_REVISION_HASH from repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,8 @@ node {
                     withEnv(["KUMA_IMAGE_TAG=${kuma_image_tag}"]) {
                         dir('infra/apps/mdn/mdn-aws/k8s') {
                             def current_revision_hash = utils.get_revision_hash()
-                            withEnv(["FROM_REVISION_HASH=${current_revision_hash}"]) {
+                            withEnv(["TO_REVISION_HASH=${env.GIT_COMMIT}",
+                                     "FROM_REVISION_HASH=${current_revision_hash}"]) {
                                 // Start a rolling update of the Kumascript-based deployments.
                                 utils.rollout()
                                 // Monitor the rollout until it has completed.


### PR DESCRIPTION
Set `TO_REVISION_HASH` to the latest commit hash of the `kumascript` repo.