### PR TITLE
Add tests for GroupData

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1435,7 +1435,7 @@
             "events":     [ "change" ]
         },
         "Selection API": {
-            "interface":  [ "Selection" ],
+            "interfaces":  [ "Selection" ],
             "properties": [ "Document.onselectionchange",
                             "GlobalEventHandlers.onselectstart" ],
             "methods":    [ "Document.getSelection()",
@@ -1893,6 +1893,7 @@
                             "AuthenticatorResponse",
                             "AuthenticatorAttestationResponse",
                             "AuthenticatorAssertionResponse" ],
+            "methods":    [],
             "properties": [],
             "events":     []
         },

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1435,7 +1435,7 @@
             "events":     [ "change" ]
         },
         "Selection API": {
-            "interfaces":  [ "Selection" ],
+            "interfaces": [ "Selection" ],
             "properties": [ "Document.onselectionchange",
                             "GlobalEventHandlers.onselectstart" ],
             "methods":    [ "Document.getSelection()",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -658,7 +658,7 @@
                             "gamepaddisconnected" ]
         },
         "Geolocation API": {
-            "guide":      [ { "url":   "/en-US/docs/Web/API/Geolocation/Using_geolocation",
+            "guides":     [ { "url":  "/en-US/docs/Web/API/Geolocation/Using_geolocation",
                               "title": "Using geolocation" } ],
             "interfaces": [ "Coordinates",
                             "Geolocation",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -658,7 +658,7 @@
                             "gamepaddisconnected" ]
         },
         "Geolocation API": {
-            "guides":     [ { "url":  "/en-US/docs/Web/API/Geolocation/Using_geolocation",
+            "guides":     [ { "url":   "/en-US/docs/Web/API/Geolocation/Using_geolocation",
                               "title": "Using geolocation" } ],
             "interfaces": [ "Coordinates",
                             "Geolocation",

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -52,7 +52,7 @@ function checkGroupData(groupDataJson) {
   for (let groupName of groupNames) {
     // the group name contains only the permitted characters
     expect(permittedCharacters.group.test(groupName)).toBe(true);
-    group = groupData[0][groupName];
+    const group = groupData[0][groupName];
 
     // the group contains interfaces, properties, methods and events
     // they are all string arrays and contain only the permitted characters

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -71,10 +71,10 @@ Check that `obj` contains:
 function checkProperties(obj, permitted, mandatory) {
   let props = Object.keys(obj);
   for (let prop of props) {
-    expect(permitted.includes(prop)).toBe(true);
+    expect(permitted).toContain(prop);
   }
   for (let prop of mandatory) {
-    expect(props.includes(prop)).toBe(true);
+    expect(props).toContain(prop);
   }
 }
 
@@ -85,7 +85,7 @@ and that each string matches the given regex.
 function checkStringArray(strings, permitted) {
   expect(Array.isArray(strings)).toBe(true);
   for (let string of strings) {
-    expect(permitted.test(string)).toBe(true);
+    expect(string).toMatch(permitted)
   }
 }
 
@@ -107,7 +107,7 @@ function checkGroupData(groupDataJson) {
   for (let groupName of groupNames) {
 
     // the group name contains only the permitted characters
-    expect(permittedCharacters.group.test(groupName)).toBe(true);
+    expect(groupName).toMatch(permittedCharacters.group);
 
     const group = groupData[0][groupName];
 
@@ -134,7 +134,7 @@ function checkGroupData(groupDataJson) {
     // overview is optional
     if (group.overview) {
       // if present it must contain only the permitted characters
-      expect(permittedCharacters.overview.test(group.overview)).toBe(true);
+      expect(group.overview).toMatch(permittedCharacters.overview);
     }
 
     // guides is optional
@@ -146,8 +146,8 @@ function checkGroupData(groupDataJson) {
         checkProperties(guide, permittedGuideProperties, mandatoryGuideProperties);
 
         // these are both strings that contain only the permitted characters
-        expect(permittedCharacters.guideTitle.test(guide.title)).toBe(true);
-        expect(permittedCharacters.guideUrl.test(guide.url)).toBe(true);
+        expect(guide.title).toMatch(permittedCharacters.guideTitle);
+        expect(guide.url).toMatch(permittedCharacters.guideUrl);
       }
     }
 

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -11,7 +11,7 @@ permitted characters.
 const permittedCharacters = {
   group:      /^[\w ()-]+$/,
   overview:   /^[\w ()-]+$/,
-  interface:  /^[\w.]+$/,
+  interface:  /^[A-Z][\w.]+$/,
   property:   /^[\w.]+$/,
   method:     /^[\w.()]+$/,
   event:      /^[\w()]+$/,

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -133,8 +133,11 @@ function checkGroupData(groupDataJson) {
 
     // overview is optional
     if (group.overview) {
-      // if present it must contain only the permitted characters
-      expect(group.overview).toMatch(permittedCharacters.overview);
+      // if present it is an array containing 1 element
+      expect(Array.isArray(group.overview)).toBe(true);
+      expect(group.overview.length).toBe(1);
+      // ... and the element must contain only the permitted characters
+      expect(group.overview[0]).toMatch(permittedCharacters.overview);
     }
 
     // guides is optional

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -1,0 +1,91 @@
+/**
+ * @prettier
+ */
+
+const { itMacro, describeMacro } = require('./utils');
+
+/*
+Different strings in GroupData objects have different sets of
+permitted characters.
+*/
+const permittedCharacters = {
+  group:      /^[\w ()-]+$/,
+  overview:   /^[\w ()-]+$/,
+  interface:  /^[\w.]+$/,
+  property:   /^[\w.]+$/,
+  method:     /^[\w.()]+$/,
+  event:      /^[\w()]+$/,
+  guideTitle: /^[\w .,]+$/,
+  guideUrl:   /^\/[\w-.~/]+$/
+}
+
+/*
+Given `strings`, which should be an array of strings,
+and `characters`, which is a regular expression defining
+the permitted characters in each string, this checks
+that `strings` really is an array and that the strings
+it contains contain only the permitted characters.
+*/
+function checkStringArray(strings, characters) {
+  expect(strings).toBeDefined();
+  expect(Array.isArray(strings)).toBe(true);
+  for (let string of strings) {
+    expect(characters.test(string)).toBe(true);
+  }
+}
+
+/*
+Performs basic validation of the GroupData JSON object
+*/
+function checkGroupData(groupDataJson) {
+
+  const groupData = JSON.parse(groupDataJson);
+
+  // GroupData is an array containing exactly one object
+  expect(Array.isArray(groupData)).toBe(true);
+  expect(groupData.length).toBe(1);
+
+  // the one object has one property for each group
+  // the property's key is the group name
+  const groupNames = Object.keys(groupData[0]);
+
+  for (let groupName of groupNames) {
+    // the group name contains only the permitted characters
+    expect(permittedCharacters.group.test(groupName)).toBe(true);
+    group = groupData[0][groupName];
+
+    // the group contains interfaces, properties, methods and events
+    // they are all string arrays and contain only the permitted characters
+    checkStringArray(group.interfaces, permittedCharacters.interface);
+    checkStringArray(group.properties, permittedCharacters.property);
+    checkStringArray(group.methods, permittedCharacters.method);
+    checkStringArray(group.events, permittedCharacters.event);
+
+    // overview is optional
+    if (group.overview) {
+      // if present it must contain only the permitted characters
+      expect(permittedCharacters.overview.test(group.overview)).toBe(true);
+    }
+
+    // guides is optional
+    if (group.guides) {
+      // if present it is an array...
+      expect(Array.isArray(group.guides)).toBe(true);
+      for (let guide of group.guides) {
+        // ...containing objects that have title and url properties
+        // these are both strings that contain only the permitted characters
+        expect(guide.title).toBeDefined();
+        expect(permittedCharacters.guideTitle.test(guide.title)).toBe(true);
+        expect(guide.url).toBeDefined();
+        expect(permittedCharacters.guideUrl.test(guide.url)).toBe(true);
+      }
+    }
+
+  }
+}
+
+describeMacro('GroupData', function() {
+    itMacro('Validate GroupData JSON', function(macro) {
+        return macro.call().then(checkGroupData);
+    });
+});

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -85,7 +85,7 @@ and that each string matches the given regex.
 function checkStringArray(strings, permitted) {
   expect(Array.isArray(strings)).toBe(true);
   for (let string of strings) {
-    expect(string).toMatch(permitted)
+    expect(string).toMatch(permitted);
   }
 }
 

--- a/tests/macros/groupdata.test.js
+++ b/tests/macros/groupdata.test.js
@@ -4,7 +4,7 @@
 
 const { itMacro, describeMacro } = require('./utils');
 
-/*
+/**
 Different strings in GroupData objects have different sets of
 permitted characters.
 */
@@ -22,7 +22,7 @@ const permittedCharacters = {
   guideUrl:   /^\/[\w-.~/]+$/
 }
 
-/*
+/**
 Properties that are allowed in a group
 */
 const permittedGroupProperties = [
@@ -37,7 +37,7 @@ const permittedGroupProperties = [
   'guides'
 ];
 
-/*
+/**
 Properties that must be present in a group
 */
 const mandatoryGroupProperties = [
@@ -47,7 +47,7 @@ const mandatoryGroupProperties = [
   'events',
 ];
 
-/*
+/**
 Properties that are allowed in a guide
 */
 const permittedGuideProperties = [
@@ -55,7 +55,7 @@ const permittedGuideProperties = [
   'url'
 ];
 
-/*
+/**
 Properties that must be present in a guide
 */
 const mandatoryGuideProperties = [
@@ -63,7 +63,7 @@ const mandatoryGuideProperties = [
   'url'
 ];
 
-/*
+/**
 Check that `obj` contains:
 * only the properties in `permitted`
 * all the properties in `mandatory`
@@ -78,7 +78,7 @@ function checkProperties(obj, permitted, mandatory) {
   }
 }
 
-/*
+/**
 Check that `strings` is an array of strings,
 and that each string matches the given regex.
 */
@@ -89,7 +89,7 @@ function checkStringArray(strings, permitted) {
   }
 }
 
-/*
+/**
 Performs basic validation of the GroupData JSON object
 */
 function checkGroupData(groupDataJson) {


### PR DESCRIPTION
This adds a test for GroupData.json. There's no spec for this structure, so I've looked at the macros that use it to try to figure out what kinds of assumptions they make about the data.

I've treated four of the properties - `interfaces`, `methods`, `properties`, and `events` - as mandatory arrays even if they are empty. As far as I can tell only `events` is actually assumed to be present (in [eventref.ejs](https://github.com/mdn/kumascript/blob/master/macros/eventref.ejs#L36)). However, since `properties` is already present in all groups, and `methods` and `interfaces` are present in all but one group ([and one of those is apparently an error](https://github.com/mdn/kumascript/blob/master/macros/GroupData.json#L1438)), well, it seemed simpler and safer to require all four in the tests, and to add the missing ones to the data.

I've tried to require that strings contain only a restricted set of characters, based on what they already contain and what seems sensible. Macros that use this data sometimes [insert it into the HTML output](https://github.com/mdn/kumascript/blob/master/macros/APIRef.ejs#L263) without any sanitation, so for example stuff like this:

```
        "Alarm API": {
            "overview":   [ "Alarm<strong> API"],
            "interfaces": [ "MozAlarmsManager" ],
            "methods":    [ "Navigator.mozSetMessageHandler()"],
            "properties": [ "Navigator.mozAlarms" ],
            "events":     []
        },
```

...would break pages.

I've tried to use the new testing framework to some extent anyway. I've used `expect` instead of `assert`, but I've not restructured the code to enable (the equivalent of) assertion messages by making every assertion a separate test, since that seems like that will make this code more complicated and verbose. I guess if we decide to use https://github.com/mattphillips/jest-expect-message then it's easy to add assertion messages to this code.