### PR TITLE
Delete JSObjectOps_warning

### DIFF
--- a/macros/JSObjectOps_warning.ejs
+++ b/macros/JSObjectOps_warning.ejs
@@ -1,7 +1,0 @@
-<%
-var text = "<code>JSObjectOps</code> is not a supported API. Details of the API may change from one release to the next. " +
-           "This documentation should be considered SpiderMonkey internals documentation, not API documentation. See " +
-           await template("Bug", ["408416"]) + " for details."
-
-
-%><%-await template("Warning", [text])%>


### PR DESCRIPTION
I've seen some massacre going on and I'd like to remind you that "guillotine" is a French word.

Replaced the macro by the content it produced on the 11 pages: https://developer.mozilla.org/en-US/search?locale=en-US&kumascript_macros=JSObjectOps_warning&topic=none
No other ref in the code as well: https://github.com/mdn/kumascript/search?q=JSObjectOps_warning&unscoped_q=JSObjectOps_warning

(P.S. low-hanging fruit but still another one to bite the dust. :))