### PR TITLE
Add some more tests for APIRef

### DIFF
--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -51,7 +51,10 @@ if (group && webAPIGroups[0][group]) {
   var rel_met = webAPIGroups[0][group].methods || [];
   var rel_prop = webAPIGroups[0][group].properties || [];
   related = rel_if.concat(rel_met, rel_prop);
-  related.splice(related.indexOf(mainIF), 1);
+  var mainIfIndex = related.indexOf(mainIF);
+  if (mainIfIndex !== -1) {
+    related.splice(mainIfIndex, 1);
+  }
   related.sort();
   events = webAPIGroups[0][group].events || [];
 }

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -18,7 +18,8 @@ const path = require('path');
 const subpagesFixturePath = path.resolve(__dirname, 'fixtures/apiref/subpages.json');
 const subpagesFixture = JSON.parse(fs.readFileSync(subpagesFixturePath, 'utf8'));
 const commonl10nFixturePath = path.resolve(__dirname, 'fixtures/apiref/commonl10n.json');
-const commonl10nFixture = JSON.parse(fs.readFileSync(commonl10nFixturePath, 'utf8'));
+const commonl10nFixture = fs.readFileSync(commonl10nFixturePath, 'utf8');
+const commonL10nJSON = JSON.parse(commonl10nFixture);
 const groupDataFixturePath = path.resolve(__dirname, 'fixtures/apiref/groupdata.json');
 const groupDataFixture = fs.readFileSync(groupDataFixturePath, 'utf8');
 const interfaceDataNoEntriesFixturePath = path.resolve(__dirname, 'fixtures/apiref/interfacedata_no_entries.json');
@@ -285,13 +286,13 @@ function checkResult(html, config) {
     expect(details.length).toEqual(Object.keys(config.expected.details).length);
 
     // Test the properties sublist
-    const expectedPropertySummary = commonl10nFixture['Properties'][config.locale];
+    const expectedPropertySummary = commonL10nJSON['Properties'][config.locale];
     const expectedPropertyItems = config.expected.details.properties[config.locale];
     const properties = details[0];
     checkItemList(expectedPropertySummary, expectedPropertyItems, properties, config, checkInterfaceItem);
 
     // Test the methods sublist
-    const expectedMethodSummary = commonl10nFixture['Methods'][config.locale];
+    const expectedMethodSummary = commonL10nJSON['Methods'][config.locale];
     const expectedMethodItems = config.expected.details.methods[config.locale];
     const methods = details[1];
     checkItemList(expectedMethodSummary, expectedMethodItems, methods, config, checkInterfaceItem);
@@ -299,7 +300,7 @@ function checkResult(html, config) {
     const hasInherited = config.expected.details.inherited;
     if (hasInherited) {
         // Test the inherited sublist
-        const expectedInheritedSummary = commonl10nFixture['Inheritance'][config.locale];
+        const expectedInheritedSummary = commonL10nJSON['Inheritance'][config.locale];
         const expectedInheritedItems = config.expected.details.inherited;
         const inherited = details[2];
         checkItemList(expectedInheritedSummary, expectedInheritedItems, inherited, config, checkRelatedItem);
@@ -308,7 +309,7 @@ function checkResult(html, config) {
     const hasImplemented = config.expected.details.implemented;
     if (hasImplemented) {
         // Test the implemented_by sublist
-        const expectedImplementedSummary = commonl10nFixture['Implemented_by'][config.locale];
+        const expectedImplementedSummary = commonL10nJSON['Implemented_by'][config.locale];
         const expectedImplementedItems = config.expected.details.implemented;
         const implemented = details[3];
         checkItemList(expectedImplementedSummary, expectedImplementedItems, implemented, config, checkRelatedItem);
@@ -317,7 +318,7 @@ function checkResult(html, config) {
     const hasEvents = config.expected.details.events;
     if (hasEvents) {
         // Test the events sublist
-        const expectedEventSummary = commonl10nFixture['Events'][config.locale];
+        const expectedEventSummary = commonL10nJSON['Events'][config.locale];
         const expectedEventItems = config.expected.details.events;
         const events = details[2];
         checkItemList(expectedEventSummary, expectedEventItems, events, config, checkRelatedItem);
@@ -326,7 +327,7 @@ function checkResult(html, config) {
     const hasRelated = config.expected.details.related;
     if (hasRelated) {
         // Test the related sublist
-        const expectedRelatedSummary = commonl10nFixture['Related_pages'][config.locale].replace('$1', config.argument);
+        const expectedRelatedSummary = commonL10nJSON['Related_pages'][config.locale].replace('$1', config.argument);
         const expectedRelatedItems = config.expected.details.related;
         const related = details[3];
         checkItemList(expectedRelatedSummary, expectedRelatedItems, related, config, checkRelatedItem);
@@ -343,6 +344,9 @@ function testMacro(config) {
             // Mock calls to L10n-Common, GroupData, and InterfaceData
             const originalTemplate = macro.ctx.template;
             macro.ctx.template = jest.fn( async (name, ...args) => {
+                if (name === "L10n:Common") {
+                    return commonl10nFixture;
+                }
                 if (name === "GroupData") {
                     return groupDataFixture;
                 }

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -10,253 +10,410 @@ const {
     lintHTML
 } = require('./utils');
 
-const GAMEPAD_SUBPAGES_EXPAND = [
-    {
-        json_modified: '2019-01-16T23:02:17.747616',
-        subpages: [],
-        tags: [
-            'Property',
-            'Gamepad API',
-            'NeedsBetterSpecLink',
-            'Reference',
-            'NeedsMarkupWork',
-            'API',
-            'Référence(2)',
-            'Games'
-        ],
-        locale: 'en-US',
-        translations: [
-            {
-                uuid: '533ea9eb-06ae-4518-82bf-4f409ebae3d0',
-                title: 'Gamepad.axes',
-                url: '/ja/docs/Web/API/Gamepad/axes',
-                tags: [
-                    'API',
-                    'Gamepad API',
-                    'NeedsBetterSpecLink',
-                    'Reference',
-                    'NeedsMarkupWork',
-                    'Property',
-                    'Référence(2)',
-                    'Games'
-                ],
-                summary:
-                    '<a href="/ja/docs/Web/API/Gamepad" title="Gamepad API の Gamepad インターフェースはそれぞれのゲームパットやその他のコントローラーを定義し、ボタンのプッシュや軸位置やIDといった情報にアクセスできるようにします。"><code>Gamepad</code></a> インターフェースの <code><strong>Gamepad.axes</strong></code> プロパティは<span class="tlid-translation translation"><span title="">デバイス上に存在する軸を持つコントロールを表す配列を返します。</span></span> (例 : アナログスティック)。-',
-                localization_tags: [],
-                locale: 'ja',
-                last_edit: '2018-12-18T04:32:23.760574',
-                review_tags: []
-            }
-        ],
-        summary:
-            'The <code><strong>Gamepad.axes</strong></code> property of the <a href="/en-US/docs/Web/API/Gamepad" title="The Gamepad interface of the Gamepad API defines an individual gamepad or other controller, allowing access to information such as button presses, axis positions, and id."><code>Gamepad</code></a> interface returns an array representing the controls with axes present on the device (e.g. analog thumb sticks).-',
-        id: 87761,
-        review_tags: [],
-        slug: 'Web/API/Gamepad/axes',
-        uuid: 'c867795d-c9df-4919-b3ff-8f3809e0485a',
-        title: 'Gamepad.axes',
-        url: '/en-US/docs/Web/API/Gamepad/axes',
-        modified: '2019-01-16T13:03:20.906343',
-        label: 'Gamepad.axes',
-        localization_tags: [],
-        last_edit: '2018-07-20T12:20:59.066605',
-        sections: [
-            {
-                id: 'Quick_Links',
-                title: null
-            },
-            {
-                id: 'Syntax',
-                title: 'Syntax'
-            },
-            {
-                id: 'Example',
-                title: 'Example'
-            },
-            {
-                id: 'Value',
-                title: 'Value'
-            },
-            {
-                id: 'Specifications',
-                title: 'Specifications'
-            },
-            {
-                id: 'Browser_compatibility',
-                title: 'Browser compatibility'
-            },
-            {
-                id: 'sect1',
-                title: null
-            },
-            {
-                id: 'sect2',
-                title: null
-            },
-            {
-                id: 'sect3',
-                title: null
-            },
-            {
-                id: 'sect4',
-                title: null
-            },
-            {
-                id: 'sect5',
-                title: null
-            },
-            {
-                id: 'sect6',
-                title: null
-            },
-            {
-                id: 'Legend',
-                title: 'Legend'
-            },
-            {
-                id: 'See_also',
-                title: 'See also'
-            }
-        ]
-    },
+/**
+* Load all the fixtures.
+*/
+const fs = require('fs');
+const path = require('path');
+const subpagesFixturePath = path.resolve(__dirname, 'fixtures/apiref/subpages.json');
+const subpagesFixture = JSON.parse(fs.readFileSync(subpagesFixturePath, 'utf8'));
+const commonl10nFixturePath = path.resolve(__dirname, 'fixtures/apiref/commonl10n.json');
+const commonl10nFixture = JSON.parse(fs.readFileSync(commonl10nFixturePath, 'utf8'));
+const groupDataFixturePath = path.resolve(__dirname, 'fixtures/apiref/groupdata.json');
+const groupDataFixture = fs.readFileSync(groupDataFixturePath, 'utf8');
+const interfaceDataNoEntriesFixturePath = path.resolve(__dirname, 'fixtures/apiref/interfacedata_no_entries.json');
+const interfaceDataNoEntriesFixture = fs.readFileSync(interfaceDataNoEntriesFixturePath, 'utf8');
+const interfaceDataFixturePath = path.resolve(__dirname, 'fixtures/apiref/interfacedata.json');
+const interfaceDataFixture = fs.readFileSync(interfaceDataFixturePath, 'utf8');
 
+/**
+* All the const objects that follow define bits of the data we expect.
+**/
+const expectedMainIfLink = {
+    withGroupData: {
+        text: 'TestInterface API',
+        target: '/docs/Web/API/TestInterface_API'
+    },
+    withoutGroupData: {
+        text: 'TestInterface',
+        target: '/docs/Web/API/TestInterface'
+    }
+}
+
+const expectedProperties = {
+    'en-US': [
+        {
+            badges: [],
+            text: 'MyTestProperty1',
+            target: '/en-US/docs/Web/API/TestInterface/TestProperty1',
+            title: 'The MyTestProperty1 property of the TestInterface interface has no badges.'
+        }
+    ],
+    'fr': [
+        {
+            badges: [],
+            text: 'MyTestProperty1 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestProperty1',
+            title: 'The MyTestProperty1 property of the TestInterface interface has no badges.'
+        }
+    ],
+    'ja': [
+        {
+          badges: [],
+          text: 'MyTestProperty1',
+          target: '/ja/docs/Web/API/TestInterface/TestProperty1',
+          title: 'The MyTestProperty1 property of the TestInterface interface has no badges (ja translation).'
+        }
+    ]
+}
+
+const expectedMethods = {
+    'en-US': [
+        {
+            badges: ['icon-beaker'],
+            text: ' MyTestMethod1',
+            target: '/en-US/docs/Web/API/TestInterface/TestMethod1',
+            title: 'The MyTestMethod1 property of the TestInterface interface is experimental.'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  MyTestMethod2',
+            target: '/en-US/docs/Web/API/TestInterface/TestMethod2',
+            title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.'
+        },
+        {
+            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
+            text: '    MyTestMethod3',
+            target: '/en-US/docs/Web/API/TestInterface/TestMethod3',
+            title: 'The MyTestMethod3 property of the TestInterface interface has all the badges.'
+        }
+    ],
+    'fr': [
+        {
+            badges: ['icon-beaker'],
+            text: ' MyTestMethod1 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestMethod1',
+            title: 'The MyTestMethod1 property of the TestInterface interface is experimental.'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  MyTestMethod2 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestMethod2',
+            title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.'
+        },
+        {
+            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
+            text: '    MyTestMethod3 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestMethod3',
+            title: 'The MyTestMethod3 property of the TestInterface interface has all the badges.'
+        }
+    ],
+    'ja': [
+        {
+            badges: ['icon-beaker'],
+            text: ' MyTestMethod1',
+            target: '/ja/docs/Web/API/TestInterface/TestMethod1',
+            title: 'The MyTestMethod1 property of the TestInterface interface is experimental (ja translation).'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  MyTestMethod2',
+            target: '/ja/docs/Web/API/TestInterface/TestMethod2',
+            title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).'
+        },
+        {
+            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
+            text: '    MyTestMethod3',
+            target: '/ja/docs/Web/API/TestInterface/TestMethod3',
+            title: 'The MyTestMethod3 property of the TestInterface interface has all the badges (ja translation).'
+        }
+    ]
+}
+
+const expectedEvents = [
     {
-        json_modified: '2019-01-16T23:01:57.128398',
-        subpages: [],
-        tags: [
-            'Property',
-            'Gamepad API',
-            'NeedsBetterSpecLink',
-            'Reference',
-            'NeedsMarkupWork',
-            'API',
-            'Référence(2)',
-            'Games'
-        ],
-        locale: 'en-US',
-        translations: [
-            {
-                uuid: '741f5a5e-3026-4d86-ab47-b6fc653c2a74',
-                title: 'Gamepad.buttons',
-                url: '/ja/docs/Web/API/Gamepad/buttons',
-                tags: [
-                    'API',
-                    'Gamepad API',
-                    'NeedsBetterSpecLink',
-                    'Reference',
-                    'NeedsMarkupWork',
-                    'Property',
-                    'Référence(2)',
-                    'Games'
-                ],
-                summary:
-                    '<a href="/ja/docs/Web/API/Gamepad" title="Gamepad API の Gamepad インターフェースはそれぞれのゲームパットやその他のコントローラーを定義し、ボタンのプッシュや軸位置やIDといった情報にアクセスできるようにします。"><code>Gamepad</code></a> インターフェースの <code><strong>Gamepad.buttons</strong></code> プロパティは<span class="tlid-translation translation"><span title="">デバイス上に存在するボタンを表すオブジェクトの配列を返します。</span></span>',
-                localization_tags: [],
-                locale: 'ja',
-                last_edit: '2018-12-18T15:36:54.445468',
-                review_tags: []
-            }
-        ],
-        summary:
-            'The <code><strong>Gamepad.buttons</strong></code> property of the <a href="/en-US/docs/Web/API/Gamepad" title="The Gamepad interface of the Gamepad API defines an individual gamepad or other controller, allowing access to information such as button presses, axis positions, and id."><code>Gamepad</code></a> interface returns an array of <a href="/en-US/docs/Web/API/GamepadButton" title="The GamepadButton interface defines an individual button of a gamepad or other controller, allowing access to the current state of different types of buttons available on the control device."><code>gamepadButton</code></a> objects representing the buttons present on the device.',
-        id: 87763,
-        review_tags: [],
-        slug: 'Web/API/Gamepad/buttons',
-        uuid: '6b6f5f4d-81cb-4b65-81dc-88dc94bbd494',
-        title: 'Gamepad.buttons',
-        url: '/en-US/docs/Web/API/Gamepad/buttons',
-        modified: '2019-01-16T13:03:39.199620',
-        label: 'Gamepad.buttons',
-        localization_tags: [],
-        last_edit: '2018-07-20T12:21:09.854338',
-        sections: [
-            {
-                id: 'Quick_Links',
-                title: null
-            },
-            {
-                id: 'Syntax',
-                title: 'Syntax'
-            },
-            {
-                id: 'Example',
-                title: 'Example'
-            },
-            {
-                id: 'Value',
-                title: 'Value'
-            },
-            {
-                id: 'Specifications',
-                title: 'Specifications'
-            },
-            {
-                id: 'Browser_compatibility',
-                title: 'Browser compatibility'
-            },
-            {
-                id: 'sect1',
-                title: null
-            },
-            {
-                id: 'sect2',
-                title: null
-            },
-            {
-                id: 'sect3',
-                title: null
-            },
-            {
-                id: 'sect4',
-                title: null
-            },
-            {
-                id: 'sect5',
-                title: null
-            },
-            {
-                id: 'sect6',
-                title: null
-            },
-            {
-                id: 'Legend',
-                title: 'Legend'
-            },
-            {
-                id: 'See_also',
-                title: 'See also'
-            }
-        ]
+        text: 'crunch',
+        target: '/docs/Web/Events/crunch'
+    },
+    {
+        text: 'stomp',
+        target: '/docs/Web/Events/stomp'
     }
 ];
 
-function checkResult(html, locale) {
+const expectedRelated = [
+    {
+        text: 'AnInterface',
+        target: '/docs/Web/API/AnInterface'
+    },
+    {
+        text: 'AnInterface.doOneThing()',
+        target: '/docs/Web/API/AnInterface/doOneThing'
+    },
+    {
+        text: 'AnotherInterface.doAnother()',
+        target: '/docs/Web/API/AnotherInterface/doAnother'
+    }
+];
+
+const expectedInherited = [
+    {
+        text: 'TestInterfaceParent',
+        target: '/docs/Web/API/TestInterfaceParent'
+    },
+    {
+        text: 'TestInterfaceGrandparent',
+        target: '/docs/Web/API/TestInterfaceGrandparent'
+    }
+];
+
+const expectedImplemented = [
+    {
+        text: 'AlsoImplementsTestInterface',
+        target: '/docs/Web/API/AlsoImplementsTestInterface'
+    },
+    {
+        text: 'ImplementsTestInterface',
+        target: '/docs/Web/API/ImplementsTestInterface'
+    }
+];
+
+const expectedBasic = {
+    mainIfLink: expectedMainIfLink.withoutGroupData,
+    details: {
+        properties: expectedProperties,
+        methods: expectedMethods
+    }
+}
+
+const expectedWithGroupData = {
+    mainIfLink: expectedMainIfLink.withGroupData,
+    details: {
+        properties: expectedProperties,
+        methods: expectedMethods,
+        events: expectedEvents,
+        related: expectedRelated
+    }
+}
+
+const expectedWithInterfaceData = {
+    mainIfLink: expectedMainIfLink.withoutGroupData,
+    details: {
+        properties: expectedProperties,
+        methods: expectedMethods,
+        inherited: expectedInherited,
+        implemented: expectedImplemented
+    }
+}
+
+/**
+* This function is used to compare two sidebar items that
+* represent interface items, like methods and properties.
+*/
+function checkInterfaceItem(actual, expected, config) {
+    // Are we on the page that this link points to?
+    const linkSlug = expected.target.split('/').slice(3).join('/');
+    if (config.currentSlug != linkSlug) {
+        // If we are not on this page, the item contains a link
+        // and the text contents includes a CTA if one should be present
+        // (CTA is specified in the test data in the cases where it is expected)
+        expect(actual.textContent).toEqual(expected.text);
+        const methodLink = actual.querySelector('a');
+        expect(methodLink.href).toEqual(expected.target);
+        expect(methodLink.getAttribute('title')).toEqual(expected.title);
+    } else {
+        // If we are on the current page, the item is just an <i>
+        // and the text contents omits the CTA
+        const methodLink = actual.querySelector('a');
+        expect(methodLink).toBeNull();
+        const methodName = actual.querySelector('i');
+        expect(actual.textContent).toContain(methodName.textContent);
+    }
+
+    // Test that the badges are what we expect
+    const badgeClasses = actual.querySelectorAll('i');
+    expect(badgeClasses.length).toEqual(expected.badges.length);
+    for (let badgeClass of badgeClasses) {
+        expect(expected.badges).toContain(badgeClass.getAttribute('class'));
+    }
+}
+
+/**
+* This function is used to compare two sidebar items that
+* represent related items, like related interfaces got from GroupData.
+*/
+function checkRelatedItem(actual, expected, config) {
+    const itemLink = actual.querySelector('a');
+    // For these items we just have to compare textContent and href
+    expect(itemLink.textContent).toEqual(expected.text);
+    expect(itemLink.href).toEqual(`/${config.locale}${expected.target}`);
+}
+
+function checkItemList(expectedSummary, expectedItems, actual, config, compareItemFunction) {
+  const actualSummary = actual.querySelector('summary');
+  expect(actualSummary.textContent).toEqual(expectedSummary);
+
+  const actualItems = actual.querySelectorAll('ol>li');
+  expect(actualItems.length).toEqual(expectedItems.length);
+  for (let i = 0; i < actualItems.length; i++) {
+      compareItemFunction(actualItems[i], expectedItems[i], config);
+  }
+}
+
+/**
+* This is the entry point for checking the resultof a test.
+* config.expected contains the expected results, and we use other bits
+* of config, most notably locale
+*/
+function checkResult(html, config) {
     // Lint the HTML
     expect(lintHTML(html)).toBeFalsy();
     const dom = JSDOM.fragment(html);
     // Check that all links reference the proper locale or use https
     const num_total_links = dom.querySelectorAll('a[href]').length;
-    const num_valid_links = dom.querySelectorAll(
-        `a[href^="/${locale}/"], a[href^="https://"]`
-    ).length;
+    const num_valid_links = dom.querySelectorAll(`a[href^="/${config.locale}/"], a[href^="https://"]`).length;
     expect(num_valid_links).toEqual(num_total_links);
+
+    // Test main interface link
+    const mainIfLink = dom.querySelector('ol>li>strong>a');
+    expect(mainIfLink.textContent).toEqual(config.expected.mainIfLink.text);
+    expect(mainIfLink.href).toEqual(`/${config.locale}${config.expected.mainIfLink.target}`);
+
+    // Test sublists
+    const details = dom.querySelectorAll('ol>li>details');
+    expect(details.length).toEqual(Object.keys(config.expected.details).length);
+
+    // Test the properties sublist
+    const expectedPropertySummary = commonl10nFixture['Properties'][config.locale];
+    const expectedPropertyItems = config.expected.details.properties[config.locale];
+    const properties = details[0];
+    checkItemList(expectedPropertySummary, expectedPropertyItems, properties, config, checkInterfaceItem);
+
+    // Test the methods sublist
+    const expectedMethodSummary = commonl10nFixture['Methods'][config.locale];
+    const expectedMethodItems = config.expected.details.methods[config.locale];
+    const methods = details[1];
+    checkItemList(expectedMethodSummary, expectedMethodItems, methods, config, checkInterfaceItem);
+
+    const hasInherited = config.expected.details.inherited;
+    if (hasInherited) {
+        // Test the inherited sublist
+        const expectedInheritedSummary = commonl10nFixture['Inheritance'][config.locale];
+        const expectedInheritedItems = config.expected.details.inherited;
+        const inherited = details[2];
+        checkItemList(expectedInheritedSummary, expectedInheritedItems, inherited, config, checkRelatedItem);
+    }
+
+    const hasImplemented = config.expected.details.implemented;
+    if (hasImplemented) {
+        // Test the implemented_by sublist
+        const expectedImplementedSummary = commonl10nFixture['Implemented_by'][config.locale];
+        const expectedImplementedItems = config.expected.details.implemented;
+        const implemented = details[3];
+        checkItemList(expectedImplementedSummary, expectedImplementedItems, implemented, config, checkRelatedItem);
+    }
+
+    const hasEvents = config.expected.details.events;
+    if (hasEvents) {
+        // Test the events sublist
+        const expectedEventSummary = commonl10nFixture['Events'][config.locale];
+        const expectedEventItems = config.expected.details.events;
+        const events = details[2];
+        checkItemList(expectedEventSummary, expectedEventItems, events, config, checkRelatedItem);
+    }
+
+    const hasRelated = config.expected.details.related;
+    if (hasRelated) {
+        // Test the related sublist
+        const expectedRelatedSummary = commonl10nFixture['Related_pages'][config.locale].replace('$1', config.argument);
+        const expectedRelatedItems = config.expected.details.related;
+        const related = details[3];
+        checkItemList(expectedRelatedSummary, expectedRelatedItems, related, config, checkRelatedItem);
+    }
+}
+
+function testMacro(config) {
+    for (const locale of ['en-US', 'fr', 'ja']) {
+        let testName = `with locale ${locale} and slug ${config.currentSlug}`;
+        if (config.argument) {
+            testName += ` and argument "${config.argument}"`;
+        }
+        itMacro(testName, function(macro) {
+            config.locale = locale;
+            macro.ctx.env.slug = config.currentSlug;
+            macro.ctx.env.locale = locale;
+            // Mock calls to L10n-Common, GroupData, and InterfaceData
+            originalTemplate = macro.ctx.template;
+            macro.ctx.template = jest.fn( async (name, ...args) => {
+                if (name === "GroupData") {
+                    return groupDataFixture;
+                }
+                if (name === "InterfaceData") {
+                    return config.interfaceData;
+                }
+                return await originalTemplate(name, ...args);
+            });
+            if (config.argument) {
+              return macro.call(config.argument).then(function(result) {
+                  checkResult(result, config);
+              });
+            } else {
+              return macro.call().then(function(result) {
+                  checkResult(result, config);
+              });
+            }
+
+        });
+    }
 }
 
 describeMacro('APIRef', function() {
     beforeEachMacro(function(macro) {
         // Mock calls to MDN.subpagesExpand
-        macro.ctx.page.subpagesExpand = jest.fn(() => {
-            return GAMEPAD_SUBPAGES_EXPAND;
+        macro.ctx.page.subpagesExpand = jest.fn((page) => {
+            expect(page).toEqual('/en-US/docs/Web/API/TestInterface');
+            return subpagesFixture;
         });
     });
 
-    for (const locale of ['en-US', 'fr', 'ja']) {
-        itMacro(`with locale ${locale}`, function(macro) {
-            macro.ctx.env.locale = locale;
-            macro.ctx.env.slug = 'Web/API/Gamepad';
-            return macro.call('Gamepad API').then(function(result) {
-                checkResult(result, locale);
-            });
-        });
-    }
+    // Test with current page as main interface page
+    testMacro({
+        currentSlug: 'Web/API/TestInterface',
+        argument: null,
+        interfaceData: interfaceDataNoEntriesFixture,
+        expected: expectedBasic
+    });
+
+    // Test with current page as a subpage
+    testMacro({
+        currentSlug: 'Web/API/TestInterface/TestMethod1',
+        argument: null,
+        interfaceData: interfaceDataNoEntriesFixture,
+        expected: expectedBasic
+    });
+
+    // Test with an argument to use in GroupData
+    testMacro({
+        currentSlug: 'Web/API/TestInterface',
+        argument: 'TestInterface',
+        interfaceData: interfaceDataNoEntriesFixture,
+        expected: expectedWithGroupData
+    });
+
+    // Test with a nonexistent but non-null argument to use in GroupData
+    testMacro({
+        currentSlug: 'Web/API/TestInterface',
+        argument: 'I don\'t exist',
+        interfaceData: interfaceDataNoEntriesFixture,
+        expected: expectedBasic
+    });
+
+    // Test with an InterfaceData that contains data for TestInterface
+    testMacro({
+        currentSlug: 'Web/API/TestInterface',
+        argument: null,
+        interfaceData: interfaceDataFixture,
+        expected: expectedWithInterfaceData
+    });
+
 });

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -334,10 +334,7 @@ function checkResult(html, config) {
 
 function testMacro(config) {
     for (const locale of ['en-US', 'fr', 'ja']) {
-        let testName = `with locale ${locale} and slug ${config.currentSlug}`;
-        if (config.argument) {
-            testName += ` and argument "${config.argument}"`;
-        }
+        let testName = `${config.name}; locale: ${locale}`;
         itMacro(testName, function(macro) {
             config.locale = locale;
             macro.ctx.env.slug = config.currentSlug;
@@ -378,6 +375,7 @@ describeMacro('APIRef', function() {
 
     // Test with current page as main interface page
     testMacro({
+        name: 'slug: \'Web/API/TestInterface\'; no InterfaceData entries; no argument',
         currentSlug: 'Web/API/TestInterface',
         argument: null,
         interfaceData: interfaceDataNoEntriesFixture,
@@ -386,6 +384,7 @@ describeMacro('APIRef', function() {
 
     // Test with current page as a subpage
     testMacro({
+        name: 'slug: \'Web/API/TestInterface/TestMethod1\'; no InterfaceData entries; no argument',
         currentSlug: 'Web/API/TestInterface/TestMethod1',
         argument: null,
         interfaceData: interfaceDataNoEntriesFixture,
@@ -394,6 +393,7 @@ describeMacro('APIRef', function() {
 
     // Test with an argument to use in GroupData
     testMacro({
+        name: 'slug: \'Web/API/TestInterface\'; no InterfaceData entries; argument: \'TestInterface\'',
         currentSlug: 'Web/API/TestInterface',
         argument: 'TestInterface',
         interfaceData: interfaceDataNoEntriesFixture,
@@ -402,6 +402,7 @@ describeMacro('APIRef', function() {
 
     // Test with a nonexistent but non-null argument to use in GroupData
     testMacro({
+        name: 'slug: \'Web/API/TestInterface\'; no InterfaceData entries; argument: \'I don\'t exist\'',
         currentSlug: 'Web/API/TestInterface',
         argument: 'I don\'t exist',
         interfaceData: interfaceDataNoEntriesFixture,
@@ -410,6 +411,7 @@ describeMacro('APIRef', function() {
 
     // Test with an InterfaceData that contains data for TestInterface
     testMacro({
+        name: 'slug: \'Web/API/TestInterface\'; InterfaceData entries expected; no argument',
         currentSlug: 'Web/API/TestInterface',
         argument: null,
         interfaceData: interfaceDataFixture,

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -250,13 +250,13 @@ function checkRelatedItem(actual, expected, config) {
 }
 
 function checkItemList(expectedSummary, expectedItems, actual, config, compareItemFunction) {
-  const actualSummary = actual.querySelector('summary');
-  expect(actualSummary.textContent).toEqual(expectedSummary);
+    const actualSummary = actual.querySelector('summary');
+    expect(actualSummary.textContent).toEqual(expectedSummary);
 
-  const actualItems = actual.querySelectorAll('ol>li');
-  expect(actualItems.length).toEqual(expectedItems.length);
-  for (let i = 0; i < actualItems.length; i++) {
-      compareItemFunction(actualItems[i], expectedItems[i], config);
+    const actualItems = actual.querySelectorAll('ol>li');
+    expect(actualItems.length).toEqual(expectedItems.length);
+    for (let i = 0; i < actualItems.length; i++) {
+        compareItemFunction(actualItems[i], expectedItems[i], config);
   }
 }
 
@@ -268,6 +268,7 @@ function checkItemList(expectedSummary, expectedItems, actual, config, compareIt
 function checkResult(html, config) {
     // Lint the HTML
     expect(lintHTML(html)).toBeFalsy();
+
     const dom = JSDOM.fragment(html);
     // Check that all links reference the proper locale or use https
     const num_total_links = dom.querySelectorAll('a[href]').length;

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -343,7 +343,7 @@ function testMacro(config) {
             macro.ctx.env.slug = config.currentSlug;
             macro.ctx.env.locale = locale;
             // Mock calls to L10n-Common, GroupData, and InterfaceData
-            originalTemplate = macro.ctx.template;
+            const originalTemplate = macro.ctx.template;
             macro.ctx.template = jest.fn( async (name, ...args) => {
                 if (name === "GroupData") {
                     return groupDataFixture;

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -261,7 +261,7 @@ function checkItemList(expectedSummary, expectedItems, actual, config, compareIt
 }
 
 /**
-* This is the entry point for checking the resultof a test.
+* This is the entry point for checking the result of a test.
 * config.expected contains the expected results, and we use other bits
 * of config, most notably locale
 */

--- a/tests/macros/fixtures/apiref/commonl10n.json
+++ b/tests/macros/fixtures/apiref/commonl10n.json
@@ -1,0 +1,69 @@
+{
+
+    "Methods": {
+        "en-US": "Methods",
+        "fr"   : "Méthodes",
+        "ja"   : "メソッド"
+    },
+
+    "Properties": {
+        "en-US": "Properties",
+        "fr"   : "Propriétés",
+        "ja"   : "プロパティ"
+    },
+
+    "Constructor": {
+        "en-US": "Constructor",
+        "fr"   : "Constructeur",
+        "ja"   : "コンストラクター"
+    },
+
+    "Inheritance": {
+        "en-US": "Inheritance:",
+        "fr"   : "Héritage\u00a0:",
+        "ja"   : "継承"
+    },
+
+    "Implemented_by": {
+        "en-US": "Implemented by:",
+        "fr"   : "Implémenté par\u00a0:",
+        "ja"   : "Implemented by:"
+    },
+
+    "Related_pages": {
+        "en-US": "Related pages for $1",
+        "fr"   : "Pages liées à $1",
+        "ja"   : "$1 に関連するページ"
+    },
+
+    "Related_pages_wo_group": {
+        "en-US": "Related pages:",
+        "fr"   : "Pages similaires\u00a0:",
+        "ja"   : "関連するページ"
+    },
+
+    "[Translate]": {
+        "en-US": "[Translate]",
+        "fr"   : "[Traduire]",
+        "ja"   : "[翻訳する]"
+    },
+
+    "TranslationCTA": {
+        "en-US": "Our volunteers haven't translated this article into your language yet. Join us and help get the job done!",
+        "fr": "Nos volontaires n'ont pas encore traduit cet article en français. Rejoignez-nous et aidez-nous à le faire&nbsp;!",
+        "ja" : "まだボランティアによって日本語に翻訳されていない記事です。MDNに参加して、翻訳してみませんか？"
+    },
+
+    "Events": {
+        "en-US": "Events",
+        "fr"   : "Événements",
+        "ja"   : "イベント"
+    },
+
+    "Interfaces": {
+        "en-US": "Interfaces",
+        "fr"   : "Interfaces",
+        "ja"   : "インターフェイス"
+    }
+
+}

--- a/tests/macros/fixtures/apiref/commonl10n.json
+++ b/tests/macros/fixtures/apiref/commonl10n.json
@@ -20,13 +20,13 @@
 
     "Inheritance": {
         "en-US": "Inheritance:",
-        "fr"   : "Héritage\u00a0:",
+        "fr"   : "Héritage :",
         "ja"   : "継承"
     },
 
     "Implemented_by": {
         "en-US": "Implemented by:",
-        "fr"   : "Implémenté par\u00a0:",
+        "fr"   : "Implémenté par :",
         "ja"   : "Implemented by:"
     },
 
@@ -38,7 +38,7 @@
 
     "Related_pages_wo_group": {
         "en-US": "Related pages:",
-        "fr"   : "Pages similaires\u00a0:",
+        "fr"   : "Pages similaires :",
         "ja"   : "関連するページ"
     },
 

--- a/tests/macros/fixtures/apiref/groupdata.json
+++ b/tests/macros/fixtures/apiref/groupdata.json
@@ -1,0 +1,11 @@
+[
+    {
+        "TestInterface": {
+            "overview":   [ "TestInterface API"],
+            "interfaces": [ "AnInterface" ],
+            "methods":    [ "AnInterface.doOneThing()", "AnotherInterface.doAnother()" ],
+            "properties": [],
+            "events":     ["crunch", "stomp"]
+        }
+    }
+]

--- a/tests/macros/fixtures/apiref/interfacedata.json
+++ b/tests/macros/fixtures/apiref/interfacedata.json
@@ -1,0 +1,30 @@
+[
+  {
+    "ImplementsTestInterface": {
+      "inh": "AndAnotherRandomThing",
+      "impl": ["TestInterface"]
+    },
+    "AlsoImplementsTestInterface": {
+      "inh": "YetAnotherRandomThing",
+      "impl": ["TestInterface", "SomethingUnrelated"]
+    },
+    "AnUnrelatedThing": {
+      "inh": "SomeOtherRandomThing",
+      "impl": []
+    },
+    "TestInterfaceGrandparent": {
+      "inh": "",
+      "impl": []
+    },
+    "TestInterfaceParent": {
+      "inh": "TestInterfaceGrandparent",
+      "impl": [
+        "SomeRandomThing"
+      ]
+    },
+    "TestInterface": {
+      "inh": "TestInterfaceParent",
+      "impl": []
+    }
+  }
+]

--- a/tests/macros/fixtures/apiref/interfacedata.json
+++ b/tests/macros/fixtures/apiref/interfacedata.json
@@ -1,30 +1,28 @@
 [
-  {
-    "ImplementsTestInterface": {
-      "inh": "AndAnotherRandomThing",
-      "impl": ["TestInterface"]
-    },
-    "AlsoImplementsTestInterface": {
-      "inh": "YetAnotherRandomThing",
-      "impl": ["TestInterface", "SomethingUnrelated"]
-    },
-    "AnUnrelatedThing": {
-      "inh": "SomeOtherRandomThing",
-      "impl": []
-    },
-    "TestInterfaceGrandparent": {
-      "inh": "",
-      "impl": []
-    },
-    "TestInterfaceParent": {
-      "inh": "TestInterfaceGrandparent",
-      "impl": [
-        "SomeRandomThing"
-      ]
-    },
-    "TestInterface": {
-      "inh": "TestInterfaceParent",
-      "impl": []
+    {
+        "ImplementsTestInterface": {
+            "inh": "AndAnotherRandomThing",
+            "impl": ["TestInterface"]
+        },
+        "AlsoImplementsTestInterface": {
+            "inh": "YetAnotherRandomThing",
+            "impl": ["TestInterface", "SomethingUnrelated"]
+        },
+        "AnUnrelatedThing": {
+            "inh": "SomeOtherRandomThing",
+            "impl": []
+        },
+        "TestInterfaceGrandparent": {
+            "inh": "",
+            "impl": []
+        },
+        "TestInterfaceParent": {
+            "inh": "TestInterfaceGrandparent",
+            "impl": ["SomeRandomThing"]
+        },
+        "TestInterface": {
+            "inh": "TestInterfaceParent",
+            "impl": []
+        }
     }
-  }
 ]

--- a/tests/macros/fixtures/apiref/interfacedata_no_entries.json
+++ b/tests/macros/fixtures/apiref/interfacedata_no_entries.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ImplementsAnInterface": {
+      "inh": "AndAnotherRandomThing",
+      "impl": ["NoThisOne"]
+    },
+    "AlsoImplementsTestInterface": {
+      "inh": "YetAnotherRandomThing",
+      "impl": ["SomethingUnrelated"]
+    },
+    "AnUnrelatedThing": {
+      "inh": "SomeOtherRandomThing",
+      "impl": []
+    },
+    "NotMyGrandParent": {
+      "inh": "",
+      "impl": []
+    },
+    "NotMyParent": {
+      "inh": "NotMyGrandParent",
+      "impl": [
+        "SomeRandomThing"
+      ]
+    }
+  }
+]

--- a/tests/macros/fixtures/apiref/interfacedata_no_entries.json
+++ b/tests/macros/fixtures/apiref/interfacedata_no_entries.json
@@ -1,26 +1,24 @@
 [
-  {
-    "ImplementsAnInterface": {
-      "inh": "AndAnotherRandomThing",
-      "impl": ["NoThisOne"]
-    },
-    "AlsoImplementsTestInterface": {
-      "inh": "YetAnotherRandomThing",
-      "impl": ["SomethingUnrelated"]
-    },
-    "AnUnrelatedThing": {
-      "inh": "SomeOtherRandomThing",
-      "impl": []
-    },
-    "NotMyGrandParent": {
-      "inh": "",
-      "impl": []
-    },
-    "NotMyParent": {
-      "inh": "NotMyGrandParent",
-      "impl": [
-        "SomeRandomThing"
-      ]
+    {
+          "ImplementsAnInterface": {
+              "inh": "AndAnotherRandomThing",
+              "impl": ["NoThisOne"]
+          },
+          "AlsoImplementsTestInterface": {
+              "inh": "YetAnotherRandomThing",
+              "impl": ["SomethingUnrelated"]
+          },
+          "AnUnrelatedThing": {
+              "inh": "SomeOtherRandomThing",
+              "impl": []
+          },
+          "NotMyGrandParent": {
+              "inh": "",
+              "impl": []
+          },
+          "NotMyParent": {
+              "inh": "NotMyGrandParent",
+              "impl": ["SomeRandomThing"]
+          }
     }
-  }
 ]

--- a/tests/macros/fixtures/apiref/subpages.json
+++ b/tests/macros/fixtures/apiref/subpages.json
@@ -1,0 +1,93 @@
+[
+    {
+        "tags": [
+            "Property"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestProperty1",
+                "url": "/ja/docs/Web/API/TestInterface/TestProperty1",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestProperty1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestProperty1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
+        "slug": "Web/API/TestInterface/TestProperty1",
+        "title": "TestInterface.MyTestProperty1",
+        "url": "/en-US/docs/Web/API/TestInterface/TestProperty1"
+    },
+
+    {
+        "tags": [
+            "Method",
+            "Experimental"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestMethod1",
+                "url": "/ja/docs/Web/API/TestInterface/TestMethod1",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestMethod1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestMethod1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental.",
+        "slug": "Web/API/TestInterface/TestMethod1",
+        "title": "MyTestMethod1",
+        "url": "/en-US/docs/Web/API/TestInterface/TestMethod1"
+    },
+
+    {
+        "tags": [
+            "Method",
+            "Deprecated",
+            "Non-standard"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestMethod2",
+                "url": "/ja/docs/Web/API/TestInterface/TestMethod2",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestMethod2</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestMethod2</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard.",
+        "slug": "Web/API/TestInterface/TestMethod2",
+        "title": "MyTestMethod2",
+        "url": "/en-US/docs/Web/API/TestInterface/TestMethod2"
+    },
+
+    {
+        "tags": [
+            "Method",
+            "Deprecated",
+            "Non-standard",
+            "Obsolete",
+            "Experimental"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestMethod3",
+                "url": "/ja/docs/Web/API/TestInterface/TestMethod3",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestMethod3</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestMethod3</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges.",
+        "slug": "Web/API/TestInterface/TestMethod3",
+        "title": "MyTestMethod3",
+        "url": "/en-US/docs/Web/API/TestInterface/TestMethod3"
+    }
+
+]


### PR DESCRIPTION
This PR contains tests for the [APIRef](https://github.com/mdn/kumascript/blob/master/macros/APIRef.ejs) macro. I'm writing tests as part of https://github.com/mdn/sprints/issues/1313: after this is merged the next step would be to update the macro (and its tests) to handle the way we are now representing events.

I don't think this tests every edge case. But APIRef's behavior is quite complex especially as it's very dependent on various data sources (subpages, GroupData, InterfaceData, L10n-Common). So I've tried to cover the main cases while trying to keep the size of test under control.

I've been guided by this comment: https://github.com/mdn/kumascript/pull/1080#issuecomment-466114220 in writing this test, so I thought it might be worth going through that here:

----

>    say the current page is at /docs/Web/API/MainIF/, is mainIF correctly given as "MainIF"?

Tested: we set this as the slug and check the result.

>    say the current page is at /docs/Web/API/MainIF/something-else, is mainIF correctly given as "MainIF"?

Tested: we try setting the slug to a subpage and check the result.

>    given a value of mainIF and a particular subtree under that page, are "ctors/"properties"/"methods" being handled correctly? e.g.
>
>   * if there are no ctors, is the section empty? If there is one, is there one item? if there are two, are they both there?
>   * if the subpages have tags for "experimental" &c, are the badges being shown.

Tested: we have test data with no ctors, one property, three methods. We have tests for no badges, on badge, two badges, and all the badges.

>  there is some tricky string-fiddling in here (e.g. https://github.com/mdn/kumascript/blob/master/macros/APIRef.ejs#L140-L143) which always makes me nervous. Are there strings we might encounter that would break the HTML output?

We have tests for the bit of code referred to here, as some of our example pages use `TestInterface.MethodName` in the title.

>  is the CTA correctly added for non-en-US locales?

Tested: the fr locale doesn't have translations, and we check that the link text includes the CTA ("[Traduire]").

> given a parameter value to use for GroupData, check that "related" and "events" are calculated properly:

Tested: we have a sample GroupData that includes interfaces, methods, and events.

> what if GroupData doesn't have an entry for the given parameter?

Tested: we test passing a different argument, that doesn't match a GroupData entry.

> what if it has various different possible combinations of interfaces, methods, properties, events?

Sort of tested: we only have one GroupData test file, but it contains a mix of stuff.

> what if the names of these things contain weird characters? Will we break the HTML? (actually I know the answer to this: yes we will, but the GroupData test should ensure that doesn't happen. But perhaps APIRef should also be defensive.)

This isn't explicitly tested. I know that the macro will give bad output if GroupData contains bad strings. But [we separately test the contents of GroupData](https://github.com/mdn/kumascript/blob/b7244253e1806b3c7247e7375856f8fe5148ca10/tests/macros/groupdata.test.js), so it should be OK. We might want to consider fixing this, but I decided not to add it in this particular effort.

> given some different values for InterfaceData, do we calculate and show inherited and implemented correctly? Does the logic in getInheritance and getImplementedBy work properly, for different values?

We test with a sample InterfaceData file that contains some inherited and implemented-by items.

> In general I think we should pay attention to anywhere where there's string-fiddling going on, and/or where we're getting string data from somewhere and sticking it in HTML output.

See above. This is somewhat tested but not explicitly, just to keep this test from getting even bigger.

-----

I've also fixed a bug in the macro that these tests found.