### PR TITLE
Drop redundant SpecData.json 'Web Background Sync'

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1314,11 +1314,6 @@
     "url": "https://webaudio.github.io/web-audio-api/",
     "status": "WD"
   },
-  "Web Background Sync": {
-    "name": "Web Background Synchronization",
-    "url": "https://wicg.github.io/BackgroundSync/spec/",
-    "status": "Living"
-  },
   "Web Bluetooth": {
     "name": "Web Bluetooth",
     "url": "https://webbluetoothcg.github.io/web-bluetooth/",


### PR DESCRIPTION
This change drops the `Web Background Sync` key from SpecData.json, because it’s redundant with the `Background Sync`, which has the same `url`: https://wicg.github.io/BackgroundSync/spec/.

As far as I can see, all existing MDN articles which refer to that spec do so using the `Background Sync` key and not the `Web Background Sync` key — so the `Web Background Sync` can be dropped without breaking anything.