### PR TITLE
refactor(macros/Compat): Rewrite `writeFlagsNote(…)` function

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -264,92 +264,84 @@ function getSupportClass(supportInfo) {
   return cssClass;
 }
 
-/*
-Generate the note for a browser flag or preference
-First checks version_added and version_removed to create a string indicating when
-a preference setting is present. Then creates a (browser specific) string
-for either a preference flag or a compile flag.
+/**
+ * Generate the note for a browser flag or preference
+ * First checks version_added and version_removed to create a string indicating when
+ * a preference setting is present. Then creates a (browser specific) string
+ * for either a preference flag or a compile flag.
+ *
+ * @param {object} supportData is a support_statement
+ * @param {string} browserId is a compat_block browser ID
+ *
+ * @return {string} The note for the flags information.
+ */
+function writeFlagsNote (supportData, browserId) {
+  // TODO: Move these to the mdn-browser-compat-data package.
+  const firefoxPrefs = 'about:config';
+  const chromePrefs = 'chrome://flags';
 
-// TODO Need to localize this
-
-`supportData` is a support_statement
-`browserId` is a compat_block browser ID
-*/
-function writeFlagsNote(supportData, browserId) {
-  let output = '';
-
-  const firefoxPrefs = ' To change preferences in Firefox, visit about:config.';
-  const chromePrefs = ' To change preferences in Chrome, visit chrome://flags.';
-
-  if (typeof(supportData.version_added) === 'string') {
-    output = `From version ${supportData.version_added}`;
+  let support = ''
+  if (typeof (supportData.version_added) === 'string') {
+    support = localize(compatStrings, 'flag_support_start');
+    support = support.replace('${versionAdded}', supportData.version_added);
   }
 
-  if (typeof(supportData.version_removed) === 'string') {
-    if (output) {
-      output += ' ';
-      output += `until version ${supportData.version_removed} (exclusive)`;
+  if (typeof (supportData.version_removed) === 'string') {
+    if (support) {
+      support = localize(compatStrings, 'flag_support_range');
+      support = support.replace('${versionAdded}', supportData.version_added);
     } else {
-      output = `Until version ${supportData.version_removed} (exclusive)`;
+      support = localize(compatStrings, 'flag_support_end');
     }
+    support = support.replace('${versionRemoved}', supportData.version_removed);
   }
 
-  let start = 'This';
-  if (output) {
-    output += ':';
-    start = ' this';
+  let start = localize(compatStrings, 'flag_start');
+  if (support) {
+    start = localize(compatStrings, 'flag_start_cont').replace('${support}', support);
   }
-
-  start += ' feature is behind the ';
 
   let flagsText = '';
   let settings = '';
 
-  for (i = 0; i < supportData.flags.length; i++) {
+  for (let i = 0; i < supportData.flags.length; i++) {
     let flag = supportData.flags[i];
     let nameString = `<code>${flag.name}</code>`;
 
     // value_to_set is optional
     let valueToSet = '';
     if (flag.value_to_set) {
-      valueToSet = ` (needs to be set to <code>${flag.value_to_set}</code>)`;
+      valueToSet = localize(compatStrings, 'flag_valueToSet').replace('${valueToSet}', flag.value_to_set);
     }
 
-    let typeString = '';
+    let typeString = localize(compatStrings, `flag_type_${flag.type}`).replace('${valueToSet}', valueToSet);
     if (flag.type === 'preference') {
+      settings = localize(compatStrings, 'flag_browser');
       switch (browserId) {
         case 'firefox':
         case 'firefox_android':
-          settings = firefoxPrefs;
-        break;
+          settings = settings.replace('${browser}', localize(compatStrings, `bc_icon_name_firefox`)).replace('${url}', firefoxPrefs);
+          break;
         case 'chrome':
         case 'chrome_android':
-          settings = chromePrefs;
-        break;
+          settings = settings.replace('${browser}', localize(compatStrings, `bc_icon_name_chrome`)).replace('${url}', chromePrefs);
+          break;
+        default:
+          settings = '';
+          break;
       }
-      typeString = ` preference${valueToSet}`;
-    }
-
-    if (flag.type === 'compile_flag') {
-      typeString = ` compile flag${valueToSet}`;
-    }
-
-    if (flag.type === 'runtime_flag') {
-      typeString = ` runtime flag${valueToSet}`;
     }
 
     flagsText += nameString + typeString;
 
-    if (i != supportData.flags.length - 1) {
-      flagsText += ' and the ';
+    if (i !== supportData.flags.length - 1) {
+      flagsText += localize(compatStrings, 'flag_misc_joiner');
     } else {
-      flagsText += '.';
+      flagsText += localize(compatStrings, 'flag_misc_end');
     }
   }
 
-  output += start + flagsText + settings;
-
-  return output;
+  return (start + flagsText + settings);
 }
 
 /*

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -276,9 +276,7 @@ function getSupportClass(supportInfo) {
  * @return {string} The note for the flags information.
  */
 function writeFlagsNote (supportData, browserId) {
-  // TODO: Move these to the mdn-browser-compat-data package.
-  const firefoxPrefs = 'about:config';
-  const chromePrefs = 'chrome://flags';
+    const browserData = bcd.browsers[browserId];
 
   let support = ''
   if (typeof (supportData.version_added) === 'string') {
@@ -315,21 +313,10 @@ function writeFlagsNote (supportData, browserId) {
     }
 
     let typeString = localize(compatStrings, `flag_type_${flag.type}`).replace('${valueToSet}', valueToSet);
-    if (flag.type === 'preference') {
-      settings = localize(compatStrings, 'flag_browser');
-      switch (browserId) {
-        case 'firefox':
-        case 'firefox_android':
-          settings = settings.replace('${browser}', localize(compatStrings, `bc_icon_name_firefox`)).replace('${url}', firefoxPrefs);
-          break;
-        case 'chrome':
-        case 'chrome_android':
-          settings = settings.replace('${browser}', localize(compatStrings, `bc_icon_name_chrome`)).replace('${url}', chromePrefs);
-          break;
-        default:
-          settings = '';
-          break;
-      }
+    if (flag.type === 'preference' && browserData && browserData.pref_url) {
+      settings = localize(compatStrings, 'flag_browser')
+        .replace('${browser}', browserData.name)
+        .replace('${url}', browserData.pref_url);
     }
 
     flagsText += nameString + typeString;

--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -432,5 +432,41 @@
         "nl"   : "Verouderd. Niet voor gebruik in nieuwe websites",
         "ru"   : "Устаревшая. Не следует использовать в новых веб-сайтах",
         "fr"   : "Obsolète. Les nouveaux sites web ne doivent pas utiliser cette fonctionnalité."
+    },
+    "flag_browser": {
+        "en-US": " To change preferences in ${browser}, visit ${url}."
+    },
+    "flag_support_start": {
+        "en-US": "From version ${versionAdded}"
+    },
+    "flag_support_range": {
+        "en-US": "From version ${versionAdded} until version ${versionRemoved} (exclusive)"
+    },
+    "flag_support_end": {
+        "en-US": "Until version ${versionRemoved} (exclusive)"
+    },
+    "flag_start": {
+        "en-US": "This feature is behind the "
+    },
+    "flag_start_cont": {
+        "en-US": "${support}: this feature is behind the "
+    },
+    "flag_valueToSet": {
+        "en-US": " (needs to be set to <code>${valueToSet}</code>)"
+    },
+    "flag_type_preference": {
+        "en-US": " preference${valueToSet}"
+    },
+    "flag_type_compile_flag": {
+        "en-US": " compile flag${valueToSet}"
+    },
+    "flag_type_runtime_flag": {
+        "en-US": " runtime flag${valueToSet}"
+    },
+    "flag_misc_joiner": {
+        "en-US": " and the "
+    },
+    "flag_misc_end": {
+        "en-US": "."
     }
 }

--- a/tests/macros/fixtures/compat/browsers.json
+++ b/tests/macros/fixtures/compat/browsers.json
@@ -1,0 +1,28 @@
+{
+    "browsers": {
+        "chrome": {
+            "name": "Chrome",
+            "pref_url": "chrome://flags"
+        },
+        "chrome_android": {
+            "name": "Chrome Android",
+            "pref_url": "chrome://flags"
+        },
+        "edge": {
+            "name": "Edge",
+            "pref_url": "about:flags"
+        },
+        "edge_mobile": {
+            "name": "Edge Mobile",
+            "pref_url": "about:flags"
+        },
+        "firefox": {
+            "name": "Firefox",
+            "pref_url": "about:config"
+        },
+        "firefox_android": {
+            "name": "Firefox Android",
+            "pref_url": "about:config"
+        }
+    }
+}


### PR DESCRIPTION
Part&nbsp;4; extracted&nbsp;from https://github.com/mdn/browser-compat-toolkit/pull/15 and https://github.com/mdn/kumascript/pull/1010.

* refactor(macros/Compat): Internationalise flag notes
* feat(macros/Compat): Use browser‑compat‑data for preference URLs

review?(@Elchi3)