### PR TITLE
Delete jsapi_compiled_script_example_pointer macro

### DIFF
--- a/macros/jsapi_compiled_script_example_pointer.ejs
+++ b/macros/jsapi_compiled_script_example_pointer.ejs
@@ -1,7 +1,0 @@
-<%
-var lang = env.locale;
-var str = 'The <a href="/' + lang + '/docs/JSAPI_User_Guide#Compiled_scripts">JSAPI User Guide</a> contains example code using compiled scripts.';
-
-
-
-%><%-str%>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=jsapi_compiled_script_example_pointer&topic=none

https://github.com/mdn/kumascript/search?utf8=%E2%9C%93&q=jsapi_compiled_script_example_pointer&type=