### PR TITLE
Fix URL of Feature Policy spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -726,7 +726,7 @@
   },
   "Feature Policy": {
     "name": "Feature Policy",
-    "url": "https://wicg.github.io/feature-policy/",
+    "url": "https://w3c.github.io/webappsec-feature-policy/",
     "status": "Draft"
   },
   "Fetch": {


### PR DESCRIPTION
The repo belonging to the currently linked GitHub Pages site for the Feature Policy spec has apparently been moved from wicg/feature-policy to w3c/webappsec-feature-policy (the current link itself yields error 404, however the old repository is redirected to the new location). This updates the link in SpecData.json accordingly.