### PR TITLE
refactor(macros): Use a more future‑proof method for sidebar slug processing

### DIFF
--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -12,7 +12,8 @@ var EventHref = '/' + locale + '/docs/Web/Events';
 var output = "";
 // slug is not available in preview mode.
 if (slug) {
-var mainIF = slug.replace('Web/API/','').split('/')[0];
+var trimmedSlug = mdn.trimSlugStart(['Web', 'API'], slug);
+var mainIF = trimmedSlug.result[0];
 mainIF = mainIF.charAt(0).toUpperCase() + mainIF.slice(1);
 var group = $0;
 var hasTag = page.hasTag;
@@ -41,9 +42,9 @@ var text = {
 
 
 // Collect all the things
-var mainIFPages = page.subpagesExpand('/en-US/docs/Web/API/' + mainIF);
-var impl = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].impl : [];
-var inh = webAPIData[0][mainIF] != undefined ? webAPIData[0][mainIF].inh : '';
+var mainIFPages = page.subpagesExpand(`/en-US/docs/${trimmedSlug.base_slug}/${mainIF}`);
+var impl = webAPIData[0][mainIF] && webAPIData[0][mainIF].impl || [];
+var inh = webAPIData[0][mainIF] && webAPIData[0][mainIF].inh || '';
 var related = [];
 var events = []
 if (group && webAPIGroups[0][group]) {

--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -11,7 +11,8 @@ var output = "";
 
 // slug is not available in preview mode.
 if (slug) {
-    var name = slug.replace('Web/CSS/','').split('/')[0];
+    var trimmedSlug = mdn.trimSlugStart(['Web', 'CSS'], slug);
+    var name = trimmedSlug.result[0];
     var hasTag = page.hasTag;
     var escapeQuotes = mdn.escapeQuotes;
     var htmlEscape = kuma.htmlEscape;

--- a/macros/EventRef.ejs
+++ b/macros/EventRef.ejs
@@ -12,8 +12,8 @@ var output = "";
 if (slug) {
 
     var groups = string.deserialize(template("GroupData"))[0];
-    var event = slug.replace('Web/Events/','').split('/')[0];
-
+    var trimmedSlug = mdn.trimSlugStart(['Web', 'Events'], slug);
+    var event = trimmedSlug.result[0];
 
     // output
     output = '<section class="Quick_links" id="Quick_Links"><ol>';

--- a/macros/InheritanceDiagram.ejs
+++ b/macros/InheritanceDiagram.ejs
@@ -1,4 +1,4 @@
-<% 
+<%
 /*
   Draws an responsive SVG diagram for the inheritance chain (inverted in rtl)
 
@@ -15,7 +15,8 @@ var result = "";
 if (slug) {
 var locale = env.locale;
 var href = 'https://developer.mozilla.org/' + locale + '/docs/Web/API/';
-var mainIF = $3 || slug.replace('Web/API/','').split('/')[0];
+var trimmedSlug = mdn.trimSlugStart(['Web', 'API'], slug);
+var mainIF = $3 || trimmedSlug.result[0];
 var rtlLocales = ['ar', 'he', 'fa'];
 var inheritanceChain = [mainIF];
 var descendants = [];
@@ -73,7 +74,7 @@ function lineWithTriangle(x, y, reverse) {
   var str = '';
   if (reverse) {
     str += '<polyline points="'+x+','+(y+24)+'  '+(x-10)+','+(y+19)+'  '+(x-10)+','+(y+29)+'  '+x+','+(y+24)+'" stroke="#D4DDE4" fill="none"/>';
-    x -= 10; 
+    x -= 10;
     str += '<line x1="'+x+'" y1="'+(y+24)+'" x2="'+(x-30)+'" y2="'+(y+24)+'" stroke="#D4DDE4"/>';
   } else {
     str += '<polyline points="'+x+','+(y+24)+'  '+(x+10)+','+(y+19)+'  '+(x+10)+','+(y+29)+'  '+x+','+(y+24)+'" stroke="#D4DDE4" fill="none"/>';

--- a/macros/InterfaceOverview.ejs
+++ b/macros/InterfaceOverview.ejs
@@ -20,7 +20,8 @@ var output = '';
 // not available.
 
 if (slug) {
-    var mainIF = slug.replace('Web/API/', '').split('/')[0];
+    var trimmedSlug = mdn.trimSlugStart(['Web', 'API'], slug);
+    var mainIF = trimmedSlug.result[0];
     mainIF = mainIF.charAt(0).toUpperCase() + mainIF.slice(1);
 
     // Convenience to shorten some function names
@@ -56,7 +57,7 @@ if (slug) {
     var strAlsoInherits = localString({
       "en-US": "Also inherits $1 from: $2"
     });
-    
+
   // Get translations of strings we need
 
     var text = {
@@ -72,7 +73,7 @@ if (slug) {
 
     // Get the information about this API specifically out of the
     // databases, as well as from the subtree below this page.
-    
+
     var mainIFPages = page.subpagesExpand('/en-US/docs/Web/API/' + mainIF);
     var events = [];
 
@@ -104,7 +105,7 @@ if (slug) {
             }
         }
     }
-    
+
     collect(mainIFPages);
 
     // Build inheritance information, if any
@@ -117,7 +118,7 @@ if (slug) {
     if (inh) {
       inherited.push(inh);
     }
-    
+
     impl.forEach(function(value, index, ar) {
       inherited.push(value);
     });
@@ -131,7 +132,7 @@ if (slug) {
         b = bSplit[bSplit.length - 1];
         return a.toLowerCase().localeCompare(b.toLowerCase());
     }
-    
+
     eventHandlers.sort(APISort);
     properties.sort(APISort);
     methods.sort(APISort);
@@ -139,9 +140,9 @@ if (slug) {
     inherited.sort(APISort);
 
     // Build inheritance list string
-    
+
     var inheritanceList = "";
-    
+
     inherited.forEach(function(val, index, ar) {
         inheritanceList += template("domxref", [val]);
         if (index != ar.length-1) {
@@ -168,39 +169,39 @@ if (slug) {
         }
         var result = '<h' + headLevel + '>' + title + '</h' + headLevel + '>';
         var inheritText = '';
-        
+
         if (title != text.Constructor) {
             // If there are any items in the section and there are
             // inherited interfaces:
-            
+
             if (pages.length && inherited.length) {
               inheritText = strAlsoInherits.replace(/\$1/ig,
                             title.toLocaleLowerCase());
               inheritText = inheritText.replace(/\$2/ig, inheritanceList);
             }
-    
+
             // ... if there are no items in the section and no inherited
             // interfaces:
             else if (!pages.length && !inherited.length) {
               inheritText = strNone.replace(/\$1/ig, title.toLocaleLowerCase());
             }
-    
+
             // ... if there are no items in the section but there are inherited
             // interfaces:
-    
+
             else if (!pages.length) {
               inheritText = strInherits.replace(/\$1/ig, title.toLocaleLowerCase());
               inheritText = inheritText.replace(/\$2/ig, inheritanceList);
             }
-    
+
             // ... otherwise, there are items in the section but none inherited,
             // so we don't have any special text at all.
-    
+
             if (inheritText.length) {
               result += '<p><em>' + inheritText + '</em></p>';
             }
         }
-        
+
         result += '<dl>';
 
         for (var i in pages) {
@@ -287,7 +288,7 @@ if (slug) {
 
         return result;
     }
-    
+
     // Time to do the output of the whole thing!
 
     if (ctors.length > 0) {

--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -1,13 +1,21 @@
 <%
-// Generate quick links for JavaScript standard objects docs
-//
-// TODO: Ordering of prototype / static methods (bug 948576)
-//
-// Parameters are OBSOLETE. DO NOT USE ANYMORE.
-//
-//  $0 - JavaScript reference section (e.g Global_Objects) – OBSOLETE
-//  $1 - JavaScript reference object/subject (e.g. Number, Array, Function) – OBSOLETE
-//  $2 - Related objects to display (comma separated) – OBSOLETE
+/**
+ * Generate quick links for JavaScript standard objects docs
+ *
+ * TODO: Ordering of prototype / static methods (bug 948576)
+ *
+ * Parameters are OBSOLETE in standard locations. DO NOT USE ANYMORE.
+ *
+ * $0 - JavaScript reference section (e.g. Microsoft_Extensions)
+ *      Available only to non-standard reference pages (eg. anything
+ *      not under 'Web/JavaScript/Reference').
+ *
+ * $1 - JavaScript reference object/subject (e.g. Date, Error)
+ *      Available only to non-standard reference pages (eg. anything
+ *      not under 'Web/JavaScript/Reference').
+ *
+ * $2 - Related objects to display (comma separated) – OBSOLETE
+ */
 
 // Strings
 var commonl10n = string.deserialize(template('L10n:Common'));
@@ -36,7 +44,31 @@ if (slug) {
 var locale = env.locale;
 var rtlLocales = ['ar', 'he', 'fa'];
 var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/' + text['refslug'] + '/' + text['stdlibslug'];
-var mainObj = slug.replace('Web/JavaScript/' + text['refslug'] + '/' + text['stdlibslug'] + '/', '').split('/')[0];
+var trimmedSlug = mdn.trimSlugStart(['Web', 'JavaScript'], slug);
+var nonStandardReference = false;
+var mainObj;
+if (trimmedSlug.result[0] === text['refslug']) {
+    trimmedSlug.base_slug += ('/' + trimmedSlug.result.shift());
+    if (trimmedSlug.result[0] === text['stdlibslug']) {
+        trimmedSlug.base_slug += ('/' + trimmedSlug.result.shift());
+    }
+} else {
+    nonStandardReference = true;
+    if ($0) {
+        let trimmed2 = mdn.trimSlugStart($0, trimmedSlug.result);
+        if (trimmed2.base_slug.length) {
+            trimmedSlug.base_slug += ('/' + trimmed2.base_slug);
+            trimmedSlug.result = trimmed2.result;
+        }
+    }
+    if ($1) {
+        mainObj = $1;
+    }
+}
+
+if (!mainObj) {
+    mainObj = trimmedSlug.result[0];
+}
 
 // Data for inheritance chain
 var inheritance = ["Object", "Function"];
@@ -85,7 +117,9 @@ for(g in groupData) {
 
 // Collect pages
 var source = {};
-source[mainObj] = page.subpagesExpand('/en-US/docs/Web/JavaScript/Reference/Global_Objects/' + mainObj);
+source[mainObj] = page.subpagesExpand(nonStandardReference && wiki.pageExists(`/en-US/docs/${trimmedSlug.base_slug}/${mainObj}`)
+    ? `/en-US/docs/${trimmedSlug.base_slug}/${mainObj}`
+    : `/en-US/docs/Web/JavaScript/Reference/Global_Objects/${mainObj}`);
 if  (inheritance.indexOf("Function") > -1) {
     source["iFunction"] = page.subpagesExpand('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function');
 }

--- a/macros/MDN-Common.ejs
+++ b/macros/MDN-Common.ejs
@@ -1,5 +1,5 @@
 <% var MDN = module.exports = {
-    
+
     /**
      * Return an HTML link using the given url, text, and title.
      */
@@ -11,7 +11,7 @@
             '</a>'
         ].join('');
     },
-    
+
     /**
      * Given a set of names and a corresponding list of values, apply HTML
      * escaping to each of the values and return an object with the results
@@ -24,7 +24,7 @@
         });
         return e;
     },
-    
+
     /**
      * Given a set of strings like this:
      *     { "en-US": "Foo", "de": "Bar", "es": "Baz" }
@@ -67,7 +67,7 @@
      *    "bye": { "en-US": "Goodbye!", "de": "Auf Wiedersehen!" }
      *   }
      * Returns the one, which matches the current locale.
-     * 
+     *
      * Example:
      *   getLocalString({"hello": {"en-US": "Hello!", "de": "Hallo!"}},
      *       "hello");
@@ -85,24 +85,24 @@
 
         return strings[key][lang];
     },
-    
+
     /**
      * Given a string, replaces all placeholders outlined by
      * $1$, $2$, etc. (i.e. numeric placeholders) or
      * $firstVariable$, $secondVariable$, etc. (i.e. string placeholders)
      * within it.
-     * 
+     *
      * If numeric placeholders are used, the 'replacements' parameter must be
      * an array. The number within the placeholder indicates the index within the
      * replacement array starting by 1.
      * If string placeholders are used, the 'replacements' parameter must be an
      * object. Its property names represent the placeholder names and their
      * values the values to be inserted.
-     * 
+     *
      * Examples:
      *   replacePlaceholders("$1$ $2$, $1$ $3$!", ["hello", "world", "contributor"])
      *   => "hello world, hello contributor!"
-     * 
+     *
      *   replacePlaceholders("$hello$ $world$, $hello$ $contributor$!",
      *       {hello: "hallo", world: "Welt", contributor: "Mitwirkender"})
      *   => "hallo Welt, hallo Mitwirkender!"
@@ -131,7 +131,76 @@
         }
         return b.replace(/(<([^>]+)>)/ig, "");
     },
-    
+
+    /**
+    * #### trimSlugStart(pathToTrim: string[], slug: string)
+    * Trims the page slug.
+    *
+    * ##### Results for `['Web', 'API']`:
+    * - `Web/API/Foo/bar` -> `{base_slug: 'Web/API', result: ['Foo', 'bar']}`
+    * - `Archive/Web/API/Foo/bar` -> `{base_slug: 'Archive/Web/API', result: ['Foo', 'bar']}`
+    * - `Mozilla/Gecko/Chrome/API/Foo/bar` -> `{base_slug: 'Mozilla/Gecko/Chrome/API', result: ['Foo', 'bar']}`
+    * - `Mozilla/Gecko/Chrome/API/Web/API` -> `{base_slug: 'Mozilla/Gecko/Chrome/API', result: ['Web', 'API']}`
+    *
+    * ##### Results for `['Web', 'CSS']`:
+    * - `Web/CSS/foo` -> `{base_slug: 'Web/CSS', result: ['foo']}`
+    * - `Archive/Web/CSS/foo` -> `{base_slug: 'Archive/Web/CSS', result: ['foo']}`
+    * - `Mozilla/Gecko/Chrome/CSS/foo` -> `{base_slug: 'Mozilla/Gecko/Chrome/CSS', result: ['foo']}`
+    * - `Web/API/CSS/foo` -> `{base_slug: '', result: ['Web', 'API', 'CSS', 'foo']}`
+    *   The above doesn't match because the path contains both `Web` and `CSS`, but they are separated by `API`.
+    * - `Web/foo` -> `{base_slug: '', result: ['Web', 'foo']}`
+    * - Edge case: legacy `API/CSS/foo` -> `{base_slug: 'API/CSS', result: ['foo']}`,
+    *   but such paths are no longer in use on MDN.
+    *
+    * @param {string|string[]} pathToTrim The slug component to trim (eg. `['Web', 'CSS']`).
+    * @param {string|string[]} slug
+    *
+    * @return {{base_slug:string, result:string[]}}
+    *   `base_slug`: The portion that was trimmed.
+    *   `result`: The path with `base_slug` removed.
+    */
+    trimSlugStart: function (pathToTrim, slug) {
+        // Copy pathToTrim to avoid leaking modifications outside.
+        pathToTrim = (typeof pathToTrim === "string")
+            ? pathToTrim.split('/')
+            : Array.from(pathToTrim);
+        let result = (typeof slug === "string")
+            ? slug.split('/')
+            : Array.from(slug);
+        if (result.length <= 1 || !pathToTrim.length) {
+            // The page is top level, so there's no need to run
+            // the rest of the function.
+            return {base_slug: '', result};
+        }
+
+        let maxLength = result.indexOf(pathToTrim.pop());
+        if (maxLength < 0) {
+            // The slug doesn't contain the searched value.
+            return {base_slug: '', result};
+        }
+
+        let trimPoint = maxLength + 1;
+
+        for (let i = pathToTrim.length - 1; i >= 0; i--) {
+            let matching = pathToTrim[i];
+            for (let j = maxLength; j > 0; j--) {
+                let matched = result[j - 1];
+                if (matching.toLowerCase() === matched.toLowerCase() ||
+                    matching.toUpperCase() === matched.toUpperCase()) {
+                    if (j === maxLength) {
+                        maxLength--;
+                        break;
+                    } else {
+                        return {base_slug: '', result};
+                    }
+                }
+            }
+        }
+
+        let base_slug = result.splice(0, trimPoint);
+        return {base_slug: base_slug.join('/'), result};
+    },
+
     /**
      * #### fetchCompatTableJSON
      * Sets proper headers and makes a request to get compat table data
@@ -153,10 +222,10 @@
     getFileContent: function(fileObjOrUrl) {
         var url = fileObjOrUrl.url || fileObjOrUrl;
         if(!url) return '';
-        
+
         var result = '',
             base_url = '';
-        
+
         // New file urls include attachment host, so we don't need to prepend it
         var fUrl = kuma.url.parse(url);
         if (!fUrl.host) {
@@ -186,7 +255,7 @@
 
     /**
      * #### cacheFnIgnoreCacheControl
-     * Cache a function, and use cached results no matter what 
+     * Cache a function, and use cached results no matter what
      * Cache-Control we get from a shift-refresh.
      */
     cacheFnIgnoreCacheControl: function (key, tm_out, to_cache) {
@@ -217,7 +286,7 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### memcacheSet(key, value, timeout)
     //
     // Store a value in memcache with the given key and timeout (in seconds)
@@ -235,7 +304,7 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### memcacheGet(key)
     //
     // Fetch the value for a key from memcache
@@ -253,11 +322,11 @@
         if (err_result) { throw err_result; }
         return result;
     },
-    
+
     // #### defaults(object, *defaults)
     //
-    // Fill in undefined properties in object with values from the defaults 
-    // objects, and return the object. As soon as the property is filled, 
+    // Fill in undefined properties in object with values from the defaults
+    // objects, and return the object. As soon as the property is filled,
     // further defaults will have no effect.
     //
     // Stolen from http://underscorejs.org/#defaults
@@ -271,25 +340,25 @@
         });
         return obj;
     },
-        
+
     // #### fetchJSONResource
-    // Fetch an HTTP resource with JSON representation, parse the JSON and 
+    // Fetch an HTTP resource with JSON representation, parse the JSON and
     // return a JS object.
     fetchJSONResource: function (url, opts) {
         opts = MDN.defaults(opts || {}, {
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': 'application/json',
                        'Content-Type': 'application/json' },
         });
         return JSON.parse(MDN.fetchHTTPResource(url, opts));
     },
-    
+
     // #### fetchHTTPResource
     // Fetch an HTTP resource, return the response body.
     fetchHTTPResource: function (url, opts) {
         opts = MDN.defaults(opts || {}, {
             method: 'GET',
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': "text/plain",
                        'Content-Type': "text/plain" },
             url: url,
@@ -330,11 +399,11 @@
                             next(buffer.toString());
                         }
                     });
-                });                 
-                req.on('error', function(err) { next(null); });                
+                });
+                req.on('error', function(err) { next(null); });
             } catch (e) {
                 next(null);
-            }            
+            }
         };
         if (opts.ignore_cache_control) {
             return MDN.cacheFnIgnoreCacheControl(opts.cache_key, opts.cache_timeout, to_cache);
@@ -342,13 +411,13 @@
             return cacheFn(opts.cache_key, opts.cache_timeout, to_cache);
         }
     },
-    
+
     /* Returns the appropriate string (usually a comma+space) for usage in a enumeration list for the current locale */
     listSeparator: function() {
         var listSeparators = { "en-US": ", ", "ar": "،", "fa": "،", "ja": "、", "ko": "·", "mn": "᠂", "ur": "،", "zh−TW": "、" };
         return mdn.localString(listSeparators);
     },
-    
+
     /*
      * FILE READING
      *
@@ -359,39 +428,39 @@
       // Check to see if the delimiter is defined. If not,
       // then default to comma.
       strDelimiter = (strDelimiter || ",");
-    
+
       // Create a regular expression to parse the CSV values.
       var objPattern = new RegExp(
         (
           // Delimiters.
           "(\\" + strDelimiter + "|\\r?\\n|\\r|^)" +
-    
+
           // Quoted fields.
           "(?:\"([^\"]*(?:\"\"[^\"]*)*)\"|" +
-    
+
           // Standard fields.
           "([^\"\\" + strDelimiter + "\\r\\n]*))"
         ),
         "gi"
         );
-    
-    
+
+
       // Create an array to hold our data. Give the array
       // a default empty first row.
       var arrData = [[]];
-    
+
       // Create an array to hold our individual pattern
       // matching groups.
       var arrMatches = null;
-    
-    
+
+
       // Keep looping over the regular expression matches
       // until we can no longer find a match.
       while (arrMatches = objPattern.exec( strData )){
-    
+
         // Get the delimiter that was found.
         var strMatchedDelimiter = arrMatches[ 1 ];
-    
+
         // Check to see if the given delimiter has a length
         // (is not the start of string) and if it matches
         // field delimiter. If id does not, then we know
@@ -400,53 +469,53 @@
           strMatchedDelimiter.length &&
           (strMatchedDelimiter != strDelimiter)
           ){
-    
+
           // Since we have reached a new row of data,
           // add an empty row to our data array.
           arrData.push( [] );
-    
+
         }
-    
-    
+
+
         // Now that we have our delimiter out of the way,
         // let's check to see which kind of value we
         // captured (quoted or unquoted).
         if (arrMatches[ 2 ]){
-    
+
           // We found a quoted value. When we capture
           // this value, unescape any double quotes.
           var strMatchedValue = arrMatches[ 2 ].replace(
             new RegExp( "\"\"", "g" ),
             "\""
             );
-    
+
         } else {
-    
+
           // We found a non-quoted value.
           var strMatchedValue = arrMatches[ 3 ];
-    
+
         }
-    
-    
+
+
         // Now that we have our value string, let's add
         // it to the data array.
         arrData[ arrData.length - 1 ].push( strMatchedValue );
       }
-    
+
       // Return the parsed data.
       return( arrData );
     },
-    
+
     loadArrayFromCSV: function(url, separator) {
         url = url.replace(/&amp;/i, "&");
         var html = MDN.fetchHTTPResource(url, {
-            headers: { 'Cache-Control': env.cache_control, 
+            headers: { 'Cache-Control': env.cache_control,
                        'Accept': 'text/csv',
                        'Content-Type': 'text/csv' },
         });
         return MDN.CSVToArray(html, separator);
     },
-    
+
     /* http://www.bugzilla.org/docs/4.2/en/html/api/Bugzilla/WebService/Bug.html#search */
     bzSearch: function (query) {
         /* Fix colon (":") encoding problems */

--- a/tests/macros/test-EventRef.js
+++ b/tests/macros/test-EventRef.js
@@ -1,15 +1,23 @@
 /* jshint node: true, mocha: true, esversion: 6 */
 
-const utils = require('./utils'),
-      chai = require('chai'),
-      chaiAsPromised = require('chai-as-promised'),
-      jsdom = require('jsdom'),
-      assert = chai.assert,
-      itMacro = utils.itMacro,
-      describeMacro = utils.describeMacro;
+// Get necessary modules
+const {itMacro, describeMacro} = require('./utils');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const jsdom = require('jsdom');
 
+const {JSDOM} = jsdom;
+const assert = chai.assert;
+
+// Set up Chai
 chai.use(chaiAsPromised);
 
+/**
+ * @param {DocumentFragment} dom
+ * @param {string} locale
+ * @param {string} expected_summary
+ * @param {boolean} found_one
+ */
 function checkSidebarDom(dom, locale, expected_summary, found_one) {
     let section = dom.querySelector('section');
     assert(section.classList.contains('Quick_links'), 'Section does not contain Quick_links class');
@@ -29,20 +37,36 @@ function checkSidebarDom(dom, locale, expected_summary, found_one) {
     }
 }
 
-describeMacro('eventref', function () {
-
+describeMacro('EventRef', () => {
     itMacro('No output in preview', function (macro) {
         macro.ctx.env.slug = '';
         macro.ctx.env.locale = 'en-US';
         return assert.eventually.equal(macro.call(), '');
     });
 
-
     itMacro('Creates a sidebar for an event in one group in en-US locale', function (macro) {
         macro.ctx.env.slug = 'Web/Events/datachannel';
         macro.ctx.env.locale = 'en-US';
         return macro.call().then(function(result) {
             let dom = jsdom.JSDOM.fragment(result);
+            checkSidebarDom(dom, 'en-US', 'WebRTC events', true);
+        });
+    });
+
+    itMacro('Creates a sidebar for an internal event in one group in en-US locale', macro => {
+        macro.ctx.env.slug = 'Mozilla/Gecko/Chrome/Events/datachannel';
+        macro.ctx.env.locale = 'en-US';
+        return macro.call().then(result => {
+            let dom = JSDOM.fragment(result);
+            checkSidebarDom(dom, 'en-US', 'WebRTC events', true);
+        });
+    });
+
+    itMacro('Creates a sidebar for an archived event in one group in en-US locale', macro => {
+        macro.ctx.env.slug = 'Archive/Web/Events/datachannel';
+        macro.ctx.env.locale = 'en-US';
+        return macro.call().then(result => {
+            let dom = JSDOM.fragment(result);
             checkSidebarDom(dom, 'en-US', 'WebRTC events', true);
         });
     });
@@ -55,5 +79,4 @@ describeMacro('eventref', function () {
             checkSidebarDom(dom, 'fr', 'DOM events', false);
         });
     });
-
 });

--- a/tests/macros/test-MDN-Common.js
+++ b/tests/macros/test-MDN-Common.js
@@ -1,0 +1,108 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+// Get necessary modules
+const {itMacro, describeMacro} = require('./utils');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+// Set up Chai
+chai.use(chaiAsPromised);
+
+describeMacro("MDN:Common", () => {
+    itMacro('require', macro => {
+        return macro.require().then(pkg => {
+            chai.assert.isObject(pkg);
+            chai.assert.isFunction(pkg.link);
+            chai.assert.isFunction(pkg.htmlEscapeArgs);
+            chai.assert.isFunction(pkg.localString);
+            chai.assert.isFunction(pkg.localStringMap);
+            chai.assert.isFunction(pkg.getLocalString);
+            chai.assert.isFunction(pkg.replacePlaceholders);
+            chai.assert.isFunction(pkg.escapeQuotes);
+            chai.assert.isFunction(pkg.trimSlugStart);
+            chai.assert.isFunction(pkg.fetchCompatTableJSON);
+            chai.assert.isFunction(pkg.getFileContent);
+            chai.assert.isFunction(pkg.cacheFnIgnoreCacheControl);
+            chai.assert.isFunction(pkg.memcacheSet);
+            chai.assert.isFunction(pkg.memcacheGet);
+            chai.assert.isFunction(pkg.defaults);
+            chai.assert.isFunction(pkg.fetchJSONResource);
+            chai.assert.isFunction(pkg.fetchHTTPResource);
+            chai.assert.isFunction(pkg.listSeparator);
+            chai.assert.isFunction(pkg.CSVToArray);
+            chai.assert.isFunction(pkg.loadArrayFromCSV);
+            chai.assert.isFunction(pkg.bzSearch);
+            chai.assert.isFunction(pkg.siteURL);
+        });
+    });
+
+    describe('test "trimSlugStart"', () => {
+        itMacro('trimSlugStart(["Web", "API"])', macro => {
+            return macro.require().then(mdn => {
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], 'Web/API/Foo/bar'),
+                    {base_slug: 'Web/API', result: ['Foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart("Web/API", 'Web/API/Foo/bar'),
+                    {base_slug: 'Web/API', result: ['Foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], ['Web', 'API', 'Foo', 'bar']),
+                    {base_slug: 'Web/API', result: ['Foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart("Web/API", ['Web', 'API', 'Foo', 'bar']),
+                    {base_slug: 'Web/API', result: ['Foo', 'bar']});
+
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], 'API/Foo/bar'),
+                    {base_slug: 'API', result: ['Foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], 'Mozilla/Gecko/Chrome/API/Foo/bar'),
+                    {base_slug: 'Mozilla/Gecko/Chrome/API', result: ['Foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], 'Mozilla/Gecko/Chrome/API/Web/API'),
+                    {base_slug: 'Mozilla/Gecko/Chrome/API', result: ['Web', 'API']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "API"], 'Web/Foo/bar'),
+                    {base_slug: '', result: ['Web', 'Foo', 'bar']});
+            });
+        });
+
+        itMacro('trimSlugStart(["Web", "CSS"])', macro => {
+            return macro.require().then(mdn => {
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'Web/CSS/foo/bar'),
+                    {base_slug: 'Web/CSS', result: ['foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart("Web/CSS", 'Web/CSS/foo/bar'),
+                    {base_slug: 'Web/CSS', result: ['foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], ['Web', 'CSS', 'foo', 'bar']),
+                    {base_slug: 'Web/CSS', result: ['foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart("Web/CSS", ['Web', 'CSS', 'foo', 'bar']),
+                    {base_slug: 'Web/CSS', result: ['foo', 'bar']});
+
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'CSS/foo/bar'),
+                    {base_slug: 'CSS', result: ['foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'Mozilla/Gecko/Chrome/CSS/foo/bar'),
+                    {base_slug: 'Mozilla/Gecko/Chrome/CSS', result: ['foo', 'bar']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'Mozilla/Gecko/Chrome/CSS/Web/CSS'),
+                    {base_slug: 'Mozilla/Gecko/Chrome/CSS', result: ['Web', 'CSS']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'Web/API/CSS/foo'),
+                    {base_slug: '', result: ['Web', 'API', 'CSS', 'foo']});
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'Web/Foo/bar'),
+                    {base_slug: '', result: ['Web', 'Foo', 'bar']});
+                // - Edge case: legacy `API/CSS/foo` -> `{base_slug: 'API/CSS', result: ['foo']}`,
+                //   but such paths are no longer in use on MDN.
+                chai.assert.deepEqual(
+                    mdn.trimSlugStart(["Web", "CSS"], 'API/CSS/foo'),
+                    {base_slug: 'API/CSS', result: ['foo']});
+            });
+        });
+    });
+});


### PR DESCRIPTION
Part of [bug&nbsp;1519579](https://bugzilla.mozilla.org/show_bug.cgi?id=1519579).

This refactors the&nbsp;sidebar slug processing method to&nbsp;avoid using `String.replace(…)`.

A bonus of this is that sidebar macros (`{{APIRef}}`, `{{CSSRef}}`, etc.) are supported outside of `Web/<namespace>`, eg. `Archive/Web/<namespace>`, `Mozilla/Gecko/Chrome/<namespace>`, etc.

## Depends on:
- [ ] #1107

---

review?(@wbamberg)