### PR TITLE
fix(macros): Use `<code class=templateLink>` for {{TemplateLink}}

### DIFF
--- a/macros/TemplateLink.ejs
+++ b/macros/TemplateLink.ejs
@@ -1,18 +1,20 @@
 <%
-//
-// Inserts a link to the specified template's page.
-// Useful when describing a template and wanting to link to its
-// code for reference.
-//
-// Note that GitHub URLs are case-sensitve.
-// e.g. {{TemplateLink("Page")}} leads to 404, but {{TemplateLink("page")}} works
-// as the file is named "page.ejs".
-//
-// Parameters:
-//
-// $0   Name of the template to link to.
-//
+/**
+ *
+ * Inserts a link to the specified template's page.
+ * Useful when describing a template and wanting to link to its
+ * code for reference.
+ *
+ * Note that GitHub URLs are case-sensitve.
+ * e.g. {{TemplateLink("Page")}} leads to 404, but {{TemplateLink("page")}} works
+ * as the file is named "page.ejs".
+ *
+ * Parameters:
+ *
+ * $0 - Name of the template to link to.
+ */
 
-var dest = "https://github.com/mdn/kumascript/tree/master/macros/" + $0 + ".ejs";
+let dest = "https://github.com/mdn/kumascript/tree/master/macros/" + $0 + ".ejs";
+let text = $0;
 %>
-<span class="templateLink"><code><a href="<%-dest%>"><%=$0%></a></code></span>
+<code class="templateLink"><a href="<%-dest%>"><%=text%></a></code>

--- a/tests/macros/TemplateLink.test.js
+++ b/tests/macros/TemplateLink.test.js
@@ -1,0 +1,16 @@
+/**
+ * @prettier
+ */
+const { assert, describeMacro, itMacro } = require('./utils');
+
+describeMacro('TemplateLink', () => {
+    itMacro('TemplateLink generates correct DOM', macro => {
+        return assert.eventually.equal(
+            macro.call('TemplateLink'),
+            '<code class="templateLink">' +
+                '<a href="https://github.com/mdn/kumascript/tree/master/macros/TemplateLink.ejs">' +
+                'TemplateLink' +
+                '</a></code>'
+        );
+    });
+});


### PR DESCRIPTION
Depends on: https://github.com/mozilla/kuma/pull/5320

review?(@chrisdavidmills, @Elchi3, @escattone, @schalkneethling, @wbamberg)