### PR TITLE
Update ToolsSidebar macro to remove obsolete extending devtools links

### DIFF
--- a/macros/ToolsSidebar.ejs
+++ b/macros/ToolsSidebar.ejs
@@ -38,13 +38,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Extending the devtools",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Settings",
     "Release_notes": "Release notes"
   },
@@ -81,13 +74,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Extending the devtools",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Settings",
     "Release_notes": "Release notes"
   },
@@ -124,13 +110,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Consola del Navegador",
       "Browser_Toolbox": "Caixa d'Eines del Navegador",
     "Extending_the_devtools": "Ampliació dels devtools",
-      "Adding_a_panel_to_the_toolbox": "Afegir un nou panell per a la caixa d'eines",
-      "Example_devtools_add-ons": "Exemple de complements de devtools",
-      "Remote_Debugging_Protocol": "Protocol de Depuració Remota",
-      "Stream_Transport": "Transport de Flux",
-      "Source_Editor": "Editor de Codi Font",
-      "The_Debugger_Interface": "Interfície de Depuració",
-      "Web_Console_custom_output": "Sortida personalitzada de la Consola Web",
     "Settings": "Configuracions",
     "Release_notes": "Notes de la versió"
   },
@@ -167,13 +146,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser-Konsole",
       "Browser_Toolbox": "Browser-Toolbox",
     "Extending_the_devtools": "Die Entwickler-Werkzeuge erweitern",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protokoll",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Einstellungen",
     "Release_notes": "Versionshinweise"
   },
@@ -210,13 +182,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Console du navigateur",
       "Browser_Toolbox": "Boite à outils du navigateur",
     "Extending_the_devtools": "Extensions pour les outils de développement",
-      "Adding_a_panel_to_the_toolbox": "Ajout d'un panneau à la boîte à outils",
-      "Example_devtools_add-ons": "Exemples d'extensions aux outils de développement",
-      "Remote_Debugging_Protocol": "Protocole de déboguage à distance",
-      "Stream_Transport": "Transport des flux",
-      "Source_Editor": "Éditeur du source",
-      "The_Debugger_Interface": "L’API Debugger",
-      "Web_Console_custom_output": "Sortie personnalisée dans la console web",
     "Settings": "Paramètres",
     "Release_notes": "Notes de version"
   },
@@ -253,13 +218,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Konsol Peramban",
       "Browser_Toolbox": "Kotak Perkakas Peramban",
     "Extending_the_devtools": "Meluaskan alat pengembang",
-      "Adding_a_panel_to_the_toolbox": "Menambah sebuah panel ke kotak perkakas",
-      "Example_devtools_add-ons": "Contoh pengaya alat pengembang",
-      "Remote_Debugging_Protocol": "Protokol Men-debug Jarak Jauh",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Peubah Sumber",
-      "The_Debugger_Interface": "Antarmuka Debugger",
-      "Web_Console_custom_output": "Konsol Web Keluaran Kustom",
     "Settings": "Pengaturan",
     "Release_notes": "Catatan Rilis"
   },
@@ -296,13 +254,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "ブラウザーコンソール",
       "Browser_Toolbox": "ブラウザーツールボックス",
     "Extending_the_devtools": "開発ツールの拡張",
-      "Adding_a_panel_to_the_toolbox": "開発ツールにパネルを追加する",
-      "Example_devtools_add-ons": "開発ツールのアドオンのサンプル",
-      "Remote_Debugging_Protocol": "リモートデバッグプロトコル",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "ソースエディター",
-      "The_Debugger_Interface": "Debugger インターフェイス",
-      "Web_Console_custom_output": "ウェブコンソールのカスタム出力",
     "Settings": "オプション",
     "Release_notes": "リリースノート"
   },
@@ -339,13 +290,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "브라우저 콘솔",
       "Browser_Toolbox": "브라우저 툴박스",
     "Extending_the_devtools": "개발도구 확장하기",
-      "Adding_a_panel_to_the_toolbox": "도구박스에 패널 더하기",
-      "Example_devtools_add-ons": "개발자 도구 애드온 예제",
-      "Remote_Debugging_Protocol": "원격 디버깅 프로토콜",
-      "Stream_Transport": "스트림 전송",
-      "Source_Editor": "소스 편집기",
-      "The_Debugger_Interface": "디버거 인터페이스",
-      "Web_Console_custom_output": "사용자 맞춤형 웹 콘솔 출력",
     "Settings": "설정",
     "Release_notes": "배포 기록"
   },
@@ -382,13 +326,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Estendendo o devtools",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Editor de código",
-      "The_Debugger_Interface": "A interface do Debugger",
-      "Web_Console_custom_output": "Output do Web Console personalizado",
     "Settings": "Configurações",
     "Release_notes": "Notas de versão"
   },
@@ -425,13 +362,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Ampliar as ferramentas de desenvolvimento",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Configurações",
     "Release_notes": "Notas de lançamento"
   },
@@ -468,13 +398,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Consolă navigator",
       "Browser_Toolbox": "Set de instrumente pentru navigator",
     "Extending_the_devtools": "Extinderea uneltelor pentru dezvoltatori",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Protocol de depanare la distanță",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Editor sursă",
-      "The_Debugger_Interface": "Interfața Debugger",
-      "Web_Console_custom_output": "Date de ieșire personalizate ale consolei web",
     "Settings": "Setări",
     "Release_notes": "Note de lansare"
   },
@@ -511,13 +434,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Extending the devtools",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Settings",
     "Release_notes": "Release notes"
   },
@@ -554,13 +470,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "Browser Console",
       "Browser_Toolbox": "Browser Toolbox",
     "Extending_the_devtools": "Extending the devtools",
-      "Adding_a_panel_to_the_toolbox": "Adding a panel to the toolbox",
-      "Example_devtools_add-ons": "Example devtools add-ons",
-      "Remote_Debugging_Protocol": "Remote Debugging Protocol",
-      "Stream_Transport": "Stream Transport",
-      "Source_Editor": "Source Editor",
-      "The_Debugger_Interface": "The Debugger Interface",
-      "Web_Console_custom_output": "Web Console custom output",
     "Settings": "Inställningar",
     "Release_notes": "Anteckningar för utgåvan"
   },
@@ -597,13 +506,6 @@ const text = mdn.localStringMap({
       "Browser_Console": "浏览器控制台",
       "Browser_Toolbox": "浏览器工具箱",
     "Extending_the_devtools": "扩展开发者工具",
-      "Adding_a_panel_to_the_toolbox": "添加一个面板到工具箱",
-      "Example_devtools_add-ons": "开发者工具附加组件实例",
-      "Remote_Debugging_Protocol": "远程调试协议",
-      "Stream_Transport": "流传输",
-      "Source_Editor": "源码编辑器",
-      "The_Debugger_Interface": "Debugger 接口",
-      "Web_Console_custom_output": "Web 控制台自定义输出",
     "Settings": "设置",
     "Release_notes": "说明"
   }
@@ -668,20 +570,7 @@ const text = mdn.localStringMap({
         </ol>
       </details>
     </li>
-    <li class="toggle">
-      <details>
-        <summary><%=text['Extending_the_devtools']%></summary>
-        <ol>
-          <li><a href="<%=baseURL%>Adding_a_panel_to_the_toolbox"><%=text['Adding_a_panel_to_the_toolbox']%></a></li>
-          <li><a href="<%=baseURL%>Example_add-ons"><%=text['Example_devtools_add-ons']%></a></li>
-          <li><a href="https://wiki.mozilla.org/Remote_Debugging_Protocol"><%=text['Remote_Debugging_Protocol']%></a></li>
-          <li><a href="https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport"><%=text['Stream_Transport']%></a></li>
-          <li><a href="<%=baseURL%>Editor"><%=text['Source_Editor']%></a></li>
-          <li><a href="<%=baseURL%>Debugger-API"><%=text['The_Debugger_Interface']%></a></li>
-          <li><a href="<%=baseURL%>Web_Console/Custom_output"><%=text['Web_Console_custom_output']%></a></li>
-        </ol>
-      </details>
-    </li>
+    <li><a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools"><%=text['Extending_the_devtools']%></a></li>
     <li><a href="<%=baseURL%>Settings"><%=text['Settings']%></a></li>
     <li><a href="<%=baseURL%>Release_notes"><%=text['Release_notes']%></a></li>
   </ol>


### PR DESCRIPTION
... and replace them with a link to the updated Browser Extensions tutorial

As per https://github.com/mdn/sprints/issues/1035

I have just made it link to the en-US version regardless of the locale, because there are not many translations of the page, but choosing the right one is a pain because the URL slugs are all localized too. So leaving it like this for now.

