### PR TITLE
Delete Ifconstant macro

### DIFF
--- a/macros/Ifconstant.ejs
+++ b/macros/Ifconstant.ejs
@@ -1,1 +1,0 @@
-<%- template('interfaceconstants', [$0, $1]) %>


### PR DESCRIPTION
Not used in pages: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=Ifconstant&topic=none

Not used in other macros: https://github.com/mdn/kumascript/search?utf8=%E2%9C%93&q=Ifconstant&type=

Another day, another macro :hocho: 