### PR TITLE
Add Media Playback Quality specification

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -949,6 +949,11 @@
     "url": "https://w3c.github.io/mediacapture-fromelement/",
     "status": "WD"
   },
+  "Media Playback Quality": {
+    "name": "Media Playback Quality",
+    "url": "https://wicg.github.io/media-playback-quality/",
+    "status": "ED"
+  },
   "Media Session": {
     "name": "Media Session Standard",
     "url": "https://wicg.github.io/mediasession/",


### PR DESCRIPTION
Adds this specification, currently in draft form, to
SpecData.json. A small bit of the mediasource spec has
moved here.