### PR TITLE
bug 1488884: Update eventref for <details>

### DIFF
--- a/macros/eventref.ejs
+++ b/macros/eventref.ejs
@@ -20,7 +20,7 @@ if (slug) {
     output += '<li><strong><a href="' +  EventHref + '">Events</a></strong></li>';
 
     function buildEventList(name, events, open) {
-        var openstr = open ? ' data-default-state="open"' : '';
+        var openstr = open ? ' open' : '';
         var result = '<li class="toggle"><details ' + openstr + '><summary>' + name + '</summary><ol>';
         for (var i = 0; i < events.length; i++) {
             result += '<li><a href="' + EventHref + '/' + events[i] + '"><code>' + events[i] + '</code></a></li>';

--- a/macros/eventref.ejs
+++ b/macros/eventref.ejs
@@ -10,53 +10,53 @@ var EventHref = '/' + locale + '/docs/Web/Events';
 var output = "";
 // slug is not available in preview mode.
 if (slug) {
-    
-var groups = string.deserialize(template("GroupData"))[0];
-var event = slug.replace('Web/Events/','').split('/')[0];
+
+    var groups = string.deserialize(template("GroupData"))[0];
+    var event = slug.replace('Web/Events/','').split('/')[0];
 
 
-// output
-output = '<section class="Quick_links" id="Quick_Links"><ol>';
-output += '<li><strong><a href="' +  EventHref + '">Events</a></strong></li>';
+    // output
+    output = '<section class="Quick_links" id="Quick_Links"><ol>';
+    output += '<li><strong><a href="' +  EventHref + '">Events</a></strong></li>';
 
-function buildEventList(name, events, open) {
-  var openstr = open ? ' data-default-state="open"' : '';
-  var result = '<li class="toggle"><details ' + openstr + '><summary>' + name + '</summary><ol>';
-  for (var i = 0; i < events.length; i++) {
-    result += '<li><a href="' + EventHref + '/' + events[i] + '"><code>' + events[i] + '</code></a></li>';
-  }
-  result += '</ol></details></li>';
-  return result;
-}
-
-var foundGroup = false;
-var collectedGroups = []
-for (g in groups) {
-    var aGroup = groups[g];
-    if (aGroup.events.indexOf(event) !== -1) {
-        foundGroup = true;
-        collectedGroups.push({name: g, events: aGroup.events.sort()});
+    function buildEventList(name, events, open) {
+        var openstr = open ? ' data-default-state="open"' : '';
+        var result = '<li class="toggle"><details ' + openstr + '><summary>' + name + '</summary><ol>';
+        for (var i = 0; i < events.length; i++) {
+            result += '<li><a href="' + EventHref + '/' + events[i] + '"><code>' + events[i] + '</code></a></li>';
+        }
+        result += '</ol></details></li>';
+        return result;
     }
-}
 
-if (collectedGroups.length === 1) {
-    output += buildEventList(collectedGroups[0].name.replace(/events/i, '') + ' events', collectedGroups[0].events, true);
-} else if (collectedGroups.length > 1) {
-    for (x in collectedGroups) {
-        output += buildEventList(collectedGroups[x].name.replace(/events/i, '') + ' events', collectedGroups[x].events, false);
-    }
-}
-
-if (!foundGroup) {
+    var foundGroup = false;
+    var collectedGroups = []
     for (g in groups) {
         var aGroup = groups[g];
-        if (aGroup.events.length > 0) {
-          output += buildEventList(g.replace(/events/i, '') + ' events', aGroup.events.sort(), false);
+        if (aGroup.events.indexOf(event) !== -1) {
+            foundGroup = true;
+            collectedGroups.push({name: g, events: aGroup.events.sort()});
         }
     }
-}
 
-output += '</ol></section>';
+    if (collectedGroups.length === 1) {
+        output += buildEventList(collectedGroups[0].name.replace(/events/i, '') + ' events', collectedGroups[0].events, true);
+    } else if (collectedGroups.length > 1) {
+        for (x in collectedGroups) {
+            output += buildEventList(collectedGroups[x].name.replace(/events/i, '') + ' events', collectedGroups[x].events, false);
+        }
+    }
+
+    if (!foundGroup) {
+        for (g in groups) {
+            var aGroup = groups[g];
+            if (aGroup.events.length > 0) {
+                output += buildEventList(g.replace(/events/i, '') + ' events', aGroup.events.sort(), false);
+            }
+        }
+    }
+
+    output += '</ol></section>';
 }
 %>
 

--- a/macros/eventref.ejs
+++ b/macros/eventref.ejs
@@ -40,10 +40,10 @@ if (slug) {
     }
 
     if (collectedGroups.length === 1) {
-        output += buildEventList(collectedGroups[0].name.replace(/events/i, '') + ' events', collectedGroups[0].events, true);
+        output += buildEventList(collectedGroups[0].name.replace(/ events/i, '') + ' events', collectedGroups[0].events, true);
     } else if (collectedGroups.length > 1) {
         for (x in collectedGroups) {
-            output += buildEventList(collectedGroups[x].name.replace(/events/i, '') + ' events', collectedGroups[x].events, false);
+            output += buildEventList(collectedGroups[x].name.replace(/ events/i, '') + ' events', collectedGroups[x].events, false);
         }
     }
 
@@ -51,7 +51,7 @@ if (slug) {
         for (g in groups) {
             var aGroup = groups[g];
             if (aGroup.events.length > 0) {
-                output += buildEventList(g.replace(/events/i, '') + ' events', aGroup.events.sort(), false);
+                output += buildEventList(g.replace(/ events/i, '') + ' events', aGroup.events.sort(), false);
             }
         }
     }

--- a/tests/macros/test-eventref.js
+++ b/tests/macros/test-eventref.js
@@ -1,0 +1,59 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+const utils = require('./utils'),
+      chai = require('chai'),
+      chaiAsPromised = require('chai-as-promised'),
+      jsdom = require('jsdom'),
+      assert = chai.assert,
+      itMacro = utils.itMacro,
+      describeMacro = utils.describeMacro;
+
+chai.use(chaiAsPromised);
+
+function checkSidebarDom(dom, locale, expected_summary, found_one) {
+    let section = dom.querySelector('section');
+    assert(section.classList.contains('Quick_links'), 'Section does not contain Quick_links class');
+
+    let summaries = dom.querySelectorAll('summary');
+    assert.equal(summaries[0].textContent, expected_summary);
+
+    let details = dom.querySelectorAll('details');
+    if (found_one) {
+        assert.equal(details.length, 1);
+        assert.isTrue(details[0].hasAttribute('data-default-state'));
+    } else {
+        assert.isAbove(details.length, 1);
+        for (var detail of details.values()) {
+            assert.isFalse(detail.hasAttribute('data-default-state'));
+        }
+    }
+}
+
+describeMacro('eventref', function () {
+
+    itMacro('No output in preview', function (macro) {
+        macro.ctx.env.slug = '';
+        macro.ctx.env.locale = 'en-US';
+        return assert.eventually.equal(macro.call(), '');
+    });
+
+
+    itMacro('Creates a sidebar for an event in one group in en-US locale', function (macro) {
+        macro.ctx.env.slug = 'Web/Events/datachannel';
+        macro.ctx.env.locale = 'en-US';
+        return macro.call().then(function(result) {
+            let dom = jsdom.JSDOM.fragment(result);
+            checkSidebarDom(dom, 'en-US', 'WebRTC events', true);
+        });
+    });
+
+    itMacro('Creates a sidebar for an event in multiple groups in fr locale', function (macro) {
+        macro.ctx.env.slug = 'Web/Events/click';
+        macro.ctx.env.locale = 'fr';
+        return macro.call().then(function(result) {
+            let dom = jsdom.JSDOM.fragment(result);
+            checkSidebarDom(dom, 'fr', 'DOM  events', false);
+        });
+    });
+
+});

--- a/tests/macros/test-eventref.js
+++ b/tests/macros/test-eventref.js
@@ -20,11 +20,11 @@ function checkSidebarDom(dom, locale, expected_summary, found_one) {
     let details = dom.querySelectorAll('details');
     if (found_one) {
         assert.equal(details.length, 1);
-        assert.isTrue(details[0].hasAttribute('data-default-state'));
+        assert.isTrue(details[0].hasAttribute('open'));
     } else {
         assert.isAbove(details.length, 1);
         for (var detail of details.values()) {
-            assert.isFalse(detail.hasAttribute('data-default-state'));
+            assert.isFalse(detail.hasAttribute('open'));
         }
     }
 }

--- a/tests/macros/test-eventref.js
+++ b/tests/macros/test-eventref.js
@@ -52,7 +52,7 @@ describeMacro('eventref', function () {
         macro.ctx.env.locale = 'fr';
         return macro.call().then(function(result) {
             let dom = jsdom.JSDOM.fragment(result);
-            checkSidebarDom(dom, 'fr', 'DOM  events', false);
+            checkSidebarDom(dom, 'fr', 'DOM events', false);
         });
     });
 


### PR DESCRIPTION
Add some tests for the eventref.ejs macro, and then switch it to use the ``open`` attribute rather than ``data-default-state="open"``.  Follow-on work, as seen in https://github.com/mdn/kumascript/pull/789#discussion_r221324136

This includes re-indenting ``eventref.ejs``, I suggest [ignoring whitespace](https://github.com/mdn/kumascript/pull/924/files?utf8=%E2%9C%93&diff=split&w=1).