### PR TITLE
Change SpecData.json CSS Scoping spec URL to https

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -506,7 +506,7 @@
   },
   "CSS Scope": {
     "name": "CSS Scoping Module Level&nbsp;1",
-    "url": "http://drafts.csswg.org/css-scoping/",
+    "url": "https://drafts.csswg.org/css-scoping/",
     "status": "WD"
   },
   "CSS Scrollbars": {


### PR DESCRIPTION
This change makes the SpecData.json spec URL for the CSS Scoping spec use `https` instead of `http` — bringing it into consistency with the URLs for other specs in SpecData.json, all of which now use `https`.