### PR TITLE
Add Screen Capture API (Q4S3)

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1397,6 +1397,22 @@
             "properties": [ "Window.performance" ],
             "events":     []
         },
+        "Screen Capture API": {
+            "guides":     [ { "url":   "/en-US/docs/Web/API/Using_Screen_Capture_API",
+                              "title": "Using the Screen Capture API" }],
+            "methods":    [ "MediaDevices.getDisplayMedia()" ],
+            "properties": [ "MediaTrackConstraintSet.cursor",
+                            "MediaTrackConstraintSet.displaySurface",
+                            "MediaTrackConstraintSet.logicalSurface",
+                            "MediaTrackSettings.cursor",
+                            "MediaTrackSettings.displaySurface",
+                            "MediaTrackSettings.logicalSurface",
+                            "MediaTrackSupportedConstraints.cursor",
+                            "MediaTrackSupportedConstraints.displaySurface",
+                            "MediaTrackSupportedConstraints.logicalSurface" ],
+            "types":      [ "CursorCaptureConstraintSet",
+                            "DisplayCaptureSurfaceType" ]
+        },
         "Screen Orientation API": {
             "guides":     [ { "url":   "/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation",
                               "title": "Managing screen orientation" } ],

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1398,8 +1398,10 @@
             "events":     []
         },
         "Screen Capture API": {
-            "guides":     [ { "url":   "/en-US/docs/Web/API/Using_Screen_Capture_API",
+            "guides":     [ { "url":   "/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture_API",
                               "title": "Using the Screen Capture API" }],
+            "interfaces": [],
+            "dictionaries": [],
             "methods":    [ "MediaDevices.getDisplayMedia()" ],
             "properties": [ "MediaTrackConstraintSet.cursor",
                             "MediaTrackConstraintSet.displaySurface",
@@ -1411,7 +1413,8 @@
                             "MediaTrackSupportedConstraints.displaySurface",
                             "MediaTrackSupportedConstraints.logicalSurface" ],
             "types":      [ "CursorCaptureConstraintSet",
-                            "DisplayCaptureSurfaceType" ]
+                            "DisplayCaptureSurfaceType" ],
+            "events":     []
         },
         "Screen Orientation API": {
             "guides":     [ { "url":   "/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation",


### PR DESCRIPTION
Adds the Screen Capture API, which adds methods and
properties to interfaces from other specifications,
introduces two new data types, and one new guide page.

Part of the Chaka Khan sprint.