### PR TITLE
Fix name of the overview page for Background Tasks

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -66,7 +66,7 @@
                             "mozinterruptend" ]
         },
         "Background Tasks": {
-              "overview":     [ "Cooperative Scheduling of Background Tasks API" ],
+              "overview":     [ "Background Tasks API" ],
               "interfaces":   [ "IdleDeadline" ],
               "methods":      [ "Window.cancelIdleCallback()",
                                 "Window.requestIdleCallback()" ],


### PR DESCRIPTION
Although the API is officially "Cooperative Scheduling of Background Tasks API", the shorthand is used for the page name on MDN.