### PR TITLE
Fix french slug for SVGAttr

### DIFF
--- a/macros/SVGAttr.ejs
+++ b/macros/SVGAttr.ejs
@@ -2,7 +2,6 @@
 /* one parameter: attribute name */
 var slug = mdn.localString({
     "en-US": "Attribute",
-    "pl"   : "Atrybut"
 });
 
 var URL = "/" + env.locale + "/docs/Web/SVG/" + slug + "/" + $0;

--- a/macros/SVGAttr.ejs
+++ b/macros/SVGAttr.ejs
@@ -3,7 +3,6 @@
 var slug = mdn.localString({
     "en-US": "Attribute",
     "de"   : "Attribut",
-    "fr"   : "Attributs",
     "pl"   : "Atrybut"
 });
 

--- a/macros/SVGAttr.ejs
+++ b/macros/SVGAttr.ejs
@@ -2,7 +2,6 @@
 /* one parameter: attribute name */
 var slug = mdn.localString({
     "en-US": "Attribute",
-    "de"   : "Attribut",
     "pl"   : "Atrybut"
 });
 


### PR DESCRIPTION
The URL for SVG attributes in french is actually [/fr/docs/Web/SVG/Attribute](https://developer.mozilla.org/fr/docs/Web/SVG/Attribute), not Attributs - it shouldn't be localized.