### PR TITLE
Bug 1451261, add class to macros for use in custom styling

### DIFF
--- a/macros/NonStandardBadge.ejs
+++ b/macros/NonStandardBadge.ejs
@@ -44,7 +44,7 @@ var titleAttrValue = mdn.localString({
 var str = "";
 
 if ($0) {
-    %><span title="<%=titleAttrValue%>"><i class="icon-warning-sign"> </i></span><%
+    %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-warning-sign"> </i></span><%
 } else {
     str = mdn.localString({
         "ca": "Non-standard",

--- a/macros/ObsoleteBadge.ejs
+++ b/macros/ObsoleteBadge.ejs
@@ -43,7 +43,7 @@ var titleAttrValue = mdn.localString({
 var str = "";
 
 if ($0) {
-    %><span title="<%=titleAttrValue%>""><i class="icon-trash"> </i></span><%
+    %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-trash"> </i></span><%
 } else {
 str = mdn.localString({
     "ca": "Obsolete",


### PR DESCRIPTION
This adds the class `icon-only-inline` that will be used as a hook for custom styling on the Kuma side. This forms part of https://github.com/mozilla/kuma/pull/5058