### PR TITLE
removing the webgl content from the learning area sidebar, and adding…

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -202,8 +202,6 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_6_Working_with_forms' : 'Express Tutorial Part 6: Working with forms',
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Part 7: Deploying to production',
     'Further_resources': 'Further resources',
-    'Advanced_learning_material': 'Advanced learning material',
-      'WebGL_graphics_processing': 'WebGL: Graphics processing',
     'Common_questions': 'Common questions',
       'HTML_questions': 'HTML questions',
       'CSS_questions': 'CSS questions',
@@ -401,8 +399,6 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_6_Working_with_forms' : 'Express Tutorial Teil 6: Mit Formularen arbeiten',
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Teil 7: Die fertige App ausliefern',
     'Further_resources': 'Weitere Ressourcen',
-    'Advanced_learning_material': 'Lernmaterial für Fortgeschrittene',
-      'WebGL_graphics_processing': 'WebGL: Mit Grafiken arbeiten',
     'Common_questions': 'Häufige Fragen',
       'HTML_questions': 'Fragen zu HTML',
       'CSS_questions': 'Fragen zu CSS',
@@ -495,7 +491,7 @@ var text = mdn.localStringMap({
       'CSS_layout': 'Esquemas CSS',
         'CSS_layout_overview': 'Visão geral de esquemas CSS',
         'Introduction' : 'Introdução a esquemas CSS',
-        'Normal_Flow': 'Normal Flow', 
+        'Normal_Flow': 'Normal Flow',
         'Flexbox': 'Flexbox',
         'Grids' : 'Grids',
         'Floats': '"Floats" - Flutuando elementos',
@@ -600,8 +596,6 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_6_Working_with_forms' : 'Tutorial Rápido Parte 6: Trabalhando com formulários',
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Tutorial Rápido Parte 7: Implantando em produção',
     'Further_resources': 'Mais recursos',
-    'Advanced_learning_material': 'Material de aprendizado avançado',
-      'WebGL_graphics_processing': 'WebGL: processamento gráfico',
     'Common_questions': 'Questões gerais',
       'HTML_questions': 'Questões sobre HTML',
       'CSS_questions': 'Questões sobre CSS',
@@ -759,8 +753,6 @@ var text = mdn.localStringMap({
         'Web_application_security' : 'Защищённость веб-приложения',
         'Assessment_DIY_mini_blog' : 'Задание: создание мини блога',
     'Further_resources': 'Дальнейшее чтение',
-    'Advanced_learning_material': 'Расширенный материал для обучения',
-      'WebGL_graphics_processing': 'WebGL: Работа с графикой',
     'Common_questions': 'Общие вопросы',
       'HTML_questions': 'Вопросы по HTML',
       'CSS_questions': 'Вопросы по CSS',
@@ -957,8 +949,6 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_6_Working_with_forms' : 'Express 教程 6： 使用表单',
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express 教程 7： 部署至生产环境',
     'Further_resources': '更多资源',
-    'Advanced_learning_material': '高级学习材料',
-      'WebGL_graphics_processing': 'WebGL：图形处理',
     'Common_questions': '常见问题',
       'HTML_questions': 'HTML 问题',
       'CSS_questions': 'CSS 问题',
@@ -1115,8 +1105,6 @@ var text = mdn.localStringMap({
         'Web_application_security' : 'Web App 安全性',
         'Assessment_DIY_mini_blog' : '親合度：DIY 迷你部落格',
     'Further_resources': '更多資源',
-    'Advanced_learning_material': '進階學習教材',
-      'WebGL_graphics_processing': 'WebGL：圖形處理',
     'Common_questions': '常見問題',
       'HTML_questions': 'HTML 問題',
       'CSS_questions': 'CSS 問題',
@@ -1339,8 +1327,6 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_6_Working_with_forms' : 'Express Tutorial Part 6: Working with forms',
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Part 7: Deploying to production',
     'Further_resources': 'Further resources',
-    'Advanced_learning_material': 'Advanced learning material',
-      'WebGL_graphics_processing': 'WebGL: Graphics processing',
     'Common_questions': 'Common questions',
       'HTML_questions': 'HTML questions',
       'CSS_questions': 'CSS questions',
@@ -1660,14 +1646,6 @@ var text = mdn.localStringMap({
     </details>
   </li>
   <li><a href="#"><strong><%=text['Further_resources']%></strong></a></li>
-  <li class="toggle">
-    <details <%=currentPageIsUnder('Other_learning_material')%>>
-        <summary><%=text['Advanced_learning_material']%></summary>
-        <ol>
-            <li><a href="<%=baseURL%>WebGL"><%=text['WebGL_graphics_processing']%></a></li>
-        </ol>
-    </details>
-  </li>
   <li class="toggle">
     <details <%=currentPageIsUnder('Common_questions')%>>
         <summary><%=text['Common_questions']%></summary>

--- a/macros/WebGLSidebar.ejs
+++ b/macros/WebGLSidebar.ejs
@@ -27,6 +27,7 @@ var text = mdn.localStringMap({
     'webgl_best_practices': 'WebGL best practices',
     'webgl_extensions': 'Using WebGL extensions',
     'basic_2d_example': 'A basic 2D WebGL animation example',
+    'WebGL_by_example': 'WebGL by example',
     'Interfaces': 'Interfaces',
     'Documentation': 'Documentation:',
     'Useful_lists': 'Useful lists',
@@ -51,6 +52,7 @@ var text = mdn.localStringMap({
     'webgl_mvp': 'WebGL model view projection',
     'webgl_best_practices': 'WebGL best practices',
     'webgl_extensions': 'Using WebGL extensions',
+    'WebGL_by_example': 'WebGL by example',
     'Interfaces': 'Interfaces',
     'Documentation': 'Dokumentation:',
     'Useful_lists': 'Nützliche Listen',
@@ -75,6 +77,7 @@ var text = mdn.localStringMap({
     'webgl_mvp': 'WebGL model view projection',
     'webgl_best_practices': 'WebGL best practices',
     'webgl_extensions': 'Using WebGL extensions',
+    'WebGL_by_example': 'WebGL by example',
     'Interfaces': 'Interfaces',
     'Documentation': 'Documentation:',
     'Useful_lists': 'Listes utiles',
@@ -99,6 +102,7 @@ var text = mdn.localStringMap({
     'webgl_mvp': 'WebGL модель, представление, проекция',
     'webgl_best_practices': 'WebGL лучшие практики',
     'webgl_extensions': 'Использование расширений WebGL',
+    'WebGL_by_example': 'WebGL by example',
     'Interfaces': 'Интерфейсы',
     'Documentation': 'Доментация:',
     'Useful_lists': 'Полезные списки',
@@ -136,6 +140,7 @@ var text = mdn.localStringMap({
         <li><a href="/<%=locale%>/docs/Web/API/WebGL_API/WebGL_best_practices"><%=text['webgl_best_practices']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebGL_API/Using_Extensions"><%=text['webgl_extensions']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebGL_API/Basic_2D_animation_example"><%=text['basic_2d_example']%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/API/WebGL_API/By_example"><%=text['WebGL_by_example']%></a></li>
       </ol>
     </details>
   </li>


### PR DESCRIPTION
… it to the WebGL sidebar instead

So I decided to remove the WebGL content from the Learning area; see the description on this page for why: https://developer.mozilla.org/en-US/docs/Learn/WebGL

The "learn by example" articles are still useful, so I've moved them into the WebGL section: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example

This PR accounts for that move in the sidebars for those docs trees.