### PR TITLE
Add test for SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -506,7 +506,7 @@
   },
   "CSS Scope": {
     "name": "CSS Scoping Module Level&nbsp;1",
-    "url": "http://drafts.csswg.org/css-scoping/",
+    "url": "https://drafts.csswg.org/css-scoping/",
     "status": "WD"
   },
   "CSS Scrollbars": {

--- a/tests/macros/test-specdata.js
+++ b/tests/macros/test-specdata.js
@@ -1,0 +1,44 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+const utils = require('./utils'),
+      chai = require('chai'),
+      jsdom = require('jsdom'),
+      assert = chai.assert,
+      itMacro = utils.itMacro,
+      describeMacro = utils.describeMacro;
+
+const specStatusValues = [
+    'REC',
+    'PR',
+    'CR',
+    'RC',
+    'WD',
+    'ED',
+    'Old-Transforms',
+    'Living',
+    'RFC',
+    'Standard',
+    'Draft',
+    'Obsolete',
+    'LC'
+];
+
+function checkSpecData(specDataJson) {
+    const entries = Object.entries(specDataJson);
+    for (let entry of entries) {
+        assert(entry.name !== undefined, 'SpecData entry is missing required "name" property');
+        assert(entry.url !== undefined, 'SpecData entry is missing required "url" property');
+        assert(entry.status !== undefined, 'SpecData entry is missing required "status" property');
+
+        assert(entry.url.startsWith('https://'), 'SpecData "url" entry is not an HTTPS URL');
+        assert(specStatusValues.includes(entry.status), 'SpecData "status" entry is not a valid value');
+    }
+}
+
+describeMacro('SpecData', function () {
+
+    itMacro('Validate SpecData JSON', function (macro) {
+        return macro.call().then(checkSpecData);
+    });
+
+});

--- a/tests/macros/test-specdata.js
+++ b/tests/macros/test-specdata.js
@@ -2,7 +2,6 @@
 
 const utils = require('./utils'),
       chai = require('chai'),
-      jsdom = require('jsdom'),
       assert = chai.assert,
       itMacro = utils.itMacro,
       describeMacro = utils.describeMacro;
@@ -23,15 +22,22 @@ const specStatusValues = [
     'LC'
 ];
 
+/*
+Performs basic validation of the SpecData JSON object:
+ * All entries must have name, url, and status properties.
+ * The url property must be an HTTPS URL.
+ * The status property must be in the list of valid status values.
+ */
 function checkSpecData(specDataJson) {
-    const entries = Object.entries(specDataJson);
-    for (let entry of entries) {
-        assert(entry.name !== undefined, 'SpecData entry is missing required "name" property');
-        assert(entry.url !== undefined, 'SpecData entry is missing required "url" property');
-        assert(entry.status !== undefined, 'SpecData entry is missing required "status" property');
+    const entries = Object.entries(JSON.parse(specDataJson));
 
-        assert(entry.url.startsWith('https://'), 'SpecData "url" entry is not an HTTPS URL');
-        assert(specStatusValues.includes(entry.status), 'SpecData "status" entry is not a valid value');
+    for (let entry of entries) {
+        assert(entry[1].name !== undefined, `SpecData entry: ${entry[0]} is missing required "name" property`);
+        assert(entry[1].url !== undefined, `SpecData entry: ${entry[0]} is missing required "url" property`);
+        assert(entry[1].status !== undefined, `SpecData entry: ${entry[0]} is missing required "status" property`);
+
+        assert(entry[1].url.startsWith('https://'), `SpecData entry: ${entry[0]}: "url" is not an HTTPS URL`);
+        assert(specStatusValues.includes(entry[1].status), `SpecData: ${entry[0]}: "status" is not a valid value`);
     }
 }
 


### PR DESCRIPTION
Currently a lot of our open PRs are for updates to SpecData.json. SpecData.json is used by spec2.ejs and SpecName.ejs. These macros are used in thousands of pages, and bad data could break them.

So this PR adds some simple tests to validate the contents of SpecData.json:

 * All entries must have name, url, and status properties.
 * The url property must be an HTTPS URL.
 * The status property must be in the list of valid status values.

This is simple but should (I hope) be enough to make it likely that the data won't break the spec2.ejs or the SpecName.ejs macros.

This PR also fixes a bug found by the tests (one of the URLs was HTTP not HTTPS).

