### PR TITLE
add tests for SVGAttr macro

### DIFF
--- a/tests/macros/svgattr.test.js
+++ b/tests/macros/svgattr.test.js
@@ -3,7 +3,7 @@
  */
 const { assert, itMacro, describeMacro } = require('./utils');
 
-describeMacro('SVGAttr', function() {
+describeMacro('SVGAttr', () => {
     for (const locale of ['en-US', 'de', 'fr']) {
         for (const attr of ['min', 'max']) {
             itMacro(`${locale} ${attr} `, function(macro) {

--- a/tests/macros/svgattr.test.js
+++ b/tests/macros/svgattr.test.js
@@ -6,7 +6,7 @@ const { assert, itMacro, describeMacro } = require('./utils');
 describeMacro('SVGAttr', () => {
     for (const locale of ['en-US', 'de', 'fr']) {
         for (const attr of ['min', 'max']) {
-            itMacro(`${locale} ${attr} `, function(macro) {
+            itMacro(`${locale} ${attr} `, macro => {
                 macro.ctx.env.locale = locale;
                 return assert.eventually.equal(
                     macro.call(attr),

--- a/tests/macros/svgattr.test.js
+++ b/tests/macros/svgattr.test.js
@@ -1,0 +1,18 @@
+/**
+ * @prettier
+ */
+const { assert, itMacro, describeMacro } = require('./utils');
+
+describeMacro('SVGAttr', function() {
+    for (const locale of ['en-US', 'de', 'fr']) {
+        for (const attr of ['min', 'max']) {
+            itMacro(`${locale} ${attr} `, function(macro) {
+                macro.ctx.env.locale = locale;
+                return assert.eventually.equal(
+                    macro.call(attr),
+                    `<code><a href="/${locale}/docs/Web/SVG/Attribute/${attr}">${attr}</a></code>`
+                );
+            });
+        }
+    }
+});


### PR DESCRIPTION
Simple tests for the `SVGAttr.ejs` macro. I wasn't planning on doing this, but thought I'd put something together when reviewing the work on https://github.com/mdn/kumascript/pull/1005.