### PR TITLE
Update locales that use new location in event.ejs

### DIFF
--- a/macros/event.ejs
+++ b/macros/event.ejs
@@ -18,7 +18,7 @@ var URL = "/" + lang + "/docs/Web/Events/" + api + $2;
  
 // Locals that don't use the new location yet
 // Remove your local when you have moved your pages
-var filter = ['es', 'ko'];
+let filter = [];
 
 if (filter.indexOf(lang) > -1) { URL = "/" + lang + '/docs/Web/Reference/Events/' + api + $2; }
 

--- a/macros/event.ejs
+++ b/macros/event.ejs
@@ -16,13 +16,6 @@ var str = $1 || $0;
  
 var URL = "/" + lang + "/docs/Web/Events/" + api + $2;
  
-// Locals that don't use the new location yet
-// Remove your local when you have moved your pages
-let filter = [];
-
-if (filter.indexOf(lang) > -1) { URL = "/" + lang + '/docs/Web/Reference/Events/' + api + $2; }
-
- 
 var anch = '';
  
 if ($2) {

--- a/macros/event.ejs
+++ b/macros/event.ejs
@@ -16,11 +16,11 @@ var str = $1 || $0;
  
 var URL = "/" + lang + "/docs/Web/Events/" + api + $2;
  
-// Locals that use the new location
-// Add your local when you have moved your pages
-var filter = ['en-US'];
+// Locals that don't use the new location yet
+// Remove your local when you have moved your pages
+var filter = ['es', 'ko'];
 
-if (filter.indexOf(lang) === -1) { URL = "/" + lang + '/docs/Web/Reference/Events/' + api + $2; }
+if (filter.indexOf(lang) > -1) { URL = "/" + lang + '/docs/Web/Reference/Events/' + api + $2; }
 
  
 var anch = '';


### PR DESCRIPTION
Most of locales have moved to new location (/docs/Web/Events), so corrected to use the list languages which use old locations.
Fixes #1029