### PR TITLE
Update IndexedDB 2 macro

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -875,17 +875,12 @@
     "status": "PR"
   },
   "IndexedDB": {
-    "name": "Indexed Database API",
+    "name": "Indexed Database API 2.0",
     "url": "https://www.w3.org/TR/IndexedDB/",
     "status": "REC"
   },
-  "IndexedDB Draft": {
-    "name": "Indexed Database API Draft",
-    "url": "https://w3c.github.io/IndexedDB/",
-    "status": "Draft"
-  },
   "IndexedDB 2": {
-    "name": "Indexed Database API 2.0",
+    "name": "Indexed Database API Draft",
     "url": "https://w3c.github.io/IndexedDB/",
     "status": "REC"
   },

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -879,10 +879,10 @@
     "url": "https://www.w3.org/TR/IndexedDB/",
     "status": "REC"
   },
-  "IndexedDB 2": {
-    "name": "Indexed Database API 2.0",
+  "IndexedDB Draft": {
+    "name": "Indexed Database API Draft",
     "url": "https://w3c.github.io/IndexedDB/",
-    "status": "REC"
+    "status": "Draft"
   },
   "InputDeviceCapabilities": {
     "name": "InputDeviceCapabilities",

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -884,6 +884,11 @@
     "url": "https://w3c.github.io/IndexedDB/",
     "status": "Draft"
   },
+  "IndexedDB 2": {
+    "name": "Indexed Database API 2.0",
+    "url": "https://w3c.github.io/IndexedDB/",
+    "status": "REC"
+  },
   "InputDeviceCapabilities": {
     "name": "InputDeviceCapabilities",
     "url": "https://wicg.github.io/InputDeviceCapabilities/",


### PR DESCRIPTION
`"Indexed Database API"` points to IndexedDB 2.0 spec and
`"Indexed Database API 2.0"` point to IndexedDB 3.0 spec

I changed `"Indexed Database API 2.0"` to `"Indexed Database API Draft"` since it points to the editor's draft.

https://www.youtube.com/watch?v=y1TEPQz02iU&feature=youtu.be&t=541