### PR TITLE
Add trailing slashes to Media Capabilities, XMLHttpRequest, and Compatibility spec URLs

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -81,7 +81,7 @@
   },
   "Compat": {
     "name": "Compatibility Standard",
-    "url": "https://compat.spec.whatwg.org",
+    "url": "https://compat.spec.whatwg.org/",
     "status": "Living"
   },
   "Compositing": {
@@ -901,7 +901,7 @@
   },
   "Media Capabilities": {
     "name": "Media Capabilities",
-    "url": "https://wicg.github.io/media-capabilities",
+    "url": "https://wicg.github.io/media-capabilities/",
     "status": "Draft"
   },
   "Media Capture": {
@@ -1571,7 +1571,7 @@
   },
   "XMLHttpRequest": {
     "name": "XMLHttpRequest",
-    "url": "https://xhr.spec.whatwg.org",
+    "url": "https://xhr.spec.whatwg.org/",
     "status": "Living"
   },
   "XPath1": {


### PR DESCRIPTION
This change adds a trailing slash to the `url` values for the Media Capabilities, XMLHttpRequest, and Compatibility specs in the SpecData.json file — making the formatting of the `url` values for those specs consistent with the formatting of other specs’ `url` values, which all have trailing slashes.

Without this change, MDN articles end up with URLs in their Specifications sections that look like this:

https://compat.spec.whatwg.org#the-webkit-text-stroke-color

...which when navigated to, redirects to this:

https://compat.spec.whatwg.org/#the-webkit-text-stroke-color

So, adding the trailing slash to the `url` value in the SpecData.json file eliminates the need for those redirects to happen.