### PR TITLE
Update SpecData XPath 2.0 URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1596,7 +1596,7 @@
   },
   "XPath2": {
     "name": "XPath 2.0",
-    "url": "https://www.w3.org/TR/xpath-20/",
+    "url": "https://www.w3.org/TR/xpath20/",
     "status": "REC"
   },
   "XPath3": {


### PR DESCRIPTION
This change makes SpecData.json use https://www.w3.org/TR/xpath20/ as the URL for the XPath 2.0 spec, because https://www.w3.org/TR/xpath-20/ now redirects to that URL.