### PR TITLE
Use the name httpRequest for request module

### DIFF
--- a/lib/kumascript/api.js
+++ b/lib/kumascript/api.js
@@ -24,7 +24,7 @@ var url = require('url'),
     async = require('async'),
     Fiber = require('fibers'),
     Future = require('fibers/future'),
-    request = require('request'),
+    httpRequest = require('request'),
     Memcached = require('memcached'),
     ks_errors = require(__dirname + '/errors'),
     ks_utils = require(__dirname + '/utils');
@@ -153,7 +153,7 @@ var APIContext = ks_utils.Class({
     // easily make HTTP requests.
     //
     // TODO: Very permissive. Should there be more restrictions on net access?
-    request: request,
+    request: httpRequest,
 
     // #### zlib
     //


### PR DESCRIPTION
This resolves a keyword collision between the module
and the test framework sinon. Without this fix, attempts
to use the request module while testing KumaScript
macros instead calls into the sinon module's request
component, which doesn't work as expected, breaking
tests.