### PR TITLE
Add Spanish translations to Compat Table

### DIFF
--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -27,6 +27,7 @@
     "bc_icon_name_webview_android": {
          "en-US": "Android webview",
          "de"   : "Android Webview",
+         "es"   : "Android webview",
          "ja"   : "Android webview",
          "nl"   : "Android webview",
          "fr"   : "Webview Android"
@@ -34,6 +35,7 @@
     "bc_icon_name_chrome": {
          "en-US": "Chrome",
          "de"   : "Chrome",
+         "es"   : "Chrome",
          "ja"   : "Chrome",
          "nl"   : "Chrome",
          "fr"   : "Chrome"
@@ -41,6 +43,7 @@
     "bc_icon_name_chrome_android": {
          "en-US": "Chrome for Android",
          "de": "Chrome für Android",
+         "es": "Chrome para Android",
          "ja": "Android 版 Chrome",
          "nl": "Chrome voor Android",
          "ru": "Chrome для Android",
@@ -49,6 +52,7 @@
     "bc_icon_name_edge": {
          "en-US": "Edge",
          "de"   : "Edge",
+         "es"   : "Edge",
          "ja"   : "Edge",
          "nl"   : "Edge",
          "fr"   : "Edge"
@@ -56,6 +60,7 @@
     "bc_icon_name_edge_mobile": {
          "en-US": "Edge Mobile",
          "de"   : "Edge Mobile",
+         "es"   : "Edge Mobile",
          "ja"   : "Edge Mobile",
          "nl"   : "Edge Mobile",
          "fr"   : "Edge Mobile"
@@ -63,6 +68,7 @@
     "bc_icon_name_firefox": {
          "en-US": "Firefox",
          "de"   : "Firefox",
+         "es"   : "Firefox",
          "ja"   : "Firefox",
          "nl"   : "Firefox",
          "fr"   : "Firefox"
@@ -70,6 +76,7 @@
     "bc_icon_name_firefox_android": {
          "en-US": "Firefox for Android",
          "de": "Firefox für Android",
+         "es": "Firefox para Android",
          "ja": "Android 版 Firefox",
          "nl": "Firefox voor Android",
          "ru": "Firefox для Android",
@@ -78,6 +85,7 @@
     "bc_icon_name_ie": {
          "en-US": "Internet Explorer",
          "de"   : "Internet Explorer",
+         "es"   : "Internet Explorer",
          "ja"   : "Internet Explorer",
          "nl"   : "Internet Explorer",
          "fr"   : "Internet Explorer"
@@ -85,6 +93,7 @@
     "bc_icon_name_nodejs": {
          "en-US": "Node.js",
          "de"   : "Node.js",
+         "es"   : "Node.js",
          "ja"   : "Node.js",
          "nl"   : "Node.js",
          "fr"   : "Node.js"
@@ -92,6 +101,7 @@
     "bc_icon_name_opera": {
          "en-US": "Opera",
          "de"   : "Opera",
+         "es"   : "Opera",
          "ja"   : "Opera",
          "nl"   : "Opera",
          "fr"   : "Opera"
@@ -99,6 +109,7 @@
     "bc_icon_name_opera_android": {
          "en-US": "Opera for Android",
          "de": "Opera für Android",
+         "es": "Opera para Android",
          "ja": "Android 版 Opera",
          "nl": "Opera voor Android",
          "ru": "Opera для Android",
@@ -107,6 +118,7 @@
     "bc_icon_name_safari": {
          "en-US": "Safari",
          "de"   : "Safari",
+         "es"   : "Safari",
          "ja"   : "Safari",
          "nl"   : "Safari",
          "fr"   : "Safari"
@@ -114,6 +126,7 @@
     "bc_icon_name_safari_ios": {
          "en-US": "Safari on iOS",
          "de"   : "Safari auf iOS",
+         "es"   : "Safari en iOS",
          "ja"   : "iOSのSafari",
          "nl"   : "Safari op iOS",
          "fr"   : "Safari sur iOS"
@@ -121,6 +134,7 @@
     "bc_icon_name_samsunginternet_android": {
          "en-US": "Samsung Internet",
          "de"   : "Samsung Internet",
+         "es"   : "Samsung Internet",
          "ja"   : "Samsung Internet",
          "nl"   : "Samsung Internet",
          "fr"   : "Samsung Internet"
@@ -146,6 +160,7 @@
     "supportsShort_yes_title": {
         "en-US": "Please update this with the earliest version of support.",
         "de"   : "Bitte mit der frühsten Version updaten in der Unterstützung vorhanden ist.",
+        "es"   : "Por favor actualizalo con la version mas temprana de soporte.",
         "fr"   : "Veuillez mettre à jour avec la version minimale du support",
         "ja"   : "対応する最も早いバージョン番号に更新してください。",
         "ru"   : "Пожалуйста, замените этот шаблон на указание самой ранней поддерживаемой версии.",
@@ -200,6 +215,7 @@
     "supportsShort_unknown": {
         "en-US": "?",
         "de"   : "?",
+        "es"   : "?",
         "fr"   : "?",
         "ja"   : "?",
         "ru"   : "?",
@@ -208,6 +224,7 @@
     "supportsShort_unknown_title": {
         "en-US": "Compatibility unknown; please update this.",
         "de"   : "Kompatibilität unbekannt. Bitte aktualisiere das.",
+        "es"   : "Compatibilidad desconocida; porfavor actualiza esto."
         "fr"   : "Compatibilité inconnue, merci de contribuer à ces données.",
         "ja"   : "実装状況不明。更新してください。",
         "ru"   : "Совместимость неизвестна; пожалуйста, обновите информацию.",
@@ -216,6 +233,7 @@
     "supportsLong_unknown": {
         "en-US": "Compatibility unknown",
         "de"   : "Kompatibilität unbekannt",
+        "es"   : "Compatibilidad desconocida",
         "fr"   : "Compatibilité inconnue",
         "ja"   : "実装状況不明",
         "ru"   : "Совместимость неизвестна",
@@ -224,6 +242,7 @@
     "feature": {
         "en-US": "Feature",
         "de"   : "Funktion",
+        "es"   : "Caracteristica",
         "fr"   : "Fonctionnalité",
         "ja"   : "機能",
         "ru"   : "Возможность",
@@ -268,6 +287,7 @@
     "bc_icon_name_deprecated": {
         "en-US": "Deprecated",
         "de"   : "Veraltet",
+        "es"   : "Deprecado",
         "fr"   : "Obsolète",
         "ja"   : "非推奨",
         "nl"   : "Verouderd",
@@ -276,6 +296,7 @@
     "bc_icon_title_deprecated": {
         "en-US": "Deprecated. Not for use in new websites.",
         "de"   : "Veraltet. Nicht für den Einsatz in neuen Webseiten gedacht.",
+        "es"   : "Deprecado. No debe ser usado en nuevos sitios web.",
         "ja"   : "非推奨。新しいウェブサイトでは使用しないでください。",
         "nl"   : "Verouderd. Niet voor gebruik in nieuwe websites",
         "ru"   : "Устаревшая. Не следует использовать в новых веб-сайтах.",
@@ -419,6 +440,7 @@
     "legend_deprecated": {
         "en-US": "Deprecated. Not for use in new websites.",
         "de"   : "Veraltet. Nicht für den Einsatz in neuen Webseiten gedacht.",
+        "es"   : "Deprecado. No debe ser usado en nuevos sitios web.",
         "ja"   : "非推奨。新しいウェブサイトでは使用しないでください。",
         "nl"   : "Verouderd. Niet voor gebruik in nieuwe websites",
         "ru"   : "Устаревшая. Не следует использовать в новых веб-сайтах",

--- a/macros/L10n-CompatTable.json
+++ b/macros/L10n-CompatTable.json
@@ -224,7 +224,7 @@
     "supportsShort_unknown_title": {
         "en-US": "Compatibility unknown; please update this.",
         "de"   : "Kompatibilität unbekannt. Bitte aktualisiere das.",
-        "es"   : "Compatibilidad desconocida; porfavor actualiza esto."
+        "es"   : "Compatibilidad desconocida; porfavor actualiza esto.",
         "fr"   : "Compatibilité inconnue, merci de contribuer à ces données.",
         "ja"   : "実装状況不明。更新してください。",
         "ru"   : "Совместимость неизвестна; пожалуйста, обновите информацию.",


### PR DESCRIPTION
Adds additional Spanish localization to `macros/L10n-CompatTable.json`.  Translations by WhoovesPON3 from @GooborgStudios.