### PR TITLE
bug 1483072: post-cutover Kumascript clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-IMAGE_PREFIX ?= quay.io/mozmar
+IMAGE_PREFIX ?= mdnwebdocs
 IMAGE_NAME ?= kumascript
 IMAGE ?= ${IMAGE_PREFIX}/${IMAGE_NAME}\:${VERSION}
 MOUNT_DIR ?= $(shell pwd)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ more before you run your local development version of MDN.
   look something like this:
 
       Successfully built 48ddc354b3f4
-      Successfully tagged quay.io/mozmar/kumascript:latest
+      Successfully tagged mdnwebdocs/kumascript:latest
 
 * Test out the changes, and repeat building the image if unhappy:
 
@@ -114,8 +114,8 @@ more before you run your local development version of MDN.
   development environment, or you can remove it. To remove your local built
   image, run one of the following:
 
-      docker rmi quay.io/mozmar/kumascript:latest  # Remove without replacing
-      docker pull quay.io/mozmar/kumascript:latest # or replace with server's version
+      docker rmi mdnwebdocs/kumascript:latest  # Remove without replacing
+      docker pull mdnwebdocs/kumascript:latest # or replace with server's version
 
 ## Setup (Docker)
 

--- a/tests/macros/test-LiveSampleURL.js
+++ b/tests/macros/test-LiveSampleURL.js
@@ -30,12 +30,12 @@ describeMacro('LiveSampleURL', function () {
         );
     });
     itMacro('Staging settings', function (macro) {
-        macro.ctx.env.live_samples = {'base_url': 'https://stage-files.mdn.moz.works'};
+        macro.ctx.env.live_samples = {'base_url': 'https://files-stage.mdn.mozit.cloud'};
         macro.ctx.env.url = 'https://developer.allizom.org/en-US/docs/Web/CSS/background-color';
         macro.ctx.env.revision_id = 1291055;
         return assert.eventually.equal(
             macro.call('Examples'),
-            'https://stage-files.mdn.moz.works/en-US/docs/Web/CSS/background-color$samples/Examples?revision=1291055'
+            'https://files-stage.mdn.mozit.cloud/en-US/docs/Web/CSS/background-color$samples/Examples?revision=1291055'
         );
     });
     itMacro('Development default settings', function (macro) {


### PR DESCRIPTION
The title says "post-cutover" cleanup, but there's nothing in this PR that has to wait until after the cut-over. The only condition is that this depends on https://github.com/mozilla/kuma/pull/5044 being merged for the tests to pass.
- change the default `IMAGE_PREFIX` within the `Makefile`
-  just use the default `IMAGE_PREFIX` within the `Jenkinsfile`
- update all relevant files to reflect that `quay.io/mozmar` has become `mdnwebdocs`
- anticipates the upcoming cut-over from MozMEAO to MozIT by updating a macro test to reflect that the stage attachments domain has changed from `stage-files.mdn.moz.works` to `files-stage.mdn.mozit.cloud` (this doesn't really matter, but it's just to be thorough)