### PR TITLE
Fix SpecData.json DeviceOrientation URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -576,7 +576,7 @@
   },
   "Device Orientation": {
     "name": "Device Orientation Events",
-    "url": "https://w3c.github.io/deviceorientation/spec-source-orientation.html",
+    "url": "https://w3c.github.io/deviceorientation/",
     "status": "WD"
   },
   "DOM Parsing": {


### PR DESCRIPTION
This change fixes the SpecData.json URL for the DeviceOrientation spec.  There’s no spec any longer at https://w3c.github.io/deviceorientation/spec-source-orientation.html.  That page just has a link to https://w3c.github.io/deviceorientation