### PR TITLE
Update Intl API list for the JS sidebar

### DIFF
--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -59,7 +59,7 @@ if (typeof inheritanceData[mainObj] != 'undefined') {
 // Data for related pages
 var groupData = {
     "Error": ["Error", "EvalError", "InternalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"],
-    "Intl": ["Intl", "Collator", "DateTimeFormat", "NumberFormat", "PluralRules"],
+    "Intl": ["Intl", "Collator", "DateTimeFormat", "ListFormat", "NumberFormat", "PluralRules", "RelativeTimeFormat"],
     "TypedArray": ["TypedArray", "Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
                    "Int32Array", "Uint32Array", "Float32Array", "Float64Array"],
     "Proxy": ["Proxy", "handler"],


### PR DESCRIPTION
This is so that the "Related pages" list in the JS sidebar shows the latest Intl constructors that were added. See e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl

Another special JS sidebar feature... :/