### PR TITLE
bug 1404669: optional cleanup

### DIFF
--- a/lib/kumascript/conf.js
+++ b/lib/kumascript/conf.js
@@ -39,9 +39,7 @@ var DEFAULT_CONFIG = {
         workerRetries: 3,
         template_root_dir: "macros",
         document_url_template:
-            "https://developer.mozilla.org/en-US/docs/{path}?raw=1",
-        template_url_template:
-            "https://developer.mozilla.org/en-US/docs/Template:{name}?raw=1",
+            "https://developer.mozilla.org/en-US/docs/{path}?raw=1&redirect=no",
         template_cache_control: 'max-age=3600'
     },
     repl: {

--- a/lib/kumascript/server.js
+++ b/lib/kumascript/server.js
@@ -37,9 +37,7 @@ var Server = ks_utils.Class({
         // Port on which the HTTP service will listen.
         port: 9000,
         // Template used to resolve incoming URL paths to document source URLs.
-        document_url_template: "http://localhost:9001/docs/{path}?raw=1",
-        // Template used to resolve macro names to URLs for the loader.
-        template_url_template: "http://localhost:9001/templates/{name}?raw=1",
+        document_url_template: "http://localhost:9001/docs/{path}?raw=1&redirect=no",
         // Root dir (relative) from which to load macros for the loader.
         template_root_dir: "macros",
         // Default cache-control header to send with HTTP loader
@@ -98,7 +96,6 @@ var Server = ks_utils.Class({
                     options: {
                         memcache: this.options.memcache,
                         statsd_conf: this.options.statsd_conf,
-                        url_template: this.options.template_url_template,
                         cache_control: this.options.template_cache_control,
                         root_dir: this.options.template_root_dir,
                         max_retries: this.options.loader_max_retries,


### PR DESCRIPTION
This PR performs some minor cleanup related to the work that was done for  [bug 1404669](https://bugzilla.mozilla.org/show_bug.cgi?id=1404669). None of this cleanup is required to actually fix the bug.

- update the default setting for `document_url_template`  to reflect the addition of `redirect=no`
- the `template_url_template` setting has been obsolete for some time, so it has been removed
