### PR TITLE
Update APIRef to work with new events structure

### DIFF
--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -166,9 +166,12 @@ function buildSublist(pages, title) {
     // in the form "eventname_event", and split off "_event" to leave us (hopefully)
     // with just "eventname" for the link text.
     if (hasTag(aPage, 'Event')) {
-        let pageName = aPage.slug.split('/').pop();
-        title = pageName.split('_')[0];
+        title = aPage.slug.split('/').pop();
+        if (title.endsWith('_event')) {
+            title = title.slice(0,-6);
+        }
     }
+
 
     var cta = '';
      if (!translated && locale != 'en-US') {

--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -172,7 +172,6 @@ function buildSublist(pages, title) {
         }
     }
 
-
     var cta = '';
      if (!translated && locale != 'en-US') {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';

--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -8,7 +8,6 @@
 var slug = env.slug;
 var locale = env.locale;
 var APIHref = '/' + locale + '/docs/Web/API';
-var EventHref = '/' + locale + '/docs/Web/Events';
 var output = "";
 // slug is not available in preview mode.
 if (slug) {
@@ -56,7 +55,6 @@ if (group && webAPIGroups[0][group]) {
     related.splice(mainIfIndex, 1);
   }
   related.sort();
-  events = webAPIGroups[0][group].events || [];
 }
 
 var pageList = mainIFPages;
@@ -64,6 +62,7 @@ var pageList = mainIFPages;
 var properties = [];
 var methods = [];
 var ctors = [];
+var events = [];
 var inheritedIF = [];
 var implementedBy = [];
 
@@ -78,6 +77,9 @@ function collect(pageList) {
     }
     if (hasTag(aPage, "Constructor")) {
         ctors.push(aPage);
+    }
+    if (hasTag(aPage, "Event")) {
+        events.push(aPage);
     }
   }
 }
@@ -102,6 +104,7 @@ function APISort(a, b) {
 properties.sort(APISort);
 methods.sort(APISort);
 ctors.sort(APISort);
+events.sort(APISort);
 
 function getInheritance(inh) {
   if (inh.length > 0) {
@@ -156,6 +159,15 @@ function buildSublist(pages, title) {
                 translated = true;
             }
         });
+    }
+
+    // Event pages have a title like "Interface: eventname event" which looks silly
+    // in the sidebar. So for event pages we use the slug, which is supposed to be
+    // in the form "eventname_event", and split off "_event" to leave us (hopefully)
+    // with just "eventname" for the link text.
+    if (hasTag(aPage, 'Event')) {
+        let pageName = aPage.slug.split('/').pop();
+        title = pageName.split('_')[0];
     }
 
     var cta = '';
@@ -222,19 +234,6 @@ function buildIFList(interfaces, title) {
   return result;
 }
 
-function buildEventList(events, title) {
-  var result = '<li class="toggle"><details open><summary>' + title + '</summary><ol>';
-
-  for (var i = 0; i < events.length; i++) {
-    result += '<li><a href="' + EventHref + '/' + events[i] + '"><code>' + events[i] + '</code></a></li>';
-  }
-
-  result += '</ol></details></li>';
-
-  return result;
-}
-
-
 // output
 output = '<section class="Quick_links" id="Quick_Links"><ol>';
 if (group && webAPIGroups[0][group] && webAPIGroups[0][group].overview) {
@@ -252,14 +251,14 @@ if (properties.length > 0) {
 if (methods.length > 0) {
   output += buildSublist(methods, text['Methods']);
 }
+if (events.length > 0) {
+  output += buildSublist(events, text['Events']);
+}
 if (inh.length > 0) {
   output += buildIFList(inheritedIF, text['Inheritance']);
 }
 if (implementedBy.length > 0) {
   output += buildIFList(implementedBy, text['Implemented_by']);
-}
-if (events.length > 0) {
-  output += buildEventList(events, text['Events']);
 }
 
 if (related.length > 0) {

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -147,7 +147,7 @@ const expectedEvents = {
         },
         {
             badges: [],
-            text: 'TestEvent3',
+            text: 'TestEvent3_another_suffix',
             target: '/en-US/docs/Web/API/TestInterface/TestEvent3',
             title: 'The MyTestEvent3 event of the TestInterface interface has no badges.'
         }
@@ -167,7 +167,7 @@ const expectedEvents = {
         },
         {
             badges: [],
-            text: 'TestEvent3 [Traduire]',
+            text: 'TestEvent3_another_suffix [Traduire]',
             target: '/fr/docs/Web/API/TestInterface/TestEvent3',
             title: 'The MyTestEvent3 event of the TestInterface interface has no badges.'
         }
@@ -187,7 +187,7 @@ const expectedEvents = {
         },
         {
             badges: [],
-            text: 'TestEvent3',
+            text: 'TestEvent3_another_suffix',
             target: '/ja/docs/Web/API/TestInterface/TestEvent3',
             title: 'The MyTestEvent3 event of the TestInterface interface has no badges (ja translation).'
         }

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -131,16 +131,68 @@ const expectedMethods = {
     ]
 }
 
-const expectedEvents = [
-    {
-        text: 'crunch',
-        target: '/docs/Web/Events/crunch'
-    },
-    {
-        text: 'stomp',
-        target: '/docs/Web/Events/stomp'
-    }
-];
+const expectedEvents = {
+    'en-US': [
+        {
+            badges: [],
+            text: 'TestEvent1',
+            target: '/en-US/docs/Web/API/TestInterface/TestEvent1',
+            title: 'The MyTestEvent1 event of the TestInterface interface has no badges.'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  TestEvent2',
+            target: '/en-US/docs/Web/API/TestInterface/TestEvent2',
+            title: 'The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard.'
+        },
+        {
+            badges: [],
+            text: 'TestEvent3',
+            target: '/en-US/docs/Web/API/TestInterface/TestEvent3',
+            title: 'The MyTestEvent3 event of the TestInterface interface has no badges.'
+        }
+    ],
+    'fr': [
+        {
+            badges: [],
+            text: 'TestEvent1 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestEvent1',
+            title: 'The MyTestEvent1 event of the TestInterface interface has no badges.'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  TestEvent2 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestEvent2',
+            title: 'The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard.'
+        },
+        {
+            badges: [],
+            text: 'TestEvent3 [Traduire]',
+            target: '/fr/docs/Web/API/TestInterface/TestEvent3',
+            title: 'The MyTestEvent3 event of the TestInterface interface has no badges.'
+        }
+    ],
+    'ja': [
+        {
+            badges: [],
+            text: 'TestEvent1',
+            target: '/ja/docs/Web/API/TestInterface/TestEvent1',
+            title: 'The MyTestEvent1 event of the TestInterface interface has no badges (ja translation).'
+        },
+        {
+            badges: ['icon-thumbs-down-alt', 'icon-warning-sign'],
+            text: '  TestEvent2',
+            target: '/ja/docs/Web/API/TestInterface/TestEvent2',
+            title: 'The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard (ja translation).'
+        },
+        {
+            badges: [],
+            text: 'TestEvent3',
+            target: '/ja/docs/Web/API/TestInterface/TestEvent3',
+            title: 'The MyTestEvent3 event of the TestInterface interface has no badges (ja translation).'
+        }
+    ]
+}
 
 const expectedRelated = [
     {
@@ -183,7 +235,8 @@ const expectedBasic = {
     mainIfLink: expectedMainIfLink.withoutGroupData,
     details: {
         properties: expectedProperties,
-        methods: expectedMethods
+        methods: expectedMethods,
+        events: expectedEvents
     }
 }
 
@@ -202,6 +255,7 @@ const expectedWithInterfaceData = {
     details: {
         properties: expectedProperties,
         methods: expectedMethods,
+        events: expectedEvents,
         inherited: expectedInherited,
         implemented: expectedImplemented
     }
@@ -297,12 +351,18 @@ function checkResult(html, config) {
     const methods = details[1];
     checkItemList(expectedMethodSummary, expectedMethodItems, methods, config, checkInterfaceItem);
 
+    // Test the events sublist
+    const expectedEventSummary = commonL10nJSON['Events'][config.locale];
+    const expectedEventItems = config.expected.details.events[config.locale];
+    const events = details[2];
+    checkItemList(expectedEventSummary, expectedEventItems, events, config, checkInterfaceItem);
+
     const hasInherited = config.expected.details.inherited;
     if (hasInherited) {
         // Test the inherited sublist
         const expectedInheritedSummary = commonL10nJSON['Inheritance'][config.locale];
         const expectedInheritedItems = config.expected.details.inherited;
-        const inherited = details[2];
+        const inherited = details[3];
         checkItemList(expectedInheritedSummary, expectedInheritedItems, inherited, config, checkRelatedItem);
     }
 
@@ -311,17 +371,8 @@ function checkResult(html, config) {
         // Test the implemented_by sublist
         const expectedImplementedSummary = commonL10nJSON['Implemented_by'][config.locale];
         const expectedImplementedItems = config.expected.details.implemented;
-        const implemented = details[3];
+        const implemented = details[4];
         checkItemList(expectedImplementedSummary, expectedImplementedItems, implemented, config, checkRelatedItem);
-    }
-
-    const hasEvents = config.expected.details.events;
-    if (hasEvents) {
-        // Test the events sublist
-        const expectedEventSummary = commonL10nJSON['Events'][config.locale];
-        const expectedEventItems = config.expected.details.events;
-        const events = details[2];
-        checkItemList(expectedEventSummary, expectedEventItems, events, config, checkRelatedItem);
     }
 
     const hasRelated = config.expected.details.related;

--- a/tests/macros/fixtures/apiref/groupdata.json
+++ b/tests/macros/fixtures/apiref/groupdata.json
@@ -4,8 +4,7 @@
             "overview":   [ "TestInterface API"],
             "interfaces": [ "AnInterface" ],
             "methods":    [ "AnInterface.doOneThing()", "AnotherInterface.doAnother()" ],
-            "properties": [],
-            "events":     ["crunch", "stomp"]
+            "properties": []
         }
     }
 ]

--- a/tests/macros/fixtures/apiref/subpages.json
+++ b/tests/macros/fixtures/apiref/subpages.json
@@ -150,7 +150,7 @@
             }
         ],
         "summary": "The <code><strong>MyTestEvent3</strong></code> event of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
-        "slug": "Web/API/TestInterface/TestEvent3_one_andanother",
+        "slug": "Web/API/TestInterface/TestEvent3_another_suffix",
         "title": "TestInterface.MyTestEvent3",
         "url": "/en-US/docs/Web/API/TestInterface/TestEvent3"
     }

--- a/tests/macros/fixtures/apiref/subpages.json
+++ b/tests/macros/fixtures/apiref/subpages.json
@@ -88,6 +88,71 @@
         "slug": "Web/API/TestInterface/TestMethod3",
         "title": "MyTestMethod3",
         "url": "/en-US/docs/Web/API/TestInterface/TestMethod3"
+    },
+
+    {
+        "tags": [
+            "Event"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestEvent1",
+                "url": "/ja/docs/Web/API/TestInterface/TestEvent1",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestEvent1</strong></code> event of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestEvent1</strong></code> event of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
+        "slug": "Web/API/TestInterface/TestEvent1_event",
+        "title": "TestInterface.MyTestEvent1",
+        "url": "/en-US/docs/Web/API/TestInterface/TestEvent1"
+    },
+
+    {
+        "tags": [
+            "Event",
+            "Deprecated",
+            "Non-standard"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestEvent2",
+                "url": "/ja/docs/Web/API/TestInterface/TestEvent2",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestEvent2</strong></code> event of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestEvent2</strong></code> event of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard.",
+        "slug": "Web/API/TestInterface/TestEvent2",
+        "title": "MyTestEvent2",
+        "url": "/en-US/docs/Web/API/TestInterface/TestEvent2"
+    },
+
+    {
+        "tags": [
+            "Event"
+        ],
+        "locale": "en-US",
+        "translations": [
+            {
+                "title": "MyTestEvent3",
+                "url": "/ja/docs/Web/API/TestInterface/TestEvent3",
+                "tags": [
+                ],
+                "summary": "The <code><strong>MyTestEvent3</strong></code> event of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
+                "locale": "ja"
+            }
+        ],
+        "summary": "The <code><strong>MyTestEvent3</strong></code> event of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
+        "slug": "Web/API/TestInterface/TestEvent3_one_andanother",
+        "title": "TestInterface.MyTestEvent3",
+        "url": "/en-US/docs/Web/API/TestInterface/TestEvent3"
     }
 
 ]


### PR DESCRIPTION
This PR is part of https://github.com/mdn/sprints/issues/1313.

It updates APIRef to look for event pages as subpages of the main interface, and then adds them alongside properties and methods. Previously, APIRef used GroupData to find links to events on the interface.

The main nasty thing here is event names, which look silly in the sidebar if we use the title (as we do for properties and methods). In this PR I've opted to use the slug and assume the value is like "eventname_event", and split off "_event". This seems a bit less fragile than using the title (mostly because titles are easier to change, and seem more likely to vary by locale).

I've tested this manually with a local Kuma and some pages scraped from production (e.g. https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest and http://localhost:8000/en-US/docs/Web/API/SpeechRecognition), and have also updated the test code for this new behavior. Still I think this needs a careful review as it's a very widely used macro.
