### PR TITLE
Add WebRTC Identity spec to SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1569,14 +1569,19 @@
     "url": "https://notifications.spec.whatwg.org/",
     "status": "Living"
   },
-  "WebRTC Statistics Identifiers": {
-    "name": "Identifiers for WebRTC's Statistics API",
-    "url": "https://w3c.github.io/webrtc-stats/",
-    "status": "CR"
-  },
   "WebRTC 1.0": {
     "name": "WebRTC 1.0: Real-time Communication Between Browsers",
     "url": "https://w3c.github.io/webrtc-pc/",
+    "status": "CR"
+  },
+  "WebRTC Identity": {
+    "name": "Identity for WebRTC",
+    "url": "https://w3c.github.io/webrtc-identity/",
+    "status": "CR"
+  },
+  "WebRTC Statistics Identifiers": {
+    "name": "Identifiers for WebRTC's Statistics API",
+    "url": "https://w3c.github.io/webrtc-stats/",
     "status": "CR"
   },
   "Web Share API": {


### PR DESCRIPTION
Adds the Identity for WebRTC specification to the
SpecData.json file.