### PR TITLE
Delete renamed_inline

### DIFF
--- a/macros/renamed_inline.ejs
+++ b/macros/renamed_inline.ejs
@@ -1,9 +1,0 @@
-<%
-// Use this as an inline indicator that something was renamed in a given Gecko release.
-//
-// Parameters:
-//  $0 - API name
-//  $1 - Gecko release it was renamed in
-
-
-%><span title="<%-await template("geckoRelease", [$1])%>" class="inlineIndicator renamed renamedInline">Renamed from <code><%=$0%></code> in Gecko <%=$1%></span>


### PR DESCRIPTION
More like renamed_deleted if you ask me.

References across MDN content: https://developer.mozilla.org/en-US/search?locale=*&kumascript_macros=renamed_inline&topic=none
References across KS codebase: https://github.com/mdn/kumascript/search?q=renamed_inline&unscoped_q=renamed_inline

When life gives you macros, you have to delete them and drink a lemonade. You can't make lemonade out of macros.