### PR TITLE
fix(macros/Compat): Fix stray closing `</tr>` tag

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -567,7 +567,7 @@ function writeCompatFeatureRow() {
     output += '<tr>';
     let feature = Object.keys(row).map((k) => row[k])[0];
     output += `<th scope="row">${writeFeatureName(row, feature)}</th>`;
-    output += `${writeCompatCells(feature.support)}</tr>`;
+    output += writeCompatCells(feature.support);
     output += '</tr>';
   }
   return output;

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -1,7 +1,14 @@
 /**
  * @prettier
  */
-const { assert, itMacro, describeMacro, beforeEachMacro } = require('./utils');
+const {
+    assert,
+    itMacro,
+    describeMacro,
+    beforeEachMacro,
+    lintHTML
+} = require('./utils');
+
 const fs = require('fs'),
     path = require('path'),
     jsdom = require('jsdom'),
@@ -37,6 +44,11 @@ describeMacro('Compat', function() {
             return assert.eventually.equal(actual, expected);
         }
     );
+
+    itMacro('Outputs valid HTML', async macro => {
+        const result = await macro.call('api.feature');
+        expect(lintHTML(result)).toBeFalsy();
+    });
 
     // Different content areas have different platforms (desktop, mobile, server)
     // which consist of different browsers


### PR DESCRIPTION
Part&nbsp;3; extracted&nbsp;from https://github.com/mdn/browser-compat-toolkit/pull/7

review?(@Elchi3)