### PR TITLE
Define WebDriver as living

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1452,7 +1452,7 @@
   "WebDriver": {
     "name": "WebDriver",
     "url": "https://w3c.github.io/webdriver/",
-    "status": "REC"
+    "status": "Living"
   },
   "WEBGL_color_buffer_float": {
     "name": "WEBGL_color_buffer_float",


### PR DESCRIPTION
WebDriver exists in two versions:

1. as a W3C recommendation published at https://www.w3.org/TR/webdriver/, also known as _WebDriver Level 1_,
2. and as a living document published at https://w3c.github.io/webdriver/, known as _WebDriver_, which is what browser vendors implement.