### PR TITLE
adding input events level 1 spec to spec data

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -889,6 +889,11 @@
     "url": "https://wicg.github.io/InputDeviceCapabilities/",
     "status": "Draft"
   },
+  "InputEvents1": {
+    "name": "Input Events Level 1",
+    "url": "https://rawgit.com/w3c/input-events/v1/",
+    "status": "WD"
+  },
   "InputEvents2": {
     "name": "Input Events Level 2",
     "url": "https://w3c.github.io/input-events/",


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1447239 for reference

According to the bug, the added inputType property is implemented as per the L1 spec, so we shold refer to the L1 spec in the documentation (as well as L2)