### PR TITLE
Remove 'Basic support' label

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -111,7 +111,7 @@ function writeFeatureName(row, feature) {
   let label = Object.keys(row)[0];
 
   if (feature.description) {
-    // Basic support or un-nested features need no prefixing
+    // Un-nested features need no prefixing
     if (label.indexOf('.') === -1) {
       desc += feature.description;
       // otherwise add a prefix so that we know where this belongs to (e.g. "parse: ISO 8601 format")
@@ -514,8 +514,8 @@ function getFormattedBrowserName(browserNameKey) {
 
 /*
 For a single row, write all the cells that contain support data.
-(That is, every cell in the row except the first, which contains
-an identifier for the row,  like "Basic support".
+(That is, every cell in the row except the first column, which contains
+the feature name)
 
 */
 function writeCompatCells(supportData) {
@@ -694,7 +694,6 @@ var identifier = query.split(".").pop();
 if (!compatData) {
     output = s_no_data_found;
 } else if (compatData.__compat) {
-    compatData.__compat.description = localize(compatStrings, 'feature_basicsupport');
     features.push({[identifier]: compatData.__compat});
 }
 

--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -229,15 +229,6 @@
         "ru"   : "Возможность",
         "nl"   : "Functie"
     },
-    "feature_basicsupport": {
-        "en-US": "Basic support",
-        "de"   : "Grundlegende Unterstützung",
-        "es"   : "Soporte básico",
-        "fr"   : "Support simple",
-        "ja"   : "基本対応",
-        "ru"   : "Базовая поддержка",
-        "nl"   : "Basisondersteuning"
-    },
     "bc_icon_name_experimental": {
         "en-US": "Experimental",
         "de"   : "Experimentell",

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -186,7 +186,7 @@ describeMacro('Compat', function() {
             let dom = JSDOM.fragment(result);
             assert.equal(
                 dom.querySelector('.bc-table tbody tr th').innerHTML,
-                'Basic support'
+                '<code>bareFeature</code>'
             );
             assert.equal(
                 dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -204,7 +204,7 @@ describeMacro('Compat', function() {
                     let dom = JSDOM.fragment(result);
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr th').innerHTML,
-                        'Basic support'
+                        'Root feature description'
                     );
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -224,7 +224,7 @@ describeMacro('Compat', function() {
                     let dom = JSDOM.fragment(result);
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr th').innerHTML,
-                        'Basic support'
+                        '<code>feature_with_mdn_url</code>'
                     );
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -249,7 +249,7 @@ describeMacro('Compat', function() {
                     let dom = JSDOM.fragment(result);
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr th').innerHTML,
-                        'Basic support'
+                        'CSP'
                     );
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -275,7 +275,7 @@ describeMacro('Compat', function() {
 
             assert.equal(
                 dom.querySelector('.bc-table tbody tr th').innerHTML,
-                '基本対応'
+                '<code>feature_with_mdn_url</code>'
             );
             assert.equal(
                 dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -298,7 +298,7 @@ describeMacro('Compat', function() {
                     let dom = JSDOM.fragment(result);
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr th').textContent,
-                        'Basic support Experimental'
+                        'experimental_feature Experimental'
                     );
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')
@@ -317,7 +317,7 @@ describeMacro('Compat', function() {
                     let dom = JSDOM.fragment(result);
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr th').textContent,
-                        'Basic support Deprecated'
+                        'deprecated_feature_with_description Deprecated'
                     );
                     assert.equal(
                         dom.querySelector('.bc-table tbody tr:nth-child(2) th')

--- a/tests/macros/fixtures/compat/feature_labels.json
+++ b/tests/macros/fixtures/compat/feature_labels.json
@@ -20,7 +20,7 @@
         },
         "feature_with_description": {
             "__compat": {
-                "description": "This will be 'Basic support' regardless",
+                "description": "Root feature description",
                 "support": {
                     "firefox": {
                         "version_added": "1"


### PR DESCRIPTION
This removes the "Basic support" label and instead displays the feature id (wrapped in \<code>) or a description if one is available. 

Looking at different compat tables:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Browser_compatibility 
"basic support" becomes "`<video>`"

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey#Browser_compatibility 
"Basic support" becomes "`accesskey`"

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color#Browser_compatibility 
"Basic support" becomes "`<input type="color">`"

https://developer.mozilla.org/en-US/docs/Web/CSS/align-self#Browser_compatibility 
"Basic support" becomes "`align-self`"

https://developer.mozilla.org/en-US/docs/Web/CSS/@page#Browser_compatibility 
"Basic support" becomes "`@page`"

https://developer.mozilla.org/en-US/docs/Web/CSS/@page/bleed#Browser_compatibility 
"Basic support" becomes "`bleed`"

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Browser_compatibility 
"Basic support" becomes "`Set-Cookie`"

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#Browser_compatibility 
"Basic support" becomes "`default-src`"

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of 
"basic support" becomes "`for..await..of`"

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Browser_compatibility 
"Basic support" becomes "`Array`"

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/entries#Browser_compatibility 
"Basic support" becomes "`entries`"

https://developer.mozilla.org/en-US/docs/Web/API/Node#Browser_compatibility 
"basic support" becomes "`Node`"

https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild#Browser_compatibility 
"basic support" becomes "`firstChild`"

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm 
"Basic support" becomes "`Alarm`"


Please let me know if you can image other (weird) cases.