### PR TITLE
Deleting Referencia_XSLT

### DIFF
--- a/macros/Referencia_XSLT.ejs
+++ b/macros/Referencia_XSLT.ejs
@@ -1,1 +1,0 @@
-<%- await template("XsltRef") %>


### PR DESCRIPTION
Marie Kondo: What is this?
\me: an old macro which was an alias for `XsltRef`
Marie Kondo: Does this spark joy?
\me: nope, not exactly
Marie Kondo: Then thank it and remove it
\me: 🔥