### PR TITLE
Update SpecData.json spec URL for Geolocation API

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -771,7 +771,7 @@
   },
   "Geolocation": {
     "name": "Geolocation API",
-    "url": "https://dev.w3.org/geo/api/spec-source.html",
+    "url": "https://www.w3.org/TR/geolocation-API",
     "status": "REC"
   },
   "Geometry Interfaces": {


### PR DESCRIPTION
This change makes SpecData.json use https://www.w3.org/TR/geolocation-API as the URL for the Geolocation API spec. Without this change, SpecData.json used the URL https://dev.w3.org/geo/api/spec-source.html — but that URL now redirects to https://w3c.github.io/geolocation-api/, which lacks some (or most) anchors used in the Specifications tables in MDN articles on the Geolocation API.

But https://www.w3.org/TR/geolocation-API has the same anchors as https://dev.w3.org/geo/api/spec-source.html did. So in order to prevent all those URLs from breaking, it’s better to update the URL to https://www.w3.org/TR/geolocation-API in this particular case, rather than https://w3c.github.io/geolocation-api/