### PR TITLE
Add trailing slash to Keyboard Lock URL

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -896,7 +896,7 @@
   },
   "Keyboard Lock": {
     "name": "Keyboard Lock",
-    "url": "https://w3c.github.io/keyboard-lock",
+    "url": "https://w3c.github.io/keyboard-lock/",
     "status": "ED"
   },
   "Keyboard Map": {


### PR DESCRIPTION
This change adds a trailing slash to the Keyboard Lock spec URL in SpecData.json.