### PR TITLE
feat(macros): Add proper support for Quicklinks to {{IncludeSubnav}}

### DIFF
--- a/macros/IncludeSubnav.ejs
+++ b/macros/IncludeSubnav.ejs
@@ -6,9 +6,15 @@
 //  $0 - URL of a page with a "Subnav" section to insert.
 //       Example: "/en-US/docs/Games".
 //       Do not use https://etc.
-//  
+
+const QUICK_LINKS_PATTERN = /^<section [^>]*\bid="Quick_Links"[^>]*>[\u0000-\uFFFF]*<\/section>$/;
 
 var url = web.spacesToUnderscores($0);
+var result = wiki.page(url, 'Subnav');
 
-%>
-<%- wiki.page(url, 'Subnav', '', 1) %>
+var isQuickLinks = QUICK_LINKS_PATTERN.test(result.trim());
+
+if (!isQuickLinks) {%>
+<h2 id="Subnav">Subnav</h2>
+<%}%>
+<%- result %>

--- a/tests/macros/test-IncludeSubnav.js
+++ b/tests/macros/test-IncludeSubnav.js
@@ -1,0 +1,54 @@
+/* jshint node: true, mocha: true, esversion: 6 */
+
+// Get necessary modules
+const sinon = require('sinon');
+const { itMacro, describeMacro, beforeEachMacro } = require('./utils');
+const chai = require('chai');
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+
+const SUBNAV = `
+<ol>
+    <li><strong><a href="/en-US/docs/Sandbox">Sandbox</a></strong>
+    <li><strong>Subpages:</strong>
+        <ol>
+            <li><a href="/en-US/docs/Sandbox/Test">Test</a></li>
+        </ol>
+    </li>
+</ol>`;
+
+describeMacro("IncludeSubnav", () => {
+    beforeEachMacro(macro => {
+        macro.ctx.wiki.page = sinon.stub();
+    });
+
+    itMacro("Legacy subnav", macro => {
+        macro.ctx.wiki.page.returns(SUBNAV);
+        return macro.call("/en-US/docs/Sandbox").then(result => {
+            let dom = JSDOM.fragment(result);
+            chai.assert.equal(dom.childElementCount, 2);
+
+            let heading = dom.firstElementChild;
+            chai.assert.equal(heading.id, "Subnav");
+            chai.assert.equal(heading.textContent.trim(), "Subnav");
+
+            let list = dom.lastElementChild;
+            chai.assert.equal(list.nodeName, "OL");
+        });
+    });
+
+    itMacro("Modern quick links", macro => {
+        macro.ctx.wiki.page.returns(`<section id="Quick_Links">${SUBNAV}</section>`);
+        return macro.call("/en-US/docs/Sandbox").then(result => {
+            let dom = JSDOM.fragment(result);
+            chai.assert.equal(dom.childElementCount, 1);
+
+            let section = dom.firstElementChild;
+            chai.assert.equal(section.nodeName, "SECTION");
+            chai.assert.equal(section.id, "Quick_Links");
+
+            let list = section.firstElementChild;
+            chai.assert.equal(list.nodeName, "OL");
+        });
+    });
+});


### PR DESCRIPTION
This makes it so that usage of the `{{IncludeSubnav}}` macro to include quick links inside the “Subnav” section, like I outlined in&nbsp;https://github.com/mdn/kumascript/issues/804#issuecomment-432411269, doesn’t require the macro invocation to be the last occurrence in the page.

review?(@davidflanagan, @Elchi3, @jwhitlock, @wbamberg)