### PR TITLE
feat(SpecData): Add remaining HTML specifications

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -599,11 +599,6 @@
     "url": "https://w3c.github.io/DOM-Parsing/",
     "status": "WD"
   },
-  "DOM WHATWG": {
-    "name": "DOM",
-    "url": "https://dom.spec.whatwg.org/",
-    "status": "Living"
-  },
   "DOM1": {
     "name": "Document Object Model (DOM) Level 1 Specification",
     "url": "https://www.w3.org/TR/REC-DOM-Level-1/",
@@ -652,7 +647,12 @@
   "DOM4": {
     "name": "DOM4",
     "url": "https://www.w3.org/TR/dom/",
-    "status": "Obsolete"
+    "status": "REC"
+  },
+  "DOM WHATWG": {
+    "name": "DOM",
+    "url": "https://dom.spec.whatwg.org/",
+    "status": "Living"
   },
   "Element Traversal": {
     "name": "Element Traversal Specification",
@@ -839,10 +839,20 @@
     "url": "https://w3c.github.io/microdata/",
     "status": "WD"
   },
+  "HTML2.0": {
+    "name": "HTML 2.0 Specification",
+    "url": "https://tools.ietf.org/html/rfc1866",
+    "status": "Obsolete"
+  },
+  "HTML3.2": {
+    "name": "HTML 3.2 Specification",
+    "url": "https://www.w3.org/TR/html32/",
+    "status": "Obsolete"
+  },
   "HTML4.01": {
     "name": "HTML 4.01 Specification",
     "url": "https://www.w3.org/TR/html401/",
-    "status": "REC"
+    "status": "Obsolete"
   },
   "HTML5 W3C": {
     "name": "HTML5",
@@ -857,6 +867,11 @@
   "HTML5.2": {
     "name": "HTML 5.2",
     "url": "https://www.w3.org/TR/html52/",
+    "status": "REC"
+  },
+  "HTML5.3": {
+    "name": "HTML 5.3",
+    "url": "https://www.w3.org/TR/html53/",
     "status": "REC"
   },
   "HTML WHATWG": {

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -872,7 +872,7 @@
   "HTML5.3": {
     "name": "HTML 5.3",
     "url": "https://www.w3.org/TR/html53/",
-    "status": "REC"
+    "status": "WD"
   },
   "HTML WHATWG": {
     "name": "HTML Living Standard",


### PR DESCRIPTION
This adds **HTML 5.3**, marks **HTML 4.1** as Obsolete, and adds the Obsolete **HTML 2.0** and **HTML 3.2**, all of which are referenced in the **Specifications** sections of some pages.

I’ve also marked **DOM4** as a **W3C Recommendation** as **HTML5.x** aren’t marked as Obsolete either.

---

review?(@chrisdavidmills, @davidflanagan, @wbamberg)