### PR TITLE
fix(macros/Compat): Improve `mdn_url` handling

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -124,7 +124,11 @@ function writeFeatureName(row, feature) {
   // Add relative MDN url, but don't link to the current page
   if (feature.mdn_url) {
     let href = feature.mdn_url.replace('https://developer.mozilla.org', '');
+    if (feature.mdn_url.includes('#') && href.split('#')[0] === '/docs/' + env.slug) {
+      href = feature.mdn_url.substring(feature.mdn_url.indexOf('#'))
+    }
     if (href !== '/docs/' + env.slug) {
+      if (href[0] === '/') href = '/' + env.locale + href;
       desc = `<a href="${href}">${desc}</a>`;
     }
   }

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -217,7 +217,12 @@ describeMacro('Compat', function() {
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
                             .innerHTML,
-                        '<a href="/docs/Web/HTTP/Headers/Content-Security-Policy/child-src"><code>subfeature_with_mdn_url</code></a>'
+                        '<a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src"><code>subfeature_with_mdn_url</code></a>'
+                    );
+                    assert.equal(
+                        dom.querySelector('.bc-table tbody tr:nth-child(3) th')
+                            .innerHTML,
+                        '<a href="#Directives"><code>subfeature_with_same_mdn_url_and_fragment</code></a>'
                     );
                 });
         }
@@ -237,9 +242,39 @@ describeMacro('Compat', function() {
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
                             .innerHTML,
-                        '<a href="/docs/Web/HTTP/Headers/Content-Security-Policy/child-src">CSP: child-src</a>'
+                        '<a href="/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src">CSP: child-src</a>'
+                    );
+                    assert.equal(
+                        dom.querySelector('.bc-table tbody tr:nth-child(3) th')
+                            .innerHTML,
+                        '<a href="#Directives">CSP Directives</a>'
                     );
                 });
+        }
+    );
+    itMacro(
+        "Creates correct feature labels for features with an MDN URL (non-'en-US' locale)",
+        async macro => {
+            macro.ctx.env.locale = 'ja';
+            macro.ctx.env.slug = 'Web/HTTP/Headers/Content-Security-Policy';
+
+            let result = await macro.call('api.feature_with_mdn_url');
+            let dom = JSDOM.fragment(result);
+
+            assert.equal(
+                dom.querySelector('.bc-table tbody tr th').innerHTML,
+                '基本対応'
+            );
+            assert.equal(
+                dom.querySelector('.bc-table tbody tr:nth-child(2) th')
+                    .innerHTML,
+                '<a href="/ja/docs/Web/HTTP/Headers/Content-Security-Policy/child-src"><code>subfeature_with_mdn_url</code></a>'
+            );
+            assert.equal(
+                dom.querySelector('.bc-table tbody tr:nth-child(3) th')
+                    .innerHTML,
+                '<a href="#Directives"><code>subfeature_with_same_mdn_url_and_fragment</code></a>'
+            );
         }
     );
     itMacro(

--- a/tests/macros/fixtures/compat/feature_labels.json
+++ b/tests/macros/fixtures/compat/feature_labels.json
@@ -56,6 +56,16 @@
                         }
                     }
                 }
+            },
+            "subfeature_with_same_mdn_url_and_fragment": {
+                "__compat": {
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy#Directives",
+                    "support": {
+                        "firefox": {
+                            "version_added": "1"
+                        }
+                    }
+                }
             }
         },
         "feature_with_mdn_url_and_description": {
@@ -72,6 +82,17 @@
                 "__compat": {
                     "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/child-src",
                     "description": "CSP: child-src",
+                    "support": {
+                        "firefox": {
+                            "version_added": "1"
+                        }
+                    }
+                }
+            },
+            "subfeature_with_same_mdn_url_and_fragment": {
+                "__compat": {
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy#Directives",
+                    "description": "CSP Directives",
                     "support": {
                         "firefox": {
                             "version_added": "1"


### PR DESCRIPTION
Part&nbsp;2; extracted&nbsp;from https://github.com/mdn/browser-compat-toolkit/pull/5

- Correctly handle anchor links
- Output localized URLs

review?(@Elchi3)