### PR TITLE
Bug 1556549: Add missing `.icon‑only‑inline` classes

### DIFF
--- a/macros/DeprecatedBadge.ejs
+++ b/macros/DeprecatedBadge.ejs
@@ -18,7 +18,7 @@ var str = mdn.localString({
 });
 
 if ($0) {
-    %><span title="<%=titleAttrValue%>"><i class="icon-thumbs-down-alt"> </i></span><%
+    %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-thumbs-down-alt"> </i></span><%
 } else {
     %><%-await template("SimpleBadge", [str, "deprecatedBadge", titleAttrValue])%><%
 }

--- a/macros/ExperimentalBadge.ejs
+++ b/macros/ExperimentalBadge.ejs
@@ -44,7 +44,7 @@ var titleAttrValue = mdn.localString({
 var str = "";
 
 if ($0) {
-    %><span title="<%=titleAttrValue%>"><i class="icon-beaker"> </i></span><%
+    %><span title="<%=titleAttrValue%>" class="icon-only-inline"><i class="icon-beaker"> </i></span><%
 } else {
 str = mdn.localString({
     "ca": "Experimental",

--- a/tests/macros/Deprecated.test.js
+++ b/tests/macros/Deprecated.test.js
@@ -3,7 +3,8 @@
  */
 const { assert, itMacro, describeMacro } = require('./utils');
 
-describeMacro('deprecated_inline', function() {
+// TODO: Add tests for other {{Deprecated_*}} macros
+describeMacro('Deprecated_Inline', function() {
     itMacro('No arguments (en-US)', function(macro) {
         return assert.eventually.equal(
             macro.call(),

--- a/tests/macros/Deprecated_Inline.test.js
+++ b/tests/macros/Deprecated_Inline.test.js
@@ -7,7 +7,7 @@ describeMacro('deprecated_inline', function() {
     itMacro('No arguments (en-US)', function(macro) {
         return assert.eventually.equal(
             macro.call(),
-            `<span title="This deprecated API should no longer be used, but will probably still work."><i class="icon-thumbs-down-alt"> </i></span>`
+            `<span title="This deprecated API should no longer be used, but will probably still work." class="icon-only-inline"><i class="icon-thumbs-down-alt"> </i></span>`
         );
     });
     itMacro('"semver" string only (en-US)', function(macro) {


### PR DESCRIPTION
Part of [bug 1556549].

This was missed in #981 by @schalkneethling.

I’ve also renamed the `deprecated_inline.test.js` file, so that `git blame` information won’t be destroyed by merging #984.

---

[bug 1556549]: https://bugzilla.mozilla.org/show_bug.cgi?id=1556549

review?(@escattone, @wbamberg)
review?(@davidflanagan): Since you don’t seem to be merging #983 or #984, which would achieve this.