### PR TITLE
fix(node/DEP0005): Disallow deprecated `Buffer(…)` constructor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
         "ecmaVersion": 2018
     },
     "rules": {
+        "no-buffer-constructor": "error",
         "no-unused-vars": ["error", {
             "args": "none",
             "varsIgnorePattern": "^_",


### PR DESCRIPTION
This replaces usage of&nbsp;the&nbsp;deprecated `Buffer(…)` constructor with the&nbsp;`Buffer.alloc(…)` and&nbsp;`Buffer.from(…)` methods.

## External links:
- https://nodejs.org/en/docs/guides/buffer-constructor-deprecation

---

Blocks [bug&nbsp;1505084](https://bugzilla.mozilla.org/show_bug.cgi?id=1505084)
Depends on #1033

review?(@davidflanagan, @Elchi3, @jwhitlock, @wbamberg)