### PR TITLE
Adding dictionaries for WebAuthn / Web Authentication API

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1895,7 +1895,9 @@
                             "AuthenticatorAssertionResponse" ],
             "methods":    [],
             "properties": [],
-            "events":     []
+            "events":     [],
+            "dictionaries": ["PublicKeyCredentialRequestOptions",
+                             "PublicKeyCredentialCreationOptions"]
         },
         "Web Components": {
             "guides":       [


### PR DESCRIPTION
Adding both:
*  [`PublicKeyCredentialRequestOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions) 
* [`PublicKeyCredentialCreationOptions`](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions)
as dictionaries relevant to the Web Authentication API sidebar.
This is part of the ongoing work for https://github.com/mdn/sprints/issues/976 