### PR TITLE
Fix SpecData.json WebDriver URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1431,7 +1431,7 @@
   },
   "WebDriver": {
     "name": "WebDriver",
-    "url": "https://w3c.github.io/webdriver/webdriver-spec.html",
+    "url": "https://w3c.github.io/webdriver/",
     "status": "REC"
   },
   "WEBGL_color_buffer_float": {


### PR DESCRIPTION
This change fixes the SpecData.json URL for the WebDriver spec.
There’s no spec any longer at
https://w3c.github.io/webdriver/webdriver-spec.html.
That page just redirects to https://w3c.github.io/webdriver/