### PR TITLE
bug 1505084: Use node 10 in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: node_js
 node_js:
-    - "8"
+    - "10"
 
 services:
   - docker


### PR DESCRIPTION
We don't use much of node in TravisCI, but we may start, and node 10 might be faster to start these days.