### PR TITLE
bug 1483072: remove Jenkins code related to MozMEAO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,11 +89,8 @@ node {
                 test_kumascript('latest')
             }
             stage('Push KumaScript Docker Image') {
-                // TODO: After cutover to IT-owned services, remove this condition.
-                if (!utils.is_mozmeao_pipeline()) {
-                    image('push')
-                    image('push', 'latest')
-                }
+                image('push')
+                image('push', 'latest')
             }
             break
 


### PR DESCRIPTION
This PR is part of the post cut-over cleanup of the Kumascript repo. It removes the Groovy code related to the MozMEAO Jenkins service, which, as of this morning, had its MDN-related pipelines (for Kuma, Kumascript, and the interactive examples) deleted.