### PR TITLE
Add tests for remaining Deprecated indicator macros

### DIFF
--- a/macros/DeprecatedBadge.ejs
+++ b/macros/DeprecatedBadge.ejs
@@ -20,6 +20,6 @@ var str = mdn.localString({
 if ($0) {
     %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-thumbs-down-alt"> </i></span><%
 } else {
-    %><%-await template("SimpleBadge", [str, "deprecatedBadge", titleAttrValue])%><%
+    %><%-await template("SimpleBadge", [str, "deprecated", titleAttrValue])%><%
 }
 %>

--- a/macros/DeprecatedGeneric.ejs
+++ b/macros/DeprecatedGeneric.ejs
@@ -24,11 +24,7 @@ if ($1) {
         n = string.trim( string.substr(t, 2) );
         ver = "JavaScript ";
         if (string.length(n) > 0) {
-            if(wiki.pageExists(lang + '/docs/JavaScript/New_in_JavaScript/' + n)) {
-                link = '/' + lang + '/docs/JavaScript/New_in_JavaScript/' + n;
-            } else if(wiki.pageExists('/en-US/docs/JavaScript/New_in_JavaScript/' + n)) {
-                link = '/en-US/docs/JavaScript/New_in_JavaScript/' + n;
-            }
+            link = '/' + lang + '/docs/Web/JavaScript/New_in_JavaScript/' + n;
         }
     } else if (string.startswith(t, "css")) {
         n = string.trim(string.substr(t, 3));
@@ -41,17 +37,13 @@ if ($1) {
         ver = "HTML";
 
         if (string.length(N) > 0) {
-            if(wiki.pageExists('/' + lang + '/docs/HTML/HTML' + N)) {
-                link = '/' + lang + '/docs/HTML/HTML' + N;
-            } else if(wiki.pageExists('/en-US/docs/HTML/HTML' + N)) {
-                link = '/en-US/docs/HTML/HTML' + N;
-            } else if(wiki.pageExists('/' + lang + '/docs/HTML')) {
-                link = '/' + lang + '/docs/HTML';
+            if(wiki.pageExists('/' + lang + '/docs/Web/HTML/HTML' + N) || wiki.pageExists('/en-US/docs/Web/HTML/HTML' + N)) {
+                link = '/' + lang + '/docs/Web/HTML/HTML' + N;
             } else {
-                link = '/en-US/docs/HTML';
+                link = '/' + lang + '/docs/Web/HTML';
             }
         } else {
-            link = '/' + lang + '/docs/HTML';
+            link = '/' + lang + '/docs/Web/HTML';
         }
     } else if (string.startswith(t, "svg")) {
         n = string.trim(string.substr(t, 3));
@@ -129,21 +121,24 @@ var str_desc = mdn.localString({
   "zh-TW": "This feature has been removed from the Web standards. Though some browsers may still support it, it is in the process of being dropped. Do not use it in old or new projects. Pages or Web apps using it may break at any time."
 });
 
-
 switch($0) {
     case 'inline':
-        %><span class="inlineIndicator deprecated deprecatedInline" title="<%=(tip)%>"><%-str%></span><%
+        if (ver) {
+            %><%-await template("SimpleBadge", [str, "deprecated", tip])%><%
+        } else {
+            %><%-await template("DeprecatedBadge")%><%
+        }
         break;
     case 'header':
         if (tip.length) { str = str + " " + tip; }
-        %><div class="blockIndicator deprecated deprecatedHeader">
+        %><div class="blockIndicator deprecated">
             <p><strong><%-str%></strong><br/><%-str_desc%></p>
         </div><%
         break;
     case 'method':
         if (tip.length) { str = str + " " + tip; }
         %><div>
-            <span class="indicatorInHeadline deprecated deprecatedMethod"><%-str%></span>
+            <span class="indicatorInHeadline deprecated"><%-str%></span>
             <h3><%-($2)%></h3>
         </div><%
         break;

--- a/macros/Deprecated_Header.ejs
+++ b/macros/Deprecated_Header.ejs
@@ -5,7 +5,7 @@
 
 var str = $0;
 if (string.IsDigit($0)) {
-  str = "gecko" + $0;
+    str = "gecko" + $0;
 }
 %>
-<%- await template("deprecatedGeneric", ["header", str]) %>
+<%- await template("DeprecatedGeneric", ["header", str]) %>

--- a/macros/Deprecated_Inline.ejs
+++ b/macros/Deprecated_Inline.ejs
@@ -3,7 +3,7 @@
 //
 // NOTE:    "Deprecated" means that the item should no longer be used, but
 //          still functions. If you mean that it no longer works at all,
-//          use the term "obsolete."
+//          use the term "Obsolete."
 //
 // Parameters:
 //
@@ -17,16 +17,14 @@
 var str = $0;
 var type = 0;   // assume we want the text badge
 
-if ($0 && $0 != undefined) {
-    if (string.IsDigit($0)) {
-        str = "gecko" + $0;
-    }
+if ($0 && string.IsDigit($0)) {
+    str = "gecko" + $0;
 } else {
     type = 1;   // switch to the icon indicator if no version specified
 }
 
 if (str.length) {
-    %><%-await template('deprecatedGeneric', ["inline",str])%><%
+    %><%-await template('DeprecatedGeneric', ["inline", str])%><%
 } else {
     %><%-await template('DeprecatedBadge', [type])%><%
 }

--- a/tests/macros/Deprecated.test.js
+++ b/tests/macros/Deprecated.test.js
@@ -1,63 +1,180 @@
 /**
+ * Tests all Deprecated indicator macros
+ *
  * @prettier
  */
-const { assert, itMacro, describeMacro } = require('./utils');
 
-// TODO: Add tests for other {{Deprecated_*}} macros
+// Get necessary modules
+const { assert, itMacro, describeMacro } = require('./utils');
+const { JSDOM } = require('jsdom');
+
+/**
+ * @param {string} result
+ */
+function testHeaderGeneric(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert(
+        dom.firstElementChild.classList.contains('blockIndicator'),
+        "Root element is a 'blockIndicator'"
+    );
+    assert(
+        dom.firstElementChild.classList.contains('deprecated'),
+        "Root element is 'deprecated'"
+    );
+    let header = dom.querySelector('strong');
+    // Block indicator has a header
+    expect(header).toEqual(expect.anything());
+    assert.equal(header.textContent.trim(), 'Deprecated');
+}
+
+/**
+ * @param {string} result
+ */
+function testInline(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert(
+        dom.firstElementChild.classList.contains('inlineIndicator'),
+        "Root element is an 'inlineIndicator'"
+    );
+    assert(
+        dom.firstElementChild.classList.contains('deprecated'),
+        "Root element is 'deprecated'"
+    );
+    assert.equal(dom.textContent.trim(), 'Deprecated');
+    assert.equal(
+        dom.firstElementChild.getAttribute('title'),
+        'This deprecated API should no longer be used, but will probably still work.'
+    );
+}
+
+/**
+ * @param {string} text
+ * @param {string} [title]
+ * @return {(result: string) => void}
+ */
+function testInlineVersioned(text, title = null) {
+    return result => {
+        const dom = JSDOM.fragment(result);
+        expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+        assert(
+            dom.firstElementChild.classList.contains('inlineIndicator'),
+            "Root element is an 'inlineIndicator'"
+        );
+        assert(
+            dom.firstElementChild.classList.contains('deprecated'),
+            "Root element is 'deprecated'"
+        );
+        assert.equal(dom.textContent.trim(), text);
+        if (title) {
+            assert.equal(dom.firstElementChild.getAttribute('title'), title);
+        }
+    };
+}
+
+/**
+ * @param {string} result
+ */
+function testIcon(result) {
+    const dom = JSDOM.fragment(result);
+    expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
+    assert.equal(
+        dom.firstElementChild.getAttribute('title'),
+        'This deprecated API should no longer be used, but will probably still work.'
+    );
+    let icon = dom.querySelector('i.icon-thumbs-down-alt');
+    expect(icon).toEqual(expect.anything());
+}
+
+describeMacro('DeprecatedGeneric', function() {
+    itMacro("Correct result for 'inline'", macro => {
+        return macro.call('inline').then(testInline);
+    });
+
+    itMacro("Correct result for 'header'", macro => {
+        return macro.call('header').then(testHeaderGeneric);
+    });
+});
+
+describeMacro('Deprecated_Header', function() {
+    itMacro('Correct result', macro => {
+        return macro.call().then(testHeaderGeneric);
+    });
+});
+
+describeMacro('DeprecatedBadge', function() {
+    itMacro('Correct result', macro => {
+        return macro.call().then(testInline);
+    });
+
+    itMacro('Correct result (icon)', macro => {
+        return macro.call(true).then(testIcon);
+    });
+});
+
 describeMacro('Deprecated_Inline', function() {
     itMacro('No arguments (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call(),
-            `<span title="This deprecated API should no longer be used, but will probably still work." class="icon-only-inline"><i class="icon-thumbs-down-alt"> </i></span>`
-        );
+        return macro.call().then(testIcon);
     });
-    itMacro('"semver" string only (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('1.9.2'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)">Deprecated since Gecko 1.9.2</span>`
-        );
+
+    itMacro("'semver' string only (en-US)", function(macro) {
+        return macro
+            .call('1.9.2')
+            .then(
+                testInlineVersioned(
+                    'Deprecated since Gecko 1.9.2',
+                    '(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)'
+                )
+            );
     });
+
     itMacro('Numeric version only (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call(45),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
-        );
+        return macro
+            .call(45)
+            .then(
+                testInlineVersioned(
+                    'Deprecated since Gecko 45',
+                    '(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)'
+                )
+            );
     });
+
     itMacro('Gecko-prefixed version (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('gecko45'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
-        );
+        return macro
+            .call('gecko45')
+            .then(
+                testInlineVersioned(
+                    'Deprecated since Gecko 45',
+                    '(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)'
+                )
+            );
     });
+
     itMacro('HTML-prefixed version (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('html4'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/HTML">HTML4</a></span>`
-        );
+        return macro
+            .call('html4')
+            .then(testInlineVersioned('Deprecated since HTML4'));
     });
+
     itMacro('JS-prefixed version (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('js1.7'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/JavaScript/New_in_JavaScript/1.7">JavaScript 1.7</a></span>`
-        );
+        return macro
+            .call('js1.7')
+            .then(testInlineVersioned('Deprecated since JavaScript 1.7'));
     });
+
     itMacro('CSS-prefixed version (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('css2'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since CSS 2</span>`
-        );
+        return macro
+            .call('css2')
+            .then(testInlineVersioned('Deprecated since CSS 2'));
     });
+
     itMacro('CSS-prefixed version (ja)', function(macro) {
         macro.ctx.env.locale = 'ja';
-        return assert.eventually.equal(
-            macro.call('css2'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="">非推奨 CSS 2</span>`
-        );
+        return macro.call('css2').then(testInlineVersioned('非推奨 CSS 2'));
     });
+
     itMacro('Nonsense-prefixed version (en-US)', function(macro) {
-        return assert.eventually.equal(
-            macro.call('foobar13'),
-            `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated</span>`
-        );
+        return macro.call('foobar13').then(testInline);
     });
 });


### PR DESCRIPTION
Based on the code from https://github.com/mdn/kumascript/pull/963.

~~Also adds the `icon-only-inline` class from #981.~~

---

Depends on #1145 and #1106

review?(@davidflanagan)