### PR TITLE
docs: Add JSDoc to all built‑in library files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,28 @@
             "args": "none",
             "varsIgnorePattern": "^_",
             "argsIgnorePattern": "^_"
-        }]
+        }],
+        "valid-jsdoc": [
+            "warn",
+            {
+                "requireParamType": true,
+                "requireParamDescription": false,
+                "requireReturn": false,
+                "requireReturnType": true,
+                "requireReturnDescription": false,
+
+                "prefer": {
+                    "arg": "param",
+                    "argument": "param",
+                    "returns": "return"
+                },
+
+                "preferType": {
+                    "Boolean": "boolean",
+                    "Number": "number",
+                    "String": "string"
+                }
+            }
+        ]
     }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -50,6 +50,12 @@
                 "methods": "^1.1.2"
             }
         },
+        "@types/pegjs": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.1.tgz",
+            "integrity": "sha512-ra8IchO9odGQmYKbm+94K58UyKCEKdZh9y0vxhG4pIpOJOBlC1C+ZtBVr6jLs+/oJ4pl+1p/4t3JtBA8J10Vvw==",
+            "dev": true
+        },
         "@tyriar/fibonacci-heap": {
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "request": "2.88.0"
     },
     "devDependencies": {
+        "@types/pegjs": "^0.10.0",
         "eslint": "^5.12.0",
         "eslint-config-prettier": "^3.3.0",
         "eslint-plugin-jest": "^22.1.2",

--- a/src/cache-lru.js
+++ b/src/cache-lru.js
@@ -6,7 +6,7 @@
 const LRU = require('lru-cache');
 const config = require('./config.js');
 
-/** @type {LRU.Cache<string, Buffer>} */
+/** @type {LRU<string, Buffer>} */
 const lru = new LRU({
     max: 1024 * 1024 * config.cacheMegabytes,
     maxAge: 60000 * config.cacheMinutes,

--- a/src/cache-lru.js
+++ b/src/cache-lru.js
@@ -6,6 +6,7 @@
 const LRU = require('lru-cache');
 const config = require('./config.js');
 
+/** @type {LRU.Cache<string, Buffer>} */
 const lru = new LRU({
     max: 1024 * 1024 * config.cacheMegabytes,
     maxAge: 60000 * config.cacheMinutes,
@@ -16,6 +17,10 @@ const lru = new LRU({
 });
 
 module.exports = {
+    /**
+     * @param {string} key
+     * @return {string|null}
+     */
     get(key) {
         let cached = lru.get(key);
         if (cached instanceof Buffer) {
@@ -24,6 +29,11 @@ module.exports = {
             return null;
         }
     },
+
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
     set(key, value) {
         lru.set(key, Buffer.from(value));
     }

--- a/src/cache-redis.js
+++ b/src/cache-redis.js
@@ -8,6 +8,10 @@ const config = require('./config.js');
 const client = Redis.createClient(config.redisURL);
 
 module.exports = {
+    /**
+     * @param {string} key
+     * @return {Promise<string|null>}
+     */
     async get(key) {
         return new Promise(function(resolve, reject) {
             client.get(key, (err, response) => {
@@ -23,6 +27,10 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
     set(key, value) {
         client.set(key, value, 'EX', config.cacheMinutes * 60);
     }

--- a/src/cache.js
+++ b/src/cache.js
@@ -10,10 +10,12 @@
  */
 const config = require('./config.js');
 
-// The cache() function that is exported by this module needs async
-// get and set functions that represent the actual caching
-// operations. If our configuration includes Redis we'll use
-// that. Otherwise we'll fall back to an in-memory LRU cache.
+/**
+ * The cache() function that is exported by this module needs async
+ * get and set functions that represent the actual caching
+ * operations. If our configuration includes Redis we'll use
+ * that. Otherwise we'll fall back to an in-memory LRU cache.
+ */
 const backend = config.redisURL
     ? require('./cache-redis.js')
     : require('./cache-lru.js');
@@ -27,6 +29,11 @@ const backend = config.redisURL
  * Note that computeValue() is expected to be an async function, and
  * we await its result. The result is that this function is async even
  * though the current LRU-based cache is not itself async.
+ *
+ * @param {string} key
+ * @param {function():string|PromiseLike<string|null>|null} computeValue
+ * @param {boolean} [skipCache]
+ * @return {Promise<string>}
  */
 async function cache(key, computeValue, skipCache = false) {
     if (!skipCache) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -45,14 +45,19 @@ const util = {
         }
         return obj;
     },
-
-    // This function takes a function argument that asynchronously
-    // computes a value and passes that value to a callback
-    // function. It returns a Promise-based version of f. Note that
-    // f() calls its callback with a single success value and there is
-    // no provision for reporting async errors.  That is not ideal,
-    // but it is the legacy system that the cacheFn() and
-    // cacheFnIgnoreCacheControl() functions below use.
+    /**
+     * This function takes a function argument that asynchronously
+     * computes a value and passes that value to a callback
+     * function. It returns a Promise-based version of f. Note that
+     * f() calls its callback with a single success value and there is
+     * no provision for reporting async errors.  That is not ideal,
+     * but it is the legacy system that the cacheFn() and
+     * cacheFnIgnoreCacheControl() functions below use.
+     *
+     * @template T
+     * @param {function(function((T|PromiseLike<T>)):void):void} f
+     * @return {function():Promise<T>}
+     */
     promiseify(f) {
         return function() {
             return new Promise((resolve, reject) => {
@@ -79,6 +84,9 @@ const util = {
      * need to be prefixed by "/en-US/docs", as well as ensuring
      * it starts with a "/" and replacing its spaces (whether
      * encoded or not) with underscores.
+     *
+     * @param {string} path
+     * @return {string}
      */
     preparePath(path) {
         if (path.charAt(0) != '/') {
@@ -107,7 +115,8 @@ const util = {
      * "path" argument is not provided or is falsy, the base URL of
      * the document service will be returned.
      *
-     * @param {string} path;
+     * @param {string} [path]
+     * @return {string}
      */
     apiURL(path) {
         if (!path) {
@@ -122,7 +131,7 @@ const util = {
      * #### htmlEscape(string)
      * Escape the given string for HTML inclusion.
      *
-     * @param {string} s
+     * @param {string} [s]
      * @return {string}
      */
     htmlEscape(s) {
@@ -133,6 +142,10 @@ const util = {
             .replace(/"/g, '&quot;');
     },
 
+    /**
+     * @param {string} a
+     * @return {string}
+     */
     escapeQuotes(a) {
         var b = '';
         for (var i = 0, len = a.length; i < len; i++) {
@@ -145,6 +158,10 @@ const util = {
         return b.replace(/(<([^>]+)>)/gi, '');
     },
 
+    /**
+     * @param {string} str
+     * @return {string}
+     */
     spacesToUnderscores(str) {
         var re1 = / /gi;
         var re2 = /%20/gi;
@@ -177,6 +194,10 @@ const mdnPrototype = {
      * Given a set of names and a corresponding list of values, apply HTML
      * escaping to each of the values and return an object with the results
      * associated with the names.
+     *
+     * @param {string[]} names
+     * @param {string[]} args
+     * @return {Record<string, string>}
      */
     htmlEscapeArgs(names, args) {
         var e = {};
@@ -190,6 +211,9 @@ const mdnPrototype = {
      * Given a set of strings like this:
      *     { "en-US": "Foo", "de": "Bar", "es": "Baz" }
      * Return the one which matches the current locale.
+     *
+     * @param {Record<string, string>} strings
+     * @return {string}
      */
     localString(strings) {
         var lang = this.env.locale;
@@ -202,6 +226,9 @@ const mdnPrototype = {
      *     { "en-US": {"name": "Foo"}, "de": {"name": "Bar"} }
      * Return a map which matches the current locale, falling back to en-US
      * properties when the localized map contains partial properties.
+     *
+     * @param {Record<string, Record<string, string>>} maps
+     * @return {Record<string, string>}
      */
     localStringMap(maps) {
         var lang = this.env.locale;
@@ -223,16 +250,21 @@ const mdnPrototype = {
 
     /**
      * Given a set of strings like this:
-     *   {
-     *    "hello": { "en-US": "Hello!", "de": "Hallo!" },
-     *    "bye": { "en-US": "Goodbye!", "de": "Auf Wiedersehen!" }
-     *   }
+     *
+     *    {
+     *      "hello": { "en-US": "Hello!", "de": "Hallo!" },
+     *      "bye": { "en-US": "Goodbye!", "de": "Auf Wiedersehen!" }
+     *    }
+     *
      * Returns the one, which matches the current locale.
      *
-     * Example:
-     *   getLocalString({"hello": {"en-US": "Hello!", "de": "Hallo!"}},
-     *       "hello");
-     *   => "Hallo!" (in case the locale is 'de')
+     * @example
+     *    getLocalString({"hello": {"en-US": "Hello!", "de": "Hallo!"}}, "hello");
+     *    // => "Hallo!" (in case the locale is 'de')
+     *
+     * @param {Record<string, Record<string, string>>} strings
+     * @param {string} key
+     * @return {string}
      */
     getLocalString(strings, key) {
         if (!strings.hasOwnProperty(key)) {
@@ -260,14 +292,19 @@ const mdnPrototype = {
      * be an object. Its property names represent the placeholder
      * names and their values the values to be inserted.
      *
-     * Examples:
+     * @example
      *   replacePlaceholders("$1$ $2$, $1$ $3$!",
      *                       ["hello", "world", "contributor"])
-     *   => "hello world, hello contributor!"
+     * // => "hello world, hello contributor!"
      *
+     * @example
      *   replacePlaceholders("$hello$ $world$, $hello$ $contributor$!",
      *       {hello: "hallo", world: "Welt", contributor: "Mitwirkender"})
-     *   => "hallo Welt, hallo Mitwirkender!"
+     * // => "hallo Welt, hallo Mitwirkender!"
+     *
+     * @param {string} string
+     * @param {Record<string, string>} replacements
+     * @return {string}
      */
     replacePlaceholders(string, replacements) {
         function replacePlaceholder(placeholder) {
@@ -289,6 +326,8 @@ const mdnPrototype = {
     /**
      * Accepts a relative URL or an attachment object
      * Returns the content of a given file.
+     *
+     * @param {string|{url:string}} fileObjOrUrl
      */
     async getFileContent(fileObjOrUrl) {
         var url = fileObjOrUrl.url || fileObjOrUrl;
@@ -328,9 +367,13 @@ const mdnPrototype = {
             }
         });
     },
-
-    // Fetch an HTTP resource with JSON representation, parse the JSON and
-    // return a JS object.
+    /**
+     * Fetch an HTTP resource with JSON representation, parse the JSON and
+     * return a JS object.
+     *
+     * @param {string} url
+     * @param {object} [opts]
+     */
     async fetchJSONResource(url, opts) {
         opts = util.defaults(opts || {}, {
             headers: {
@@ -342,7 +385,13 @@ const mdnPrototype = {
         return JSON.parse(await this.MDN.fetchHTTPResource(url, opts));
     },
 
-    // Fetch an HTTP resource, return the response body.
+    /**
+     * Fetch an HTTP resource, return the response body.
+     *
+     * @param {string} url
+     * @param {object} [opts]
+     * @return {Promise<string>}
+     */
     async fetchHTTPResource(url, opts) {
         opts = util.defaults(opts || {}, {
             method: 'GET',
@@ -384,7 +433,11 @@ const mdnPrototype = {
         }
     },
 
-    // http://www.bugzilla.org/docs/4.2/en/html/api/Bugzilla/WebService/Bug.html#search
+    /**
+     * @see http://www.bugzilla.org/docs/4.2/en/html/api/Bugzilla/WebService/Bug.html#search
+     *
+     * @param {string} query
+     */
     async bzSearch(query) {
         /* Fix colon (":") encoding problems */
         query = query.replace(/&amp;/g, '&');
@@ -397,7 +450,11 @@ const mdnPrototype = {
         return resource.result;
     },
 
-    /* Derive the site URL from the request URL */
+    /**
+     * Derive the site URL from the request URL
+     *
+     * @return {string}
+     */
     siteURL() {
         var p = url.parse(this.env.url, true),
             site_url = p.protocol + '//' + p.host;
@@ -406,6 +463,12 @@ const mdnPrototype = {
 };
 
 const stringPrototype = {
+    /**
+     * @param {string} source
+     * @param {string|RegExp} pattern
+     * @param {function(...any):Promise<string>} asyncReplacer
+     * @return {string}
+     */
     async asyncReplace(source, pattern, asyncReplacer) {
         // Find all the matches, replace with "", and discard the result
         let matches = [];
@@ -448,37 +511,76 @@ const stringPrototype = {
         return strings.join('');
     },
 
+    /**
+     * @param {string} str
+     * @param {string} sub_str
+     * @return {boolean}
+     */
     StartsWith(str, sub_str) {
         return ('' + str).indexOf(sub_str) === 0;
     },
 
+    /**
+     * @param {string} str
+     * @param {string} suffix
+     * @return {boolean}
+     */
     EndsWith(str, suffix) {
         str = '' + str;
         return str.indexOf(suffix, str.length - suffix.length) !== -1;
     },
 
+    /**
+     * @param {string} str
+     * @param {string} sub_str
+     * @return {boolean}
+     */
     Contains(str, sub_str) {
         return ('' + str).indexOf(sub_str) !== -1;
     },
 
+    /**
+     * @param {string} str
+     * @return {any}
+     */
     Deserialize(str) {
         return JSON.parse(str);
     },
 
-    /* Check if first character in string is a decimal digit. */
+    /**
+     * Check if first character in string is a decimal digit.
+     *
+     * @param {string} str
+     * @return {boolean}
+     */
     IsDigit(str) {
         return /^\d/.test('' + str);
     },
 
-    /* Check if first character in string is an alphabetic character. */
+    /**
+     * Check if first character in string is an alphabetic character.
+     *
+     * @param {string} str
+     * @return {boolean}
+     */
     IsLetter(str) {
         return /^[a-zA-Z]/.test('' + str);
     },
 
+    /**
+     * @param {string} val
+     * @return {string}
+     */
     Serialize(val) {
         return JSON.stringify(val);
     },
 
+    /**
+     * @param {string} str
+     * @param {number} start
+     * @param {number} [length]
+     * @return {string}
+     */
     Substr(str, start, length) {
         if (length) {
             return ('' + str).substr(start, length);
@@ -487,18 +589,36 @@ const stringPrototype = {
         }
     },
 
+    /**
+     * @param {string} str
+     * @return {string}
+     */
     toLower(str) {
         return ('' + str).toLowerCase();
     },
 
+    /**
+     * @param {string} str
+     * @return {string}
+     */
     ToUpperFirst(str) {
         return ('' + str).charAt(0).toUpperCase() + ('' + str).slice(1);
     },
 
+    /**
+     * @param {string} str
+     * @return {string}
+     */
     Trim(str) {
         return ('' + str).trim();
     },
 
+    /**
+     * @param {string} str
+     * @param {number} index
+     * @param {number} [count]
+     * @return {string}
+     */
     Remove(str, index, count) {
         var out = '' + str.substring(0, Number(index));
         if (count) {
@@ -507,39 +627,68 @@ const stringPrototype = {
         return out;
     },
 
+    /**
+     * @param {string} str
+     * @param {string|RegExp} from
+     * @param {string} to
+     * @return {string}
+     */
     Replace(str, from, to) {
         return ('' + str).replace(RegExp(from, 'g'), to);
     },
 
+    /**
+     * @param {any[]} list
+     * @param {string} [sep]
+     * @return {string}
+     */
     Join(list, sep) {
         return list.join(sep);
     },
 
+    /**
+     * @param {string} str
+     * @return {number}
+     */
     Length(str) {
         return ('' + str).length;
     }
 };
 
 const wikiPrototype = {
-    //
-    // Given a string, escape any quotes within it so it can be
-    // passed to other functions.
-    //
+    /**
+     * Given a string, escape any quotes within it so it can be
+     * passed to other functions.
+     */
     escapeQuotes: util.escapeQuotes,
 
-    // Check if the given wiki page exists.
-    // This was "temporarily" disabled 7 years ago!
+    /**
+     * Check if the given wiki page exists.
+     * This was "temporarily" disabled 7 years ago!
+     *
+     * @param {string} path
+     * @return {true}
+     */
     pageExists(/*path*/) {
         // Temporarily disabling this.
         // See: https://bugzilla.mozilla.org/show_bug.cgi?id=775590#c4
         return true;
     },
 
-    // Retrieve the content of a document for inclusion,
-    // optionally filtering for a single section.
-    //
-    // Doesn't support the revision parameter offered by DekiScript
-    //
+    /**
+     * Retrieve the content of a document for inclusion,
+     * optionally filtering for a single section.
+     *
+     * Doesn't support the revision parameter offered by DekiScript
+     *
+     * @param {string} path
+     * @param {string} [section]
+     * @param {any} [revision]
+     * @param {boolean} [show]
+     * @param {number} [heading]
+     * @param {boolean} ignore_cache_control
+     * @return {Promise<string>}
+     */
     async page(path, section, revision, show, heading, ignore_cache_control) {
         var key_text = path.toLowerCase();
         if (section) {
@@ -630,7 +779,12 @@ const wikiPrototype = {
         }
     },
 
-    // Returns the page object for the specified page.
+    /**
+     * Returns the page object for the specified page.
+     *
+     * @param {string} path
+     * @return {Promise<object>}
+     */
     async getPage(path) {
         var key = 'kuma:get_page:' + path.toLowerCase();
         return JSON.parse(
@@ -659,7 +813,13 @@ const wikiPrototype = {
         );
     },
 
-    // Retrieve the full uri of a given wiki page.
+    /**
+     * Retrieve the full uri of a given wiki page.
+     *
+     * @param {string} path
+     * @param {string} query
+     * @return {string}
+     */
     uri(path, query) {
         const parts = url.parse(this.env.url);
         var out = parts.protocol + '//' + parts.host + util.preparePath(path);
@@ -668,14 +828,21 @@ const wikiPrototype = {
         }
         return out;
     },
-
-    // Inserts a pages sub tree
-    // if reverse is non-zero, the sort is backward
-    // if ordered is true, the output is an <ol> instead of <ul>
-    //
-    // Special note: If ordered is true, pages whose locale differ from
-    // the current page's locale are omitted, to work around misplaced
-    // localizations showing up in navigation.
+    /**
+     * Inserts a pages sub tree
+     * if reverse is non-zero, the sort is backward
+     * if ordered is true, the output is an <ol> instead of <ul>
+     *
+     * Special note: If ordered is true, pages whose locale differ from
+     * the current page's locale are omitted, to work around misplaced
+     * localizations showing up in navigation.
+     *
+     * @param {string} path
+     * @param {number} depth
+     * @param {boolean} self
+     * @param {boolean} reverse
+     * @param {boolean} ordered
+     */
     async tree(path, depth, self, reverse, ordered) {
         // If the path ends with a slash, remove it.
         if (path.substr(-1, 1) === '/') {
@@ -764,7 +931,7 @@ const wikiPrototype = {
                         folderItem.url +
                         '">' +
                         util.htmlEscape(folderItem.title) +
-                        '</a></li>';
+                        '</object></li>';
                 }
 
                 // Now dive into the child items
@@ -798,14 +965,29 @@ const wikiPrototype = {
 };
 
 const uriPrototype = {
-    // Encode text as a URI component.
+    /**
+     * Encode text as a URI component.
+     *
+     * FIXME: This actually calls `encodeURI` instead of `encodeURIComponent`.
+     *
+     * @param {string} str
+     * @return {string}
+     */
     encode(str) {
         return encodeURI(str);
     }
 };
 
 const webPrototype = {
-    // Insert a hyperlink.
+    /**
+     * Insert a hyperlink.
+     *
+     * @param {string} uri
+     * @param {string} [text]
+     * @param {string} [title]
+     * @param {string} [target]
+     * @return {string}
+     */
     link(uri, text, title, target) {
         var out = [
             '<a href="' + util.spacesToUnderscores(util.htmlEscape(uri)) + '"'
@@ -820,18 +1002,29 @@ const webPrototype = {
         return out.join('');
     },
 
-    // Given a URL, convert all spaces to underscores. This lets us fix a
-    // bunch of places where templates assume this is done automatically
-    // by the API, like MindTouch did.
+    /**
+     * Given a URL, convert all spaces to underscores. This lets us fix a
+     * bunch of places where templates assume this is done automatically
+     * by the API, like MindTouch did.
+     *
+     * @param {string} str
+     * @return {string}
+     */
     spacesToUnderscores(str) {
         return util.spacesToUnderscores(str);
     }
 };
 
 const pagePrototype = {
-    // Determines whether or not the page has the specified tag. Returns
-    // true if it does, otherwise false. This is case-insensitive.
-    //
+    /**
+     * Determines whether or not the page has the specified tag. Returns
+     * true if it does, otherwise false. This is case-insensitive.
+     *
+     * @param {object} aPage
+     * @param {string[]} [aPage.tags]
+     * @param {string} aTag
+     * @return {boolean}
+     */
     hasTag: function(aPage, aTag) {
         // First, return false at once if there are no tags on the page
 
@@ -858,16 +1051,23 @@ const pagePrototype = {
         return false;
     },
 
-    // Optional path, defaults to current page
-    //
-    // Optional depth. Number of levels of children to include, 0
-    // is the path page
-    //
-    // Optional self, defaults to false. Include the path page in
-    // the results
-    //
-    // This is not called by any macros, and is only used here by
-    // wiki.tree(), so we could move it to be part of that function.
+    /**
+     * Optional path, defaults to current page
+     *
+     * Optional depth. Number of levels of children to include, 0
+     * is the path page
+     *
+     * Optional self, defaults to false. Include the path page in
+     * the results
+     *
+     * This is not called by any macros, and is only used here by
+     * wiki.tree(), so we could move it to be part of that function.
+     *
+     * @param {string} [path]
+     * @param {number} [depth]
+     * @param {boolean} [self]
+     * @return {Promise<any[]>}
+     */
     async subpages(path, depth, self) {
         var url = util.apiURL((path ? path : this.env.url) + '$children');
         var depth_check = parseInt(depth);
@@ -887,14 +1087,20 @@ const pagePrototype = {
         return result;
     },
 
-    // Optional path, defaults to current page
-    //
-    // Optional depth. Number of levels of children to include, 0
-    // is the path page
-    //
-    // Optional self, defaults to false. Include the path page in
-    // the results
-    //
+    /**
+     * Optional path, defaults to current page
+     *
+     * Optional depth. Number of levels of children to include, 0
+     * is the path page
+     *
+     * Optional self, defaults to false. Include the path page in
+     * the results
+     *
+     * @param {string} [path]
+     * @param {number} [depth]
+     * @param {boolean} [self]
+     * @return {Promise<any[]>}
+     */
     async subpagesExpand(path, depth, self) {
         var url = util.apiURL(
             (path ? path : this.env.url) + '$children?expand'
@@ -915,7 +1121,12 @@ const pagePrototype = {
         return result;
     },
 
-    // Flatten subPages list
+    /**
+     * Flatten subPages list
+     *
+     * @param {any[]} pages
+     * @return {any[]}
+     */
     subPagesFlatten(pages) {
         var output = [];
 
@@ -941,6 +1152,10 @@ const pagePrototype = {
         }
     },
 
+    /**
+     * @param {string} [path]
+     * @return {Promise<any[]>}
+     */
     async translations(path) {
         var url = util.apiURL((path ? path : this.env.url) + '$json');
         var json = await this.MDN.fetchJSONResource(url);
@@ -953,26 +1168,32 @@ const pagePrototype = {
 };
 
 class Environment {
-    // Intialize an environment object that will be used to render
-    // all of the macros in one document or page. We pass in a context
-    // object (which may come from HTTP request headers) that gives
-    // details like the page title and URL. These are available to macros
-    // through the global 'env' object, and some of the properties
-    // are also copied onto the global 'page' object.
-    //
-    // Note that we don't use the Environment object directly when
-    // executing macros. Instead call getExecutionContext(), supplying
-    // the macro arguments list to get an object specific for executing
-    // one macro.
-    //
-    // Note that we pass the Templates object when we create an Environment.
-    // this is so that macros can recursively execute other named macros
-    // in the same environment.
-    //
-    // The optional third argument is for use only by tests. Setting it to
-    // true makes us not freeze the environment so that tests can stub out
-    // methods in the API like mdn.fetchJSONResources
-    //
+    /**
+     * Initialize an environment object that will be used to render
+     * all of the macros in one document or page. We pass in a context
+     * object (which may come from HTTP request headers) that gives
+     * details like the page title and URL. These are available to macros
+     * through the global 'env' object, and some of the properties
+     * are also copied onto the global 'page' object.
+     *
+     * Note that we don't use the Environment object directly when
+     * executing macros. Instead call getExecutionContext(), supplying
+     * the macro arguments list to get an object specific for executing
+     * one macro.
+     *
+     * Note that we pass the Templates object when we create an Environment.
+     * this is so that macros can recursively execute other named macros
+     * in the same environment.
+     *
+     * The optional third argument is for use only by tests. Setting it to
+     * true makes us not freeze the environment so that tests can stub out
+     * methods in the API like mdn.fetchJSONResources
+     *
+     * @param {{locale:string,url:string}} perPageContext
+     * @param {string} [perPageContext.slug]
+     * @param {any} templates
+     * @param {boolean} [testing]
+     */
     constructor(perPageContext, templates, testing = false) {
         // Freeze an object unless we're in testing mode
         function freeze(o) {
@@ -996,6 +1217,11 @@ class Environment {
          *
          * And the freeze() call is a safety measure to prevent
          * macros from modifying the execution environment.
+         *
+         * @template {object} T
+         * @param {T} o
+         * @param {any} binding
+         * @return {T}
          */
         function prepareProto(o, binding) {
             let p = {};
@@ -1042,18 +1268,24 @@ class Environment {
         globals.page = globals.Page = freeze(page);
         globals.env = globals.Env = freeze(env);
 
-        // Macros use the global template() method to excute other
+        // Macros use the global template() method to execute other
         // macros. This is the one function that we can't just
-        // implement on globalsPrototype because it needs acccess to
+        // implement on globalsPrototype because it needs access to
         // this.templates.
         globals.template = this._renderTemplate.bind(this);
 
         this.prototypeEnvironment = freeze(globals);
     }
 
-    // A templating function that we define in the global environment
-    // so that templates can invoke other templates. This is not part
-    // of the public API of the class; it is for use by other templates
+    /**
+     * A templating function that we define in the global environment
+     * so that templates can invoke other templates. This is not part
+     * of the public API of the class; it is for use by other templates
+     *
+     * @param {string} name
+     * @param {any[]} [args]
+     * @return {Promise<string>}
+     */
     async _renderTemplate(name, args) {
         return await this.templates.render(
             name,
@@ -1061,8 +1293,13 @@ class Environment {
         );
     }
 
-    // Get a customized environment object that is specific to a single
-    // macro on a page by including the arguments to be passed to that macro.
+    /**
+     * Get a customized environment object that is specific to a single
+     * macro on a page by including the arguments to be passed to that macro.
+     *
+     * @param {any[]} [args]
+     * @return {any}
+     */
     getExecutionContext(args) {
         let context = Object.create(this.prototypeEnvironment);
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -4,11 +4,29 @@
  */
 
 /**
+ * @typedef {object} Token
+ * @property {string} name
+ * @property {Location} location
+ */
+/**
+ * @typedef {object} Location
+ * @property {object} start
+ * @property {number} start.line
+ * @property {number} start.column
+ */
+
+/**
  * This is the common superclass of the other error classes here.
  * It includes the code for excerpting the portion of the document that the
  * error occurs in and drawing an ASCII art arrow to point at it.
  */
 class SourceCodeError extends Error {
+    /**
+     * @param {Error} cause
+     * @param {number} line
+     * @param {number} column
+     * @param {string} [name]
+     */
     constructor(cause, line, column, name) {
         super();
         this.cause = cause;
@@ -23,10 +41,15 @@ class SourceCodeError extends Error {
         }
     }
 
-    // TODO(djf): a lot of our HTML documents have really long lines and
-    // showing line-oriented errors when the column number is > 100
-    // doesn't really make sense. Perhaps we can modify this function to
-    // show the relevant context in a more useful way.
+    /**
+     * TODO(djf): a lot of our HTML documents have really long lines and
+     * showing line-oriented errors when the column number is > 100
+     * doesn't really make sense. Perhaps we can modify this function to
+     * show the relevant context in a more useful way.
+     *
+     * @param {string} source
+     * @return {string}
+     */
     getSourceContext(source) {
         function arrow(column) {
             let arrow = '';
@@ -69,6 +92,10 @@ class SourceCodeError extends Error {
  * of the error.
  */
 class MacroInvocationError extends SourceCodeError {
+    /**
+     * @param {Error} error
+     * @param {string} source
+     */
     constructor(error, source) {
         // If the error is not a SyntaxError, with a location property then
         // just return it instead of creating a wrapper object
@@ -92,6 +119,11 @@ class MacroInvocationError extends SourceCodeError {
  * macro in the HTML document, which it determines from the token argument.
  */
 class MacroNotFoundError extends SourceCodeError {
+    /**
+     * @param {Error} error
+     * @param {string} source
+     * @param {Token} token
+     */
     constructor(error, source, token) {
         super(
             error,
@@ -116,6 +148,11 @@ class MacroNotFoundError extends SourceCodeError {
  * macro in the HTML document and also includes the underlying error message.
  */
 class MacroCompilationError extends SourceCodeError {
+    /**
+     * @param {Error} error
+     * @param {string} source
+     * @param {Token} token
+     */
     constructor(error, source, token) {
         super(
             error,
@@ -141,6 +178,11 @@ class MacroCompilationError extends SourceCodeError {
  * from the underlying runtime error.
  */
 class MacroExecutionError extends SourceCodeError {
+    /**
+     * @param {Error} error
+     * @param {string} source
+     * @param {Token} token
+     */
     constructor(error, source, token) {
         super(
             error,

--- a/src/errors.js
+++ b/src/errors.js
@@ -100,7 +100,7 @@ class MacroInvocationError extends SourceCodeError {
         // If the error is not a SyntaxError, with a location property then
         // just return it instead of creating a wrapper object
         if (error.name !== 'SyntaxError' || error.location === undefined) {
-            return error;
+            return /** @type {SourceCodeError} */(error);
         }
 
         super(error, error.location.start.line, error.location.start.column);

--- a/src/firelogger.js
+++ b/src/firelogger.js
@@ -4,8 +4,14 @@
  * error messages to Kuma when a document can't be rendered correctly.
  *
  * @prettier
+ *
+ * @param {object} [options]
+ * @param {number} [options.max_header_length]
+ * @param {string[]} [options.levels]
+ * @param {function(...any):void} [options.logger]
+ * @return {function(any,any,function():void):void}
  */
-module.exports = function(options) {
+module.exports = function firelogger(options) {
     options = options || {};
     // HACK: Under 8k seems like an arbitrary best guess at a max
     var max_header_length = options.max_header_length || 8000;

--- a/src/firelogger.js
+++ b/src/firelogger.js
@@ -9,7 +9,7 @@
  * @param {number} [options.max_header_length]
  * @param {string[]} [options.levels]
  * @param {function(...any):void} [options.logger]
- * @return {function(any,any,function():void):void}
+ * @return {function(any, any, function():void):void}
  */
 module.exports = function firelogger(options) {
     options = options || {};
@@ -82,7 +82,7 @@ module.exports = function firelogger(options) {
                 // Non-standard `X-FireLogger: plaintext` header skips the
                 // base64 part and sticks each JSON-encoded log message into a
                 // header. Good for debugging by curl
-                d_lines = messages.map(JSON.stringify);
+                d_lines = messages.map(m => JSON.stringify(m));
             } else {
                 // `X-FireLogger: 1.2` is what's expected from the add-on, but
                 // accept anything else.

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @prettier
+ */
+/// <reference types="pegjs"/>
+import { PegjsError, ParserOptions } from 'pegjs';
+
+export type SyntaxError = PegjsError;
+export var SyntaxError: any;
+
+export function parse(input: string, options?: ParserOptions): any;

--- a/src/render.js
+++ b/src/render.js
@@ -51,6 +51,13 @@ const {
     MacroExecutionError
 } = require('./errors.js');
 
+/**
+ * @param {string} source
+ * @param {any} templates
+ * @param {{locale:string,url:string}} pageEnvironment
+ * @param {string} [pageEnvironment.slug]
+ * @return {Promise<[string, Error[]]>}
+ */
 async function render(source, templates, pageEnvironment) {
     // Parse the source document.
     let tokens;
@@ -75,10 +82,12 @@ async function render(source, templates, pageEnvironment) {
     // be the same each time. (This is an important optimization for
     // xref macros, for example, since they can make asynchronous
     // network requests, and documents often have duplicate xrefs.)
+    /** @type {Array<Promise<string>>} */
     let promises = [];
     let signatureToPromiseIndex = new Map();
 
     // Keep track of errors that occur when rendering the macros.
+    /** @type {Array<Error|null>} */
     let errors = [];
 
     // Loop through the tokens

--- a/src/render.js
+++ b/src/render.js
@@ -54,8 +54,12 @@ const {
 /**
  * @param {string} source
  * @param {any} templates
- * @param {{locale:string,url:string}} pageEnvironment
- * @param {string} [pageEnvironment.slug]
+ * @param {object} pageEnvironment
+ *   @param {string} [pageEnvironment.locale]
+ *   @param {string} [pageEnvironment.slug]
+ *   @param {string} [pageEnvironment.title]
+ *   @param {string[]} [pageEnvironment.tags]
+ *   @param {string} [pageEnvironment.url]
  * @return {Promise<[string, Error[]]>}
  */
 async function render(source, templates, pageEnvironment) {

--- a/src/server.js
+++ b/src/server.js
@@ -70,7 +70,7 @@ class Server {
     /**
      * Start the service listening
      *
-     * @param {port} number
+     * @param {number} port
      */
     listen(port) {
         port = port || config.port;
@@ -88,6 +88,9 @@ class Server {
 
     /**
      * This is the "hello world" endpoint for GET /
+     *
+     * @param {express.Request} req
+     * @param {express.Response} res
      */
     root(req, res) {
         res.send('<html><body><p>Hello from KumaScript!</p></body></html>');
@@ -97,6 +100,9 @@ class Server {
      * #### GET /revision
      *
      * Return the value of the git commit hash for HEAD.
+     *
+     * @param {express.Request} req
+     * @param {express.Response} res
      */
     revision(req, res) {
         res.set({ 'content-type': 'text/plain; charset=utf-8' }).send(
@@ -111,6 +117,9 @@ class Server {
      * doesn't mean that its supporting services (like the macro
      * loader and the document service) can be successfully used
      * from this service.
+     *
+     * @param {express.Request} req
+     * @param {express.Response} res
      */
     healthz(req, res) {
         res.sendStatus(204);
@@ -122,6 +131,9 @@ class Server {
      * a step further and means not only that this Express app is up
      * and running, but also that one or more macros have been found
      * and that the document service is ready.
+     *
+     * @param {express.Request} req
+     * @param {express.Response} res
      */
     readiness(req, res) {
         // If we're running, then we're ready to go. But we need to make
@@ -158,6 +170,9 @@ class Server {
      * #### GET /macros
      *
      * Get JSON of available macros (also known as templates)
+     *
+     * @param {express.Request} req
+     * @param {express.Response} res
      */
     macros(req, res) {
         let macros = [];
@@ -183,6 +198,9 @@ class Server {
      * #### POST /docs/
      *
      * Process POST body, respond with result of macro evaluation
+     *
+     * @param {express.Request} request
+     * @param {express.Response} response
      */
     docs(request, response) {
         let body = '';

--- a/src/templates.js
+++ b/src/templates.js
@@ -30,13 +30,18 @@ const path = require('path');
 const ejs = require('ejs');
 
 class Templates {
+    /**
+     * @param {string} macroDirectory
+     */
     constructor(macroDirectory) {
         this.macroDirectory = macroDirectory;
+        /** @type {Map<string, string>} */
         this.macroNameToPath = new Map();
 
         // Find all the macros in the macros dir and build a map
         // from macro name to filename
         const dirs = [macroDirectory];
+        /** @type {Map<string, string[]>} */
         const duplicates = new Map();
 
         // Walk the directory tree under the specified root directory.
@@ -88,6 +93,11 @@ class Templates {
         }
     }
 
+    /**
+     * @param {string} name
+     * @param {Record<string, any>} args
+     * @return {Promise<string>}
+     */
     async render(name, args) {
         // Normalize the macro name by converting colons to hyphens and
         // uppercase letters to lowercase.
@@ -99,6 +109,7 @@ class Templates {
             throw new ReferenceError(`Unknown macro ${name}`);
         }
 
+        /** @type {string} */
         let rendered = await ejs.renderFile(path, args, {
             cache: true,
             async: true
@@ -106,6 +117,9 @@ class Templates {
         return rendered.trim();
     }
 
+    /**
+     * @return {Map<string, string>}
+     */
     getTemplateMap() {
         return new Map(this.macroNameToPath);
     }

--- a/src/templates.js
+++ b/src/templates.js
@@ -95,7 +95,7 @@ class Templates {
 
     /**
      * @param {string} name
-     * @param {Record<string, any>} args
+     * @param {Record<string, any>} [args]
      * @return {Promise<string>}
      */
     async render(name, args) {

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -11,55 +11,185 @@ const vnu = require('vnu-jar');
 const Environment = require('../../src/environment.js');
 const Templates = require('../../src/templates.js');
 
-// When we were doing mocha testing, we used this.macro to hold this.
-// But Jest doesn't use the this object, so we just store the object here.
+// TODO: Maybe use a class for this?
+/**
+ * @typedef Macro
+ * @property {typeof Environment.prototype.prototypeEnvironment} ctx
+ *           Give the test-case writer access to the macro's globals (ctx).
+ *           For example, "macro.ctx.env.locale" can be manipulated to something
+ *           other than 'en-US' or "macro.ctx.wiki.getPage" can be mocked
+ *           using `jest.fn()` to avoid network calls.
+ *
+ * @property {(name: string, result: string) => void} mockTemplate
+ *           When writing tests for a macro that invokes other macros with
+ *           the `template()` function, you sometimes want to specify
+ *           a mock return value for those other macros.
+ *
+ *           This function provides a much easier way to handle that than
+ *           using `jest.fn()` directly.
+ *
+ *           To unmock a template result, simply call `unmockTemplate()`
+ *           with the same `name`.
+ *
+ * @property {(name: string) => boolean} unmockTemplate
+ *           Stops mocking the result of a `template()` function call.
+ *
+ * @property {(...args: any[]) => Promise<string>} call
+ *           Use this function to make test calls on the named macro, if applicable.
+ *           Its arguments become the arguments to the macro. It returns a promise.
+ */
+
+/**
+ * When we were doing mocha testing, we used this.macro to hold this.
+ * But Jest doesn't use the this object, so we just store the object here.
+ * @type {Macro}
+ */
 let macro = null;
 
+/**
+ * Asserts that value is truthy.
+ *
+ * @template T Type of value.
+ * @param {T} x Actual value.
+ */
 function assert(x) {
-    expect(x).toBe(true);
+    expect(x).toBeTruthy();
 }
 
+/**
+ * Asserts non-strict equality (==) of actual and expected.
+ *
+ * @template T Type of the objects.
+ * @param {T} x Actual value.
+ * @param {any} y Potential expected value.
+ */
 assert.equal = (x, y) => {
     expect(x).toEqual(y);
 };
 
 assert.eventually = {
+    /**
+     * Asserts non-strict equality (==) of actual and expected.
+     *
+     * @template T Type of the objects.
+     * @param {T|PromiseLike<T>} x Actual value.
+     * @param {any} y Potential expected value.
+     */
     async equal(x, y) {
         expect(await x).toEqual(y);
     }
 };
 
-assert.include = (list, element) => {
-    expect(list).toContain(element);
-};
+/**
+ * Asserts that value is true.
+ *
+ * @template T Type of value.
+ * @param {T} value Actual value.
+ */
 assert.isTrue = value => {
     expect(value).toEqual(true);
 };
+
+/**
+ * Asserts that value is false.
+ *
+ * @template T Type of value.
+ * @param {T} value Actual value.
+ */
 assert.isFalse = value => {
     expect(value).toEqual(false);
 };
+
+/**
+ * Asserts value is strictly greater than (>) floor.
+ *
+ * @param {number} value Actual value.
+ * @param {number} floor Minimum Potential expected value.
+ */
 assert.isAbove = (value, floor) => {
     expect(value).toBeGreaterThan(floor);
 };
+
+/**
+ * Asserts that value is an array.
+ *
+ * @template T Type of value.
+ * @param {T} value Actual value.
+ */
 assert.isArray = value => {
     expect(value).toBeInstanceOf(Array);
 };
+
+/**
+ * Asserts that value is an object of type 'Object'
+ * (as revealed by Object.prototype.toString).
+ *
+ * @template T Type of value.
+ * @param {T} value Actual value.
+ * @remarks The assertion does match subclassed objects.
+ */
 assert.isObject = value => {
     expect(value).toBeInstanceOf(Object);
 };
+
+/**
+ * Asserts that value is a function.
+ *
+ * @template T Type of value.
+ * @param {T} value Actual value.
+ */
 assert.isFunction = value => {
     expect(value).toBeInstanceOf(Function);
 };
+
+/**
+ * Asserts that object has a property named by property.
+ *
+ * @template T Type of object.
+ * @param {T} value Container object.
+ * @param {string} prop Potential contained property of object.
+ */
 assert.property = (value, prop) => {
     expect(value).toHaveProperty(prop);
 };
+
+/**
+ * Asserts that object doesn't have a property named by property.
+ *
+ * @template T Type of object.
+ * @param {T} value Container object.
+ * @param {string} prop Potential contained property of object.
+ */
 assert.notProperty = (value, prop) => {
     expect(value).not.toHaveProperty(prop);
 };
+
+/**
+ * Asserts that set1 and set2 have the same members. Order is not take into account.
+ *
+ * @template T Type of set values.
+ * @param {T[]} a1 Actual set of values.
+ * @param {T[]} a2 Potential expected set of values.
+ */
 assert.sameMembers = (a1, a2) => {
     expect(new Set(a1)).toEqual(new Set(a2));
 };
 
+/**
+ * Asserts that haystack includes needle.
+ *
+ * @template T
+ * @param {string|T[]} list Container string or array.
+ * @param {string|T} element Potential value contained in haystack.
+ */
+assert.include = (list, element) => {
+    expect(list).toContain(element);
+};
+
+/**
+ * @param {string} macroName
+ * @return {Macro}
+ */
 function createMacroTestObject(macroName) {
     let templates = new Templates(__dirname + '/../../macros/');
     let pageContext = {
@@ -165,7 +295,8 @@ function afterEachMacro(teardown) {
  * success, and, on failure, a string detailing all of the errors.
  *
  * @param {string} html
- * @param {boolean} fragment
+ * @param {boolean} [fragment]
+ * @return {string|null}
  */
 function lintHTML(html, fragment = true) {
     if (fragment) {
@@ -183,7 +314,7 @@ function lintHTML(html, fragment = true) {
         });
         return null;
     } catch (error) {
-        const error_message = error.message
+        const error_message = /** @type {Error} */ (error).message
             .split(os.EOL)
             .filter(line => line.startsWith('Error: '))
             .join(os.EOL);

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -178,7 +178,7 @@ assert.sameMembers = (a1, a2) => {
 /**
  * Asserts that haystack includes needle.
  *
- * @template T
+ * @template T Type of values in haystack.
  * @param {string|T[]} list Container string or array.
  * @param {string|T} element Potential value contained in haystack.
  */

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -23,6 +23,8 @@ config.logging = false;
 
 /**
  * Creates an HTTP server for fixtures
+ *
+ * @return {express.Express}
  */
 function createKumaServer() {
     let app = express();


### PR DESCRIPTION
I had originally opened #959 way back, but some of the JSDoc comments were converted to plain comments without type information in #1035, this restores all of them and adds new ones.

review?(@davidflanagan, @Elchi3, @wbamberg)