### PR TITLE
Fix SpecData.json Static Range URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1161,7 +1161,7 @@
   },
   "Static Range": {
     "name": "Static Range",
-    "url": "https://w3c.github.io/staticrange/index.html",
+    "url": "https://w3c.github.io/staticrange/",
     "status": "ED"
   },
   "Storage": {


### PR DESCRIPTION
This change makes the SpecData.json data for the Static Range spec use https://w3c.github.io/staticrange/ as the spec URL. It removes the unnecessary `index.html` part of the URL path.