### PR TITLE
Adding the distribution options page to the sidebar

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -72,7 +72,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': 'Request the right permissions',
     'WebExtensions/API': 'JavaScript APIs',
     'WebExtensions/manifest.json': 'Manifest keys',
-    'WebExtensions/Distribution_options': 'Distribution Options'
+    'WebExtensions/Distribution_options': 'Distribution Options',
     'Themes': 'Themes',
     'Themes/Theme_concepts': 'Browser themes',
     'Themes/Theme_concepts_': 'Browser theme concepts',
@@ -159,7 +159,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': 'Demander les bonnes permissions',
     'WebExtensions/API': 'Les API JavaScript',
     'WebExtensions/manifest.json': 'Clés de manifeste',
-    'WebExtensions/Distribution_options': 'Distribution Options'
+    'WebExtensions/Distribution_options': 'Distribution Options',
     'Themes': 'Thèmes',
     'Themes/Theme_concepts': 'Thème de navigateur',
     'Themes/Theme_concepts_': 'Concepts des thèmes',
@@ -246,7 +246,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': '正しいパーミッションを要求する',
     'WebExtensions/API': 'JavaScript API 群',
     'WebExtensions/manifest.json': 'Manifest keys',
-    'WebExtensions/Distribution_options': 'Distribution Options'
+    'WebExtensions/Distribution_options': 'Distribution Options',
     'Themes': 'テーマ',
     'Themes/Theme_concepts': 'ブラウザのテーマ',
     'Themes/Theme_concepts_': 'ブラウザのテーマのコンセプト',

--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -388,7 +388,6 @@ var text = mdn.localStringMap({
       </details>
     </li>
     <li><a href="<%=baseURL%>WebExtensions/Distribution_options"><%=text['WebExtensions/Distribution_options']%></a></li>
-
     <li><a href="<%=baseURL%>Themes"><strong><%=text['Themes']%></strong></a></li>
     <li class="toggle">
       <details>

--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -72,6 +72,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': 'Request the right permissions',
     'WebExtensions/API': 'JavaScript APIs',
     'WebExtensions/manifest.json': 'Manifest keys',
+    'WebExtensions/Distribution_options': 'Distribution Options'
     'Themes': 'Themes',
     'Themes/Theme_concepts': 'Browser themes',
     'Themes/Theme_concepts_': 'Browser theme concepts',
@@ -158,6 +159,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': 'Demander les bonnes permissions',
     'WebExtensions/API': 'Les API JavaScript',
     'WebExtensions/manifest.json': 'Clés de manifeste',
+    'WebExtensions/Distribution_options': 'Distribution Options'
     'Themes': 'Thèmes',
     'Themes/Theme_concepts': 'Thème de navigateur',
     'Themes/Theme_concepts_': 'Concepts des thèmes',
@@ -244,6 +246,7 @@ var text = mdn.localStringMap({
     'WebExtensions/Request_the_right_permissions': '正しいパーミッションを要求する',
     'WebExtensions/API': 'JavaScript API 群',
     'WebExtensions/manifest.json': 'Manifest keys',
+    'WebExtensions/Distribution_options': 'Distribution Options'
     'Themes': 'テーマ',
     'Themes/Theme_concepts': 'ブラウザのテーマ',
     'Themes/Theme_concepts_': 'ブラウザのテーマのコンセプト',
@@ -384,6 +387,7 @@ var text = mdn.localStringMap({
       %>
       </details>
     </li>
+    <li><a href="<%=baseURL%>WebExtensions/Distribution_options"><%=text['WebExtensions/Distribution_options']%></a></li>
 
     <li><a href="<%=baseURL%>Themes"><strong><%=text['Themes']%></strong></a></li>
     <li class="toggle">


### PR DESCRIPTION
According to this [MDN Sprints Issue #546](https://app.zenhub.com/workspaces/mdn-sprint-board-5ab3d23fd0f4ea53b0022a61/issues/mdn/sprints/546), adding the Distribution Options page to the sidebar under Browser Extensions.