### PR TITLE
test utility function for HTML linting with tests

### DIFF
--- a/macros/AddonSidebar.ejs
+++ b/macros/AddonSidebar.ejs
@@ -9,7 +9,7 @@ function currentPageIsUnder(root) {
   if (slug && slug.indexOf(rootSlug) != -1) {
     return 'open';
   }
-  return 'closed';
+  return '';
 }
 
 var text = mdn.localStringMap({
@@ -439,7 +439,7 @@ var text = mdn.localStringMap({
         <ol>
           <li><a href="https://blog.mozilla.org/addons"><%=text['Blog']%></a></li>
           <li><a href="https://discourse.mozilla.org/c/add-ons"><%=text['Forums']%></a></li>
-          <li><a href="http://stackoverflow.com/questions/tagged/firefox-addon">Stack Overflow</a></li>
+          <li><a href="https://stackoverflow.com/questions/tagged/firefox-addon">Stack Overflow</a></li>
           <li><a href="<%=baseURL%>#Contact_us"><%=text['#Contact_us']%></a></li>
         </ol>
       </details>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -77,9 +77,9 @@
             }
         },
         "acorn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-            "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+            "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
             "dev": true
         },
         "acorn-globals": {
@@ -113,9 +113,9 @@
             }
         },
         "ajv": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-            "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+            "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -124,9 +124,9 @@
             }
         },
         "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
             "dev": true
         },
         "ansi-regex": {
@@ -518,11 +518,11 @@
             "dev": true
         },
         "async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+            "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "^4.17.11"
             }
         },
         "async-limiter": {
@@ -938,6 +938,14 @@
             "dev": true,
             "requires": {
                 "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
             }
         },
         "bser": {
@@ -953,12 +961,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
         },
         "bytes": {
             "version": "3.0.0",
@@ -1211,9 +1213,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-            "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+            "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
             "dev": true
         },
         "core-util-is": {
@@ -1235,9 +1237,9 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
             "dev": true
         },
         "cssstyle": {
@@ -1456,6 +1458,12 @@
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
             "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -1468,14 +1476,6 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
-            },
-            "dependencies": {
-                "is-arrayish": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-                    "dev": true
-                }
             }
         },
         "es-abstract": {
@@ -1556,9 +1556,9 @@
             }
         },
         "eslint": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
-            "integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.13.0.tgz",
+            "integrity": "sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -1590,7 +1590,6 @@
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
                 "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
                 "semver": "^5.5.1",
@@ -1618,18 +1617,18 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz",
-            "integrity": "sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz",
+            "integrity": "sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==",
             "dev": true,
             "requires": {
                 "get-stdin": "^6.0.0"
             }
         },
         "eslint-plugin-jest": {
-            "version": "22.1.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.1.3.tgz",
-            "integrity": "sha512-JTZTI6WQoNruAugNyCO8fXfTONVcDd5i6dMRFA5g3rUFn1UDDLILY1bTL6alvNXbW2U7Sc2OSpi8m08pInnq0A==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.3.0.tgz",
+            "integrity": "sha512-P1mYVRNlOEoO5T9yTqOfucjOYf1ktmJ26NjwjH8sxpCFQa6IhBGr5TpKl3hcAAT29hOsRJVuMWmTsHoUVo9FoA==",
             "dev": true
         },
         "eslint-plugin-prettier": {
@@ -2074,601 +2073,6 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-                    "dev": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "resolved": false,
-                    "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.4",
-                    "resolved": false,
-                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "resolved": false,
-                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-                    "dev": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                    "dev": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": false,
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.5.1",
-                    "resolved": false,
-                    "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-                    "dev": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                    "dev": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-                    "dev": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "resolved": false,
-                    "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                    "dev": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "resolved": false,
-                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-                    "dev": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.21",
-                    "resolved": false,
-                    "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": "^2.1.0"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "resolved": false,
-                    "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "resolved": false,
-                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "resolved": false,
-                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": false,
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": false,
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                },
-                "minipass": {
-                    "version": "2.2.4",
-                    "resolved": false,
-                    "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "resolved": false,
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.2.0",
-                    "resolved": false,
-                    "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.10.0",
-                    "resolved": false,
-                    "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.3",
-                    "resolved": false,
-                    "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-                    "dev": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.1.10",
-                    "resolved": false,
-                    "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "resolved": false,
-                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "dev": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-                    "dev": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-                    "dev": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "resolved": false,
-                    "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                    "dev": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.7",
-                    "resolved": false,
-                    "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "resolved": false,
-                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": false,
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.2",
-                    "resolved": false,
-                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.0.5"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                    "dev": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "resolved": false,
-                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.5.0",
-                    "resolved": false,
-                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-                    "dev": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-                    "dev": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.1",
-                    "resolved": false,
-                    "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                    "dev": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "3.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                    "dev": true
-                }
-            }
-        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2747,9 +2151,9 @@
             }
         },
         "globals": {
-            "version": "11.10.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-            "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
             "dev": true
         },
         "graceful-fs": {
@@ -2765,9 +2169,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+            "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
             "dev": true,
             "requires": {
                 "async": "^2.5.0",
@@ -3028,21 +2432,21 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "inquirer": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-            "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+            "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
                 "cli-cursor": "^2.1.0",
                 "cli-width": "^2.0.0",
-                "external-editor": "^3.0.0",
+                "external-editor": "^3.0.3",
                 "figures": "^2.0.0",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "mute-stream": "0.0.7",
                 "run-async": "^2.2.0",
-                "rxjs": "^6.1.0",
+                "rxjs": "^6.4.0",
                 "string-width": "^2.1.0",
                 "strip-ansi": "^5.0.0",
                 "through": "^2.3.6"
@@ -3094,20 +2498,17 @@
                 "kind-of": "^3.0.2"
             }
         },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
-        },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "^1.0.0"
-            }
         },
         "is-callable": {
             "version": "1.1.4",
@@ -3298,6 +2699,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
             "dev": true
         },
         "isarray": {
@@ -3726,9 +3133,9 @@
                     "dev": true
                 },
                 "source-map-support": {
-                    "version": "0.5.9",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+                    "version": "0.5.10",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+                    "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
                     "dev": true,
                     "requires": {
                         "buffer-from": "^1.0.0",
@@ -4099,15 +3506,15 @@
             }
         },
         "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
             "dev": true
         },
         "mdn-browser-compat-data": {
-            "version": "0.0.62",
-            "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.62.tgz",
-            "integrity": "sha512-KNeLRBBJF8z2TwRCJTG28J9NdLdrzdz580wmQIg4hBBH9L6Bw40rWU4oVYL1M2k8V5H6D599QjFaqwTNBCq3yw==",
+            "version": "0.0.67",
+            "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.67.tgz",
+            "integrity": "sha512-VZzaoKzq2wJEUWqVAwC5dLZMXRRlaukRotzRIqsbIUDxVxqPbrmYwizyl/vMPWMqXxvcHKkto/Whm8BDpn2Ogg==",
             "requires": {
                 "extend": "3.0.2"
             }
@@ -4178,16 +3585,16 @@
             "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+            "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "~1.38.0"
             }
         },
         "mimic-fn": {
@@ -4350,12 +3757,13 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-            "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
                 "semver": "^5.5.0",
                 "shellwords": "^0.1.1",
                 "which": "^1.3.0"
@@ -4397,13 +3805,13 @@
             }
         },
         "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
+                "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
             }
@@ -4433,9 +3841,9 @@
             "dev": true
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
+            "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==",
             "dev": true
         },
         "oauth-sign": {
@@ -4472,9 +3880,9 @@
             }
         },
         "object-keys": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
             "dev": true
         },
         "object-visit": {
@@ -4781,12 +4189,6 @@
                 "find-up": "^2.1.0"
             }
         },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
-        },
         "pn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -4812,9 +4214,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-            "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+            "version": "1.16.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+            "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
             "dev": true
         },
         "prettier-linter-helpers": {
@@ -4991,9 +4393,9 @@
             }
         },
         "realpath-native": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-            "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
@@ -5137,10 +4539,13 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-            "dev": true
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
         },
         "resolve-cwd": {
             "version": "2.0.0",
@@ -5212,9 +4617,9 @@
             }
         },
         "rxjs": {
-            "version": "6.3.3",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+            "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -5249,7 +4654,6 @@
                 "capture-exit": "^1.2.0",
                 "exec-sh": "^0.2.0",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.3",
                 "micromatch": "^3.1.4",
                 "minimist": "^1.1.1",
                 "walker": "~1.0.5",
@@ -5654,9 +5058,9 @@
             "dev": true
         },
         "slice-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-            "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.0",
@@ -5854,9 +5258,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-            "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -5981,15 +5385,43 @@
             "dev": true
         },
         "table": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
-            "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+            "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
             "dev": true,
             "requires": {
-                "ajv": "^6.6.1",
+                "ajv": "^6.9.1",
                 "lodash": "^4.17.11",
-                "slice-ansi": "2.0.0",
-                "string-width": "^2.1.1"
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+                    "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.0.0"
+                    }
+                }
             }
         },
         "test-exclude": {
@@ -6341,6 +5773,12 @@
                 "extsprintf": "^1.2.0"
             }
         },
+        "vnu-jar": {
+            "version": "18.11.5",
+            "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.11.5.tgz",
+            "integrity": "sha512-XxTYLOUgQYdvIlAgX1BtxZiQ97/OKuBaEojqZdjMnjI+OXDkSyQGNGpzUQIQygeRrFVdQ1/eAVfiRE/iIlV0fg==",
+            "dev": true
+        },
         "w3c-hr-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -6504,9 +5942,9 @@
             }
         },
         "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+            "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
         "jest-junit-reporter": "^1.1.0",
         "jsonlint": "^1.6.3",
         "pegjs": "^0.10.0",
-        "prettier": "^1.15.3"
+        "prettier": "^1.15.3",
+        "vnu-jar": "^18.11.5"
     },
     "jest": {
+        "testEnvironment": "node",
         "coveragePathIgnorePatterns": [
             "src/parser.js"
         ]

--- a/tests/macros/addonsidebar.test.js
+++ b/tests/macros/addonsidebar.test.js
@@ -1,0 +1,168 @@
+/**
+ * @prettier
+ */
+const url = require('url');
+
+const { JSDOM } = require('jsdom');
+
+const { beforeEachMacro,
+        describeMacro,
+        itMacro,
+        lintHTML } = require('./utils');
+
+const SUMMARIES = {
+    'en-US': new Set([
+        'Getting started',
+        'Concepts',
+        'User interface',
+        'How to',
+        'Porting',
+        'Firefox workflow',
+        'JavaScript APIs',
+        'Manifest keys',
+        'Browser themes',
+        'Publishing add-ons',
+        'Distributing add-ons',
+        'Channels'
+    ]),
+    'fr': new Set([
+        'Démarrage',
+        'Concepts',
+        'Interface Utilisateur',
+        'Mode d\'emploi',
+        'Portage',
+        'Déroulement avec Firefox',
+        'Les API JavaScript',
+        'Clés de manifeste',
+        'Thème de navigateur',
+        'Publication de votre extension',
+        'Distribuer votre module',
+        'Canaux de discussions'
+    ]),
+    'ja': new Set([
+        '始めましょう',
+        '概念',
+        'ユーザーインターフェイス',
+        '逆引きリファレンス',
+        '移行',
+        'Firefox でのワークフロー',
+        'JavaScript API 群',
+        'Manifest keys',
+        'ブラウザのテーマ',
+        'アドオンを公開する',
+        'アドオンの配布',
+        'チャンネル'
+    ]),
+};
+
+const MANIFEST_SLUG = 'Mozilla/Add-ons/WebExtensions/manifest.json';
+
+function getMockResultForFetchJSONResource(doc_url) {
+    const locale = url.parse(doc_url).pathname.split('/')[1];
+    return {
+        locale: `${locale}`,
+        url: `/${locale}/docs/${MANIFEST_SLUG}`,
+        subpages: [
+            {
+                locale: `${locale}`,
+                url: `/${locale}/docs/${MANIFEST_SLUG}/author`,
+                subpages: [],
+                slug: `${MANIFEST_SLUG}/author`,
+                title: 'author'
+            },
+            {
+                locale: `${locale}`,
+                url: `/${locale}/docs/${MANIFEST_SLUG}/background`,
+                subpages: [],
+                slug: `${MANIFEST_SLUG}/background`,
+                title: 'background'
+            },
+            {
+                locale: `${locale}`,
+                url: `/${locale}/docs/${MANIFEST_SLUG}/theme`,
+                subpages: [],
+                slug: `${MANIFEST_SLUG}/theme`,
+                title: 'theme'
+            },
+            {
+                locale: `${locale}`,
+                url: `/${locale}/docs/${MANIFEST_SLUG}/version`,
+                subpages: [],
+                slug: `${MANIFEST_SLUG}/version`,
+                title: 'version'
+            },
+        ],
+        slug: MANIFEST_SLUG,
+        title: 'manifest.json'
+    };
+}
+
+function checkSidebarDom(html, locale, is_under_web_ext_api=false) {
+    // Lint the HTML
+    expect(lintHTML(html)).toBeFalsy();
+    const dom = JSDOM.fragment(html);
+    const section = dom.querySelector('section.Quick_links');
+    // Check the basics
+    expect(section).toBeTruthy();
+    // Check the total number of top-level list items that can be toggled
+    expect(
+        section.querySelectorAll('ol > li.toggle').length
+    ).toEqual(SUMMARIES[locale].size);
+    // Check that all links reference the proper locale or use https
+    const num_total_links = section.querySelectorAll('a[href]').length;
+    const num_valid_links = section.querySelectorAll(
+        `a[href^="/${locale}/docs/Mozilla/Add-ons"], a[href^="https://"]`
+    ).length;
+    expect(num_valid_links).toEqual(num_total_links);
+    // Check that one of the list item's details are open by default (or not)
+    const details_open = section.querySelector(
+        'ol > li.toggle > details[open]'
+    );
+    if (is_under_web_ext_api) {
+        expect(details_open).toBeTruthy();
+    } else {
+        expect(details_open).toBeFalsy();
+    }
+    // Check a sample of the DOM for localized content
+    for (const node of section.querySelectorAll('summary')) {
+        expect(SUMMARIES[locale].has(node.textContent)).toBe(true);
+    }
+    // Check for "WebExtensions/manifest.json" details
+    for (const name of ['author', 'background', 'theme', 'version']) {
+        const href = `/${locale}/docs/${MANIFEST_SLUG}/${name}`;
+        expect(section.querySelector(`li > a[href="${href}"]`)).toBeTruthy();
+    }
+}
+
+describeMacro('AddonSidebar', function() {
+    beforeEachMacro(function(macro) {
+        // Mock calls to template('WebExtAPISidebar', [])
+        macro.ctx.template = jest.fn((macro, args) => {
+            // This template will be tested on its own, so nothing needed here.
+            return '';
+        });
+        // Mock calls to MDN.fetchJSONResource(doc_url)
+        macro.ctx.MDN.fetchJSONResource = jest.fn((doc_url) => {
+            return getMockResultForFetchJSONResource(doc_url);
+        });
+    });
+
+    for (const locale of ['en-US', 'fr', 'ja']) {
+        itMacro(`with locale ${locale}`, function(macro) {
+            macro.ctx.env.locale = locale;
+            macro.ctx.env.slug = 'Mozilla/Add-ons/AMO';
+            return macro.call().then(function(result) {
+                expect(macro.ctx.template).toHaveBeenCalledTimes(1);
+                checkSidebarDom(result, locale);
+            });
+        });
+        itMacro(`with locale ${locale} under WebExtensions/API`, function(macro) {
+            macro.ctx.env.locale = locale;
+            macro.ctx.env.slug = 'Mozilla/Add-ons/WebExtensions/API/alarms';
+            return macro.call().then(function(result) {
+                expect(macro.ctx.template).toHaveBeenCalledTimes(1);
+                checkSidebarDom(result, locale, true);
+            });
+        });
+    }
+});

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -3,6 +3,10 @@
  */
 
 // Provides utilities that as a whole constitute the macro test framework.
+const { execSync } = require('child_process');
+const os = require('os');
+
+const vnu = require('vnu-jar');
 
 const Environment = require('../../src/environment.js');
 const Templates = require('../../src/templates.js');
@@ -154,11 +158,44 @@ function afterEachMacro(teardown) {
     });
 }
 
+/**
+ * This function validates its input as HTML. By default, it assumes the input
+ * is an HTML fragment, wrapping it to make a complete HTML document, but the
+ * second argument can be set to false to avoid wrapping. It returns null on
+ * success, and, on failure, a string detailing all of the errors.
+ *
+ * @param {string} html
+ * @param {boolean} fragment
+ */
+function lintHTML(html, fragment=true) {
+    if (fragment) {
+        html = `<!DOCTYPE html>
+                <html>
+                <head><title>test</title></head>
+                <body>${html}</body>
+                </html>`;
+    }
+    try {
+        execSync(`java -jar ${vnu} --errors-only --format text -`, {
+            input: html,
+            stdio: 'pipe',
+            timeout: 15000
+        });
+        return null;
+    } catch (error) {
+        const error_message = error.message.split(os.EOL).filter(
+            line => line.startsWith('Error: ')
+        ).join(os.EOL);
+        return error_message;
+    }
+}
+
 // ### Exported public API
 module.exports = {
     assert,
     itMacro,
     describeMacro,
     afterEachMacro,
-    beforeEachMacro
+    beforeEachMacro,
+    lintHTML
 };

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -167,7 +167,7 @@ function afterEachMacro(teardown) {
  * @param {string} html
  * @param {boolean} fragment
  */
-function lintHTML(html, fragment=true) {
+function lintHTML(html, fragment = true) {
     if (fragment) {
         html = `<!DOCTYPE html>
                 <html>
@@ -183,9 +183,10 @@ function lintHTML(html, fragment=true) {
         });
         return null;
     } catch (error) {
-        const error_message = error.message.split(os.EOL).filter(
-            line => line.startsWith('Error: ')
-        ).join(os.EOL);
+        const error_message = error.message
+            .split(os.EOL)
+            .filter(line => line.startsWith('Error: '))
+            .join(os.EOL);
         return error_message;
     }
 }

--- a/tests/macros/utils.test.js
+++ b/tests/macros/utils.test.js
@@ -23,18 +23,16 @@ const ERROR_TEST_CASES = [
         title: 'with an illegal value for a link attribute',
         html: '<a href="https://example.com" rel="xxx">an example</a>',
         error: 'Bad value “xxx” for attribute “rel” on element “a”'
-    },
+    }
 ];
 
 describe('test lintHTML function', function() {
-    for (let test of ERROR_TEST_CASES) {
+    for (const test of ERROR_TEST_CASES) {
         it(test.title, function() {
-            expect(lintHTML(test.html)).toEqual(
-                expect.stringContaining(test.error)
-            );
+            expect(lintHTML(test.html)).toContain(test.error);
         });
     }
-    it('with valid HTML input', async function() {
+    it('with valid HTML input', function() {
         expect(lintHTML('<div>This is nice</div>')).toBeFalsy();
     });
 });

--- a/tests/macros/utils.test.js
+++ b/tests/macros/utils.test.js
@@ -1,0 +1,40 @@
+/**
+ * @prettier
+ */
+const { lintHTML } = require('./utils');
+
+const ERROR_TEST_CASES = [
+    {
+        title: 'with an invalid HTML element',
+        html: '<junk></junk>',
+        error: 'Element “junk” not allowed'
+    },
+    {
+        title: 'with an HTML element missing its closing tag',
+        html: '<div>closing tag has gone missing',
+        error: 'Unclosed element “div”'
+    },
+    {
+        title: 'with an illegal link attribute',
+        html: '<a href="https://example.com" junk="xxx">an example</a>',
+        error: 'Attribute “junk” not allowed on element “a” at this point'
+    },
+    {
+        title: 'with an illegal value for a link attribute',
+        html: '<a href="https://example.com" rel="xxx">an example</a>',
+        error: 'Bad value “xxx” for attribute “rel” on element “a”'
+    },
+];
+
+describe('test lintHTML function', function() {
+    for (let test of ERROR_TEST_CASES) {
+        it(test.title, function() {
+            expect(lintHTML(test.html)).toEqual(
+                expect.stringContaining(test.error)
+            );
+        });
+    }
+    it('with valid HTML input', async function() {
+        expect(lintHTML('<div>This is nice</div>')).toBeFalsy();
+    });
+});


### PR DESCRIPTION
The main thrust of this PR is that it adds a `lintHTML()` test utility function -- which uses the [npm package](https://www.npmjs.com/package/vnu-jar) of the [Nu HTML Checker (v.Nu)](https://github.com/validator/validator) -- that can be used within the tests for many of the KumaScript macros (thanks to @wbamberg for that idea). I debated (and waffled) on whether I should make `lintHTML()` synchronous or asynchronous. I originally made it asynchronous, but decided in the end that it wasn't worth the extra mental/coding complexity given that its target environment was the test suite. I'd be happy to switch it back, or add it as an additional choice, if others disagree with that decision.

It also adds a new macro test (for the `AddonSidebar.ejs` macro) because I wanted to use `lintHTML()` at least once before submitting it for review. The tests for the `AddonSidebar.ejs` macro, however, go quite a bit further than just using `lintHTML()` (maybe too far, in the sense that it was a lot of work to understand and select an appropriate level of detail to test -- I'm hoping @wbamberg can guide me on that).

I also made two small tweaks to the `AddonSidebar.ejs` macro:
- I updated the Stack Overflow link to use `https` instead of `http`
- I stopped adding `closed` as an attribute to one of the `<details>` elements, since it's technically not a legal attribute for that element type and `lintHTML()` flags it as an error

This PR depends on https://github.com/mozilla/kuma/pull/5253 to add the JRE to the KumaScript Docker image, but since that has already been reviewed and merged, we're good to go there.
