### PR TITLE
Add Payment Method Identifiers spec to SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1044,6 +1044,11 @@
     "url": "https://w3c.github.io/payment-handler/",
     "status": "WD"
   },
+  "Payment Method Identifiers": {
+    "name": "Payment Method Identifiers",
+    "url": "https://w3c.github.io/payment-method-id/",
+    "status": "CR"
+  },
   "Permissions API": {
     "name": "Permissions",
     "url": "https://w3c.github.io/permissions/",


### PR DESCRIPTION
This spec describes the format of Payment Method IDs
used by Payment Request API, and includes a registry
of valid standard payment methods, such as "basic-card".