### PR TITLE
Fix SpecData.json Input Events Level 2 URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -866,7 +866,7 @@
   },
   "InputEvents2": {
     "name": "Input Events Level 2",
-    "url": "https://w3c.github.io/input-events/index.html",
+    "url": "https://w3c.github.io/input-events/",
     "status": "WD"
   },
   "IntersectionObserver": {


### PR DESCRIPTION
This change makes the SpecData.json data for the Input Events Level 2 spec use https://w3c.github.io/input-events/ as the spec URL. It removes the unnecessary `index.html` part of the URL path.