### PR TITLE
GroupData: Update Fullscreen API to match current spec

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -622,6 +622,7 @@
             "overview":   [ "Fullscreen API" ],
             "guides":     [],
             "interfaces": [],
+            "dictionaries": [ "FullscreenOptions" ],
             "methods":    [ "Document.exitFullscreen()",
                             "Element.requestFullscreen()" ],
             "properties": [ "Document.fullscreen",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -620,13 +620,16 @@
         },
         "Fullscreen API": {
             "overview":   [ "Fullscreen API" ],
+            "guides":     [],
             "interfaces": [],
             "methods":    [ "Document.exitFullscreen()",
                             "Element.requestFullscreen()" ],
             "properties": [ "Document.fullscreen",
-                            "Document.fullscreenElement",
+                            "DocumentOrShadowRoot.fullscreenElement",
                             "Document.onfullscreenchange",
-                            "Document.onfullscreenerror" ],
+                            "Document.onfullscreenerror",
+                            "Element.onfullscreenchange",
+                            "Element.onfullscreenerror" ],
             "events":     [ "fullscreenchange",
                             "fullscreenerror" ]
         },


### PR DESCRIPTION
Updated per spec at: https://fullscreen.spec.whatwg.org/#api

Part of Q4S2 work.