### PR TITLE
Fix {{Non‑standard_Header}} in preview mode

### DIFF
--- a/macros/Non-standardGeneric.ejs
+++ b/macros/Non-standardGeneric.ejs
@@ -40,7 +40,7 @@ if (env.tags && env.tags.includes("Firefox OS")) {
 
 switch($0) {
     case 'inline':
-        %><span class="inlineIndicator nonStandard"><%-str_inline%></span><%
+        %><%-await template("NonStandardBadge")%><%
         break;
     case 'header':
         %><div class="blockIndicator nonStandard">

--- a/macros/Non-standardGeneric.ejs
+++ b/macros/Non-standardGeneric.ejs
@@ -4,73 +4,50 @@
 */
 
 var str_inline = mdn.localString({
-  "en-US": "Non-standard",
-  "de":    "Kein Standard",
-  "es":    "No estándar",
-  "fr":    "Non standard",
-  "ja":    "非標準",
-  "pl":    "Niestandardowy",
-  "ru":    "Не стандартно",
-  "zh-CN": "非标准",
-  "zh-TW": "非標準"
+    "en-US": "Non-standard",
+    "de":    "Kein Standard",
+    "es":    "No estándar",
+    "fr":    "Non standard",
+    "ja":    "非標準",
+    "pl":    "Niestandardowy",
+    "ru":    "Не стандартно",
+    "zh-CN": "非标准",
+    "zh-TW": "非標準",
 });
 
 var str_long = mdn.localString({
-  "en-US": "This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.",
-  "de":    "Diese Funktion entspricht nicht dem Standard und ist nicht Teil der Standardisierung. Diese Funktion darf nicht in Webseiten, die via das Internet zugänglich sind, benutzt werden: Sie wird nicht für alle Nutzer funktionieren. Es kann zu umfangreichen Inkompatibilitäten zwischen verschiedenen Implementierungen kommen und die Funktionsweise oder Eigenschaften könnten in der Zukunft verändert werden.",
-  "fr":    "Cette fonctionnalité n'est ni standard, ni en voie de standardisation. Ne l'utilisez pas pour des sites accessibles sur le Web : elle ne fonctionnera pas pour tout utilisateur. Il peut également y avoir d'importantes incompatibilités entre les implémentations et son comportement peut être modifié dans le futur.",
-  "it":    "Questa funzionalità non è standard e non è parte di un processo di standardizzazione. Non utilizzarla in siti accessibili dal Web: non funzionerà per tutti gli utenti. Inoltre si potrebbero verificare incompatibilità sostanziali tra le implementazioni, ed il comportamento potrebbe cambiare in futuro.",
-  "ja":    "この機能は標準ではなく、標準化の予定もありません。公開されているウェブサイトには使用しないでください。ユーザーによっては使用できないことがあります。実装ごとに大きな差があることもあり、将来は振る舞いが変わるかもしれません。",
-  "ru":    "Эта возможность не является стандартной и стандартизировать её пока никто не собирается. Не используйте её на сайтах, смотрящих во внешний мир: она будет работать не у всех пользователей. Также могут присутствовать большие несовместимости между реализациями и её поведение может в будущем измениться.",
-  "zh-CN": "该特性是非标准的，请尽量不要在生产环境中使用它！"
+    "en-US": "This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.",
+    "de":    "Diese Funktion entspricht nicht dem Standard und ist nicht Teil der Standardisierung. Diese Funktion darf nicht in Webseiten, die via das Internet zugänglich sind, benutzt werden: Sie wird nicht für alle Nutzer funktionieren. Es kann zu umfangreichen Inkompatibilitäten zwischen verschiedenen Implementierungen kommen und die Funktionsweise oder Eigenschaften könnten in der Zukunft verändert werden.",
+    "fr":    "Cette fonctionnalité n'est ni standard, ni en voie de standardisation. Ne l'utilisez pas pour des sites accessibles sur le Web : elle ne fonctionnera pas pour tout utilisateur. Il peut également y avoir d'importantes incompatibilités entre les implémentations et son comportement peut être modifié dans le futur.",
+    "it":    "Questa funzionalità non è standard e non è parte di un processo di standardizzazione. Non utilizzarla in siti accessibili dal Web: non funzionerà per tutti gli utenti. Inoltre si potrebbero verificare incompatibilità sostanziali tra le implementazioni, ed il comportamento potrebbe cambiare in futuro.",
+    "ja":    "この機能は標準ではなく、標準化の予定もありません。公開されているウェブサイトには使用しないでください。ユーザーによっては使用できないことがあります。実装ごとに大きな差があることもあり、将来は振る舞いが変わるかもしれません。",
+    "ru":    "Эта возможность не является стандартной и стандартизировать её пока никто не собирается. Не используйте её на сайтах, смотрящих во внешний мир: она будет работать не у всех пользователей. Также могут присутствовать большие несовместимости между реализациями и её поведение может в будущем измениться.",
+    "zh-CN": "该特性是非标准的，请尽量不要在生产环境中使用它！",
 });
 
 var str_fxos_long = mdn.localString({
-  "en-US": "This feature is not on a current W3C standards track, but it is supported on the Firefox OS platform. Although implementations may change in the future and it is not supported widely across browsers, it is suitable for use in code dedicated to Firefox OS apps.",
-  "de":    "Diese Funktion ist nicht Teil der W3C-Standards, allerdings wird sie innerhalb der Platform des Firefox-Betriebssystems unterstützt. Obwohl sich Implementierungen über längere Zeit ändern können und die Funktion gegenwärtig nicht universell von allen Browsern unterstüzt wird, ist sie durchaus für den Programmiergebrauch in dedizierten Applikationen für das Firefox-Betriebssystem geeignet.",
-  "fr":    "Cette fonctionnalité n'est pas en voie de standardisation au W3C, mais elle est supportée par la plateforme Firefox OS. Bien que son implémentation puisse changer dans le futur et qu'elle n'est pas largement supportée par les différents navigateurs, elle est utilisable pour du code dédié aux applications Firefox OS.",
-  "it":    "Questa funzionalità non è al momento parte di un processo di standardizzazione del W3C, ma è supportata dalla piattaforma Firefox OS. Sebbene l'implementazione potrebbe cambiare in futuro e non è supportata sufficientemente tra i vari browser, è comunque adatta per l'utilizzo nel codice dedicato ad applicazioni per Firefox OS.",
-  "ja":    "この機能は現在 W3C の標準化のプロセスに乗っていませんが、Firefox OS プラットフォームではサポートされています。将来は動作が変わるかもしれませんし、他のブラウザーで広くサポートされているわけでもありませんが、Firefox OS アプリ専用のコードで使うには適しています。",
-  "ru":    "Эта возможность не является стандартом W3C и стандартизировать её пока никто не собирается, но она поддерживается на платформе Firefox OS. Хотя возможность не поддерживается всеми браузерами и в будущем её реализация может изменяться, она может использоваться в коде приложений для Firefox OS."
+    "en-US": "This feature is not on a current W3C standards track, but it is supported on the Firefox OS platform. Although implementations may change in the future and it is not supported widely across browsers, it is suitable for use in code dedicated to Firefox OS apps.",
+    "de":    "Diese Funktion ist nicht Teil der W3C-Standards, allerdings wird sie innerhalb der Platform des Firefox-Betriebssystems unterstützt. Obwohl sich Implementierungen über längere Zeit ändern können und die Funktion gegenwärtig nicht universell von allen Browsern unterstüzt wird, ist sie durchaus für den Programmiergebrauch in dedizierten Applikationen für das Firefox-Betriebssystem geeignet.",
+    "fr":    "Cette fonctionnalité n'est pas en voie de standardisation au W3C, mais elle est supportée par la plateforme Firefox OS. Bien que son implémentation puisse changer dans le futur et qu'elle n'est pas largement supportée par les différents navigateurs, elle est utilisable pour du code dédié aux applications Firefox OS.",
+    "it":    "Questa funzionalità non è al momento parte di un processo di standardizzazione del W3C, ma è supportata dalla piattaforma Firefox OS. Sebbene l'implementazione potrebbe cambiare in futuro e non è supportata sufficientemente tra i vari browser, è comunque adatta per l'utilizzo nel codice dedicato ad applicazioni per Firefox OS.",
+    "ja":    "この機能は現在 W3C の標準化のプロセスに乗っていませんが、Firefox OS プラットフォームではサポートされています。将来は動作が変わるかもしれませんし、他のブラウザーで広くサポートされているわけでもありませんが、Firefox OS アプリ専用のコードで使うには適しています。",
+    "ru":    "Эта возможность не является стандартом W3C и стандартизировать её пока никто не собирается, но она поддерживается на платформе Firefox OS. Хотя возможность не поддерживается всеми браузерами и в будущем её реализация может изменяться, она может использоваться в коде приложений для Firefox OS.",
 });
 
-var fxosCheck = 0;
-
-for (i = 0 ; i <= env.tags.length-1 ; i++) {
-    if (env.tags[i] == "Firefox OS") {
-      fxosCheck = 1;
-      break;        // we can break out now, to save some time
-    }
+if (env.tags && env.tags.includes("Firefox OS")) {
+    str_long = str_fxos_long;
 }
-
-if (fxosCheck == 0) {
 
 switch($0) {
-  case 'inline':
-    %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
-    break;
-  case 'header':
-    %><div class="blockIndicator nonStandard nonStandardHeader">
-      <p><strong><%-str_inline%></strong><br/>
-      <%-str_long%></p>
-      </div><%
-    break;
-}
-
-} else {
-
-switch($0) {
-  case 'inline':
-    %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
-    break;
-  case 'header':
-    %><div class="blockIndicator nonStandard nonStandardHeader">
-      <p><strong><%-str_inline%></strong><br/>
-      <%-str_fxos_long%></p>
-      </div><%
-    break;
-}
-
+    case 'inline':
+        %><span class="inlineIndicator nonStandard"><%-str_inline%></span><%
+        break;
+    case 'header':
+        %><div class="blockIndicator nonStandard">
+            <p><strong><%-str_inline%></strong><br/>
+            <%-str_long%></p>
+        </div><%
+        break;
 }
 
 %>

--- a/macros/NonStandardBadge.ejs
+++ b/macros/NonStandardBadge.ejs
@@ -1,44 +1,16 @@
-<% /* Inserts a badge indicating a term or API is non-standard.
-
-    Parameters:
-        $0  If specified and non-zero, a small badge is displayed.
-
-*/
+<%
+/* Inserts a badge indicating a term or API is non-standard.
+ *
+ *  Parameters:
+ *      $0  If specified and non-zero, a small badge is displayed.
+ *
+ */
 
 var titleAttrValue = mdn.localString({
-    "ca": "This API has not been standardized.",
-    "cs": "This API has not been standardized.",
-    "de": "This API has not been standardized.",
-    "el": "This API has not been standardized.",
-    "es": "This API has not been standardized.",
-    "fa": "This API has not been standardized.",
-    "fi": "This API has not been standardized.",
-    "fr": "Cette API n'a pas été standardisée.",
-    "he": "This API has not been standardized.",
-    "hr": "This API has not been standardized.",
-    "hu": "This API has not been standardized.",
-    "id": "This API has not been standardized.",
-    "it": "This API has not been standardized.",
-    "ja": "この API は標準化されていません。",
-    "ka": "This API has not been standardized.",
-    "ko": "This API has not been standardized.",
-    "ms": "This API has not been standardized.",
-    "nl": "This API has not been standardized.",
-    "pl": "This API has not been standardized.",
-    "ro": "This API has not been standardized.",
-    "ru": "Это API не было стандартизировано.",
-    "sq": "This API has not been standardized.",
-    "th": "This API has not been standardized.",
-    "tr": "This API has not been standardized.",
-    "vi": "This API has not been standardized.",
-    "bn-BD": "This API has not been standardized.",
-    "fy-NL": "This API has not been standardized.",
-    "ga-IE": "This API has not been standardized.",
-    "pt-BR": "This API has not been standardized.",
-    "pt-PT": "This API has not been standardized.",
-    "zh-CN": "This API has not been standardized.",
-    "zh-TW": "This API has not been standardized.",
-    "en-US": "This API has not been standardized."
+    "en-US": "This API has not been standardized.",
+    "fr":    "Cette API n'a pas été standardisée.",
+    "ja":    "この API は標準化されていません。",
+    "ru":    "Это API не было стандартизировано.",
 });
 
 var str = "";
@@ -47,39 +19,16 @@ if ($0) {
     %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-warning-sign"> </i></span><%
 } else {
     str = mdn.localString({
-        "ca": "Non-standard",
-        "cs": "Non-standard",
-        "de": "Non-standard",
-        "el": "Non-standard",
-        "es": "Non-standard",
-        "fa": "Non-standard",
-        "fi": "Non-standard",
-        "fr": "Non standard",
-        "he": "לא סטנדרטי",
-        "hr": "Non-standard",
-        "hu": "Non-standard",
-        "id": "Non-standard",
-        "it": "Non-standard",
-        "ja": "非標準",
-        "ka": "Non-standard",
-        "ko": "Non-standard",
-        "ms": "Non-standard",
-        "nl": "Non-standard",
-        "pl": "Non-standard",
-        "ro": "Non-standard",
-        "ru": "Нестандартное",
-        "sq": "Non-standard",
-        "th": "Non-standard",
-        "tr": "Non-standard",
-        "vi": "Non-standard",
-        "bn-BD": "Non-standard",
-        "fy-NL": "Non-standard",
-        "ga-IE": "Non-standard",
-        "pt-BR": "Non-standard",
-        "pt-PT": "Non-standard",
+        "en-US": "Non-standard",
+        "de":    "Kein Standard",
+        "es":    "No estándar",
+        "fr":    "Non standard",
+        "he":    "לא סטנדרטי",
+        "ja":    "非標準",
+        "pl":    "Niestandardowy",
+        "ru":    "Не стандартно",
         "zh-CN": "非标准",
         "zh-TW": "非標準",
-        "en-US": "Non-standard"
     });
-    %><%-await template("SimpleBadge", [str, "nonstandardBadge", titleAttrValue])%><%
+    %><%-await template("SimpleBadge", [str, "nonStandard", titleAttrValue])%><%
 }%>

--- a/tests/macros/Non-standard.test.js
+++ b/tests/macros/Non-standard.test.js
@@ -1,0 +1,84 @@
+/**
+ * Tests all Non-standard indicator macros
+ *
+ * @prettier
+ */
+
+// Get necessary modules
+const { assert, describeMacro, itMacro } = require('./utils');
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+
+/**
+ * @param {string} result
+ * @return {[string, DocumentFragment]}
+ */
+function testHeaderGeneric(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert(dom.firstElementChild.classList.contains("blockIndicator"),
+        "Root element is a 'blockIndicator'");
+    assert(dom.firstElementChild.classList.contains("nonStandard"),
+        "Root element is 'nonStandard'");
+    let header = dom.querySelector("strong");
+    // Block indicator has a header
+    expect(header).toEqual(expect.anything());
+    assert.equal(header.textContent.trim(), "Non-standard");
+    return [result, dom];
+}
+
+function testInline(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert(dom.firstElementChild.classList.contains("inlineIndicator"),
+        "Root element is an 'inlineIndicator'");
+    assert(dom.firstElementChild.classList.contains("nonStandard"),
+        "Root element is 'nonStandard'");
+    assert.equal(dom.textContent.trim(), "Non-standard");
+}
+
+describeMacro("Non-standardGeneric", function() {
+    itMacro("Correct result for 'inline'", macro => {
+        return macro.call('inline').then(testInline);
+    });
+
+    itMacro("Correct result for 'header'", macro => {
+        return macro.call('header')
+            .then(testHeaderGeneric)
+            .then(([,dom]) => {
+                // Non-standard Header doesn't contain the string 'Firefox OS'
+                expect(dom.querySelector("p").textContent).not.toContain("Firefox OS");
+            });
+    });
+
+    itMacro("Correct result for 'header' (Firefox OS)", macro => {
+        macro.ctx.env.tags = ["Firefox OS"];
+        return macro.call('header')
+            .then(testHeaderGeneric)
+            .then(([,dom]) => {
+                // Non-standard Header contains the string 'Firefox OS'
+                expect(dom.querySelector("p").textContent).toContain("Firefox OS");
+            });
+    });
+});
+
+describeMacro("Non-standard_Header", function() {
+    itMacro("Correct result", macro => {
+        return macro.call()
+            .then(testHeaderGeneric)
+            .then(([,dom]) => {
+                // Non-standard Header doesn't contain the string 'Firefox OS'
+                expect(dom.querySelector("p").textContent).not.toContain("Firefox OS");
+            });
+    });
+
+    itMacro("Correct result (Firefox OS)", macro => {
+        macro.ctx.env.tags = ["Firefox OS"];
+        return macro.call()
+            .then(testHeaderGeneric)
+            .then(([,dom]) => {
+                // Non-standard Header contains the string 'Firefox OS'
+                expect(dom.querySelector("p").textContent).toContain("Firefox OS");
+            });
+    });
+});

--- a/tests/macros/Non-standard.test.js
+++ b/tests/macros/Non-standard.test.js
@@ -37,6 +37,14 @@ function testInline(result) {
     assert.equal(dom.textContent.trim(), "Non-standard");
 }
 
+function testIcon(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert.equal(dom.firstElementChild.getAttribute("title"), "This API has not been standardized.");
+    let icon = dom.querySelector("i.icon-warning-sign");
+    expect(icon).toEqual(expect.anything());
+}
+
 describeMacro("Non-standardGeneric", function() {
     itMacro("Correct result for 'inline'", macro => {
         return macro.call('inline').then(testInline);
@@ -80,5 +88,21 @@ describeMacro("Non-standard_Header", function() {
                 // Non-standard Header contains the string 'Firefox OS'
                 expect(dom.querySelector("p").textContent).toContain("Firefox OS");
             });
+    });
+});
+
+describeMacro("NonStandardBadge", function() {
+    itMacro("Correct result", macro => {
+        return macro.call().then(testInline);
+    });
+
+    itMacro("Correct result (icon)", macro => {
+        return macro.call(true).then(testIcon);
+    });
+});
+
+describeMacro("Non-standard_Inline", function() {
+    itMacro("Correct result", macro => {
+        return macro.call().then(testIcon);
     });
 });


### PR DESCRIPTION
To preserve `git blame` and history, this should be merged using the **Merge&nbsp;commit** strategy.

review?(@davidflanagan)