### PR TITLE
bug xxxx: Enable debugger during test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test-macros:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
 	    /node_modules/.bin/mocha --timeout=${TEST_RUN_TIMEOUT} ${TEST_RUN_ARGS} tests/macros
 
+test-debug:
+    docker run ${DOCKER_RUN_ARGS} -p 9229:9229 ${IMAGE} \
+        /node_modules/.bin/mocha --timeout=${TEST_RUN_TIMEOUT} --inspect-brk=0.0.0.0 ${TEST_RUN_ARGS} tests
+
 lint:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
 	    /node_modules/.bin/jshint --show-non-errors lib tests

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ more before you run your local development version of MDN.
     * `node run.js`
 * To run tests:
     * `./node_modules/.bin/mocha tests`
+    * To run the tests with the debugger on
+        * `make test-debug`
+        * The debugger listens on port 9229 and the first line is automatically a breakpoint.
 * To check code quality:
     * `./node_modules/.bin/jshint --show-non-errors lib tests`
         * This will make a racket if it hits `parser.js`


### PR DESCRIPTION
Enable the Node debugger during the test run.

- The debugger is enabled when running the tests with `make test-debug`
- The debugger is exposed on port 9229
- The debugger automatically breaks on the first line of the code

# Next steps:
- [ ] Open or find a bug to link this to.
