### PR TITLE
Update SpecData CSS Logical Properties URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -471,7 +471,7 @@
   },
   "CSS Logical Properties": {
     "name": "CSS Logical Properties and Values Level&nbsp;1",
-    "url": "https://drafts.csswg.org/css-logical-props/",
+    "url": "https://drafts.csswg.org/css-logical/",
     "status": "ED"
   },
   "CSS Masks": {


### PR DESCRIPTION
This change makes https://drafts.csswg.org/css-logical/ be used by SpecData.json as the URL for the CSS Logical Properties and Values spec, because https://drafts.csswg.org/css-logical-props/ now redirects to that URL.