### PR TITLE
refactor: Use extensionless require

### DIFF
--- a/run.js
+++ b/run.js
@@ -15,8 +15,8 @@ if (process.env.NEW_RELIC_LICENSE_KEY && process.env.NEW_RELIC_APP_NAME) {
 }
 
 // Start up a server instance.
-const config = require('./src/config.js');
-const Server = require('./src/server.js');
+const config = require('./src/config');
+const Server = require('./src/server');
 console.log(`KumaScript server starting (PID ${process.pid}).`);
 var server = new Server();
 server.listen(config.port);

--- a/src/cache-lru.js
+++ b/src/cache-lru.js
@@ -4,7 +4,7 @@
  * @prettier
  */
 const LRU = require('lru-cache');
-const config = require('./config.js');
+const config = require('./config');
 
 const lru = new LRU({
     max: 1024 * 1024 * config.cacheMegabytes,

--- a/src/cache-redis.js
+++ b/src/cache-redis.js
@@ -4,7 +4,7 @@
  * @prettier
  */
 const Redis = require('redis');
-const config = require('./config.js');
+const config = require('./config');
 const client = Redis.createClient(config.redisURL);
 
 module.exports = {

--- a/src/cache.js
+++ b/src/cache.js
@@ -8,15 +8,15 @@
  *
  * @prettier
  */
-const config = require('./config.js');
+const config = require('./config');
 
 // The cache() function that is exported by this module needs async
 // get and set functions that represent the actual caching
 // operations. If our configuration includes Redis we'll use
 // that. Otherwise we'll fall back to an in-memory LRU cache.
 const backend = config.redisURL
-    ? require('./cache-redis.js')
-    : require('./cache-lru.js');
+    ? require('./cache-redis')
+    : require('./cache-lru');
 
 /**
  * Look up the specified key in the cache, and return its value if

--- a/src/environment.js
+++ b/src/environment.js
@@ -26,8 +26,8 @@
 const url = require('url');
 const request = require('request');
 
-const cache = require('./cache.js');
-const config = require('./config.js');
+const cache = require('./cache');
+const config = require('./config');
 
 // Utility functions are collected here. These are functions that are used
 // by the exported functions below. Some of them are themselves exported.

--- a/src/render.js
+++ b/src/render.js
@@ -42,14 +42,14 @@
  *
  * @prettier
  */
-const Parser = require('./parser.js');
-const Environment = require('./environment.js');
+const Parser = require('./parser');
+const Environment = require('./environment');
 const {
     MacroInvocationError,
     MacroNotFoundError,
     MacroCompilationError,
     MacroExecutionError
-} = require('./errors.js');
+} = require('./errors');
 
 async function render(source, templates, pageEnvironment) {
     // Parse the source document.

--- a/src/server.js
+++ b/src/server.js
@@ -23,10 +23,10 @@ const express = require('express');
 const morgan = require('morgan');
 const request = require('request');
 
-const config = require('./config.js');
-const firelogger = require('./firelogger.js');
-const Templates = require('./templates.js');
-const render = require('./render.js');
+const config = require('./config');
+const firelogger = require('./firelogger');
+const Templates = require('./templates');
+const render = require('./render');
 
 class Server {
     /**
@@ -70,7 +70,7 @@ class Server {
     /**
      * Start the service listening
      *
-     * @param {port} number
+     * @param {number} port
      */
     listen(port) {
         port = port || config.port;

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -29,7 +29,7 @@ describe('cache() function', () => {
         async backend => {
             const config = require('../src/config');
             config.redisURL = backend === 'lru' ? null : 'redis://';
-            const cache = require('../src/cache.js');
+            const cache = require('../src/cache');
 
             let compute = jest.fn(() => String(Math.random()));
 
@@ -50,7 +50,7 @@ describe('cache() function', () => {
         async backend => {
             const config = require('../src/config');
             config.redisURL = backend === 'lru' ? null : 'redis://';
-            const cache = require('../src/cache.js');
+            const cache = require('../src/cache');
 
             let compute = jest.fn(() => String(Math.random()));
 
@@ -65,7 +65,7 @@ describe('cache() function', () => {
     it.each(['lru', 'redis'])('does not cache null (%s)', async backend => {
         const config = require('../src/config');
         config.redisURL = backend === 'lru' ? null : 'redis://';
-        const cache = require('../src/cache.js');
+        const cache = require('../src/cache');
         let compute = jest.fn(() => null);
 
         await cache('key4', compute);
@@ -84,7 +84,7 @@ describe('cache() function', () => {
         async backend => {
             const config = require('../src/config');
             config.redisURL = backend === 'lru' ? null : 'redis://';
-            const cache = require('../src/cache.js');
+            const cache = require('../src/cache');
             async function expectExceptionFor(x) {
                 try {
                     let value = await cache('key6', () => x);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -8,7 +8,7 @@ describe('config.js', () => {
     });
 
     it('default configuration', () => {
-        const config = require('../src/config.js');
+        const config = require('../src/config');
 
         expect(config.port).toBe(9080);
         expect(config.documentURLTemplate).toBe(
@@ -33,7 +33,7 @@ describe('config.js', () => {
         process.env['KUMASCRIPT_CACHE_MEGABYTES'] = '100';
         process.env['KUMASCRIPT_CACHE_MINUTES'] = '1000';
 
-        const config = require('../src/config.js');
+        const config = require('../src/config');
 
         expect(config.port).toBe(80);
         expect(config.documentURLTemplate).toBe('A');

--- a/tests/environment.test.js
+++ b/tests/environment.test.js
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-const Environment = require('../src/environment.js');
+const Environment = require('../src/environment');
 
 // We test using `with` because that is what EJS uses. But Jest
 // runs tests in strict mode, so we have to hide the with inside

--- a/tests/macros.test.js
+++ b/tests/macros.test.js
@@ -5,7 +5,7 @@
  */
 const fs = require('fs');
 const ejs = require('ejs');
-const Templates = require('../src/templates.js');
+const Templates = require('../src/templates');
 
 describe('macros/ directory', () => {
     describe('compile all macros', () => {

--- a/tests/macros/utils.js
+++ b/tests/macros/utils.js
@@ -8,8 +8,8 @@ const os = require('os');
 
 const vnu = require('vnu-jar');
 
-const Environment = require('../../src/environment.js');
-const Templates = require('../../src/templates.js');
+const Environment = require('../../src/environment');
+const Templates = require('../../src/templates');
 
 // When we were doing mocha testing, we used this.macro to hold this.
 // But Jest doesn't use the this object, so we just store the object here.

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -2,7 +2,7 @@
  * @prettier
  */
 
-const Parser = require('../src/parser.js');
+const Parser = require('../src/parser');
 
 describe('Parser', function() {
     it('input with no macros', () => {

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -3,14 +3,14 @@
  */
 
 const fs = require('fs');
-const Templates = require('../src/templates.js');
-const render = require('../src/render.js');
+const Templates = require('../src/templates');
+const render = require('../src/render');
 const {
     MacroInvocationError,
     MacroNotFoundError,
     MacroCompilationError,
     MacroExecutionError
-} = require('../src/errors.js');
+} = require('../src/errors');
 
 describe('render() function', () => {
     function fixture(name) {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -7,8 +7,8 @@ const path = require('path');
 const express = require('express');
 const request = require('request');
 
-const Server = require('../src/server.js');
-const config = require('../src/config.js');
+const Server = require('../src/server');
+const config = require('../src/config');
 
 const FIXTURES_PATH = path.join(__dirname, 'fixtures', 'server');
 const KUMA_PORT = 11111;

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -2,7 +2,7 @@
  * @prettier
  */
 
-const Templates = require('../src/templates.js');
+const Templates = require('../src/templates');
 
 describe('Templates class', () => {
     it('has the expected methods', () => {


### PR DESCRIPTION
This converts the project to use extensionless require, like what is being done in tests.

review?(@davidflanagan)