### PR TITLE
Update SVG2 spec data URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1211,7 +1211,7 @@
   },
   "SVG2": {
     "name": "Scalable Vector Graphics (SVG) 2",
-    "url": "https://svgwg.org/svg2-draft/",
+    "url": "https://www.w3.org/TR/2018/CR-SVG2-20181004/",
     "status": "CR"
   },
   "Telephony API": {


### PR DESCRIPTION
PR based on that W3C article: https://www.w3.org/blog/news/archives/7343