### PR TITLE
Add a Makefile target to run tests and output junit test results.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,16 +5,16 @@
 def test(docker_tag='') {
     def jenkins_uid = sh(script: 'id -u jenkins', returnStdout: true).trim()
     // The user ID within the Docker container must match the "jenkins"
-    // user ID so that it's able to create the "test-results.xml" file.
+    // user ID so that it's able to create the "test-report.xml" file.
     def run_args = "-u ${jenkins_uid}" + ' -v ${PWD}:${APP_DIR} -w ${APP_DIR}'
     try {
         withEnv(["VERSION=${docker_tag}",
                  "DOCKER_RUN_ARGS=${run_args}"]) {
-            utils.sh_with_notify("make test",
+            utils.sh_with_notify("make test-junit",
                                  "Test the Kumascript code and macros")
         }
     } finally {
-        junit 'test-results.xml'
+        junit 'test-report.xml'
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ test:
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
 	  /node_modules/.bin/jest -w1
 
+test-junit:
+	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \
+	  /node_modules/.bin/jest --ci --testResultsProcessor="/node_modules/jest-junit-reporter"
+
 test-coverage:
 	rm -rf coverage
 	docker run ${DOCKER_RUN_ARGS} ${IMAGE} \

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ src/parser.js: src/parser.pegjs
 	echo "/* eslint-disable */" > src/parser.js
 	npx pegjs -o - src/parser.pegjs >> src/parser.js
 
-.PHONY: clean run local-tests test test-coverage lint lint-json bash shrinkwrap
+.PHONY: clean run local-tests test test-junit test-coverage lint lint-json bash shrinkwrap

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3623,6 +3623,15 @@
                 "pretty-format": "^23.6.0"
             }
         },
+        "jest-junit-reporter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jest-junit-reporter/-/jest-junit-reporter-1.1.0.tgz",
+            "integrity": "sha1-iNYAbsE/gt9AxHiCyGQJic3LFDQ=",
+            "dev": true,
+            "requires": {
+                "xml": "^1.0.1"
+            }
+        },
         "jest-leak-detector": {
             "version": "23.6.0",
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
@@ -6513,6 +6522,12 @@
             "requires": {
                 "async-limiter": "~1.0.0"
             }
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "eslint-plugin-jest": "^22.1.2",
         "eslint-plugin-prettier": "^3.0.1",
         "jest": "^23.6.0",
+        "jest-junit-reporter": "^1.1.0",
         "jsonlint": "^1.6.3",
         "pegjs": "^0.10.0",
         "prettier": "^1.15.3"


### PR DESCRIPTION
The Jenkinsfile expects a test report in junit format. This patch adds
a Jest plugin to generate that report and adds a Makefile target to
run tests using that plugin.