### PR TITLE
fix: css fonts module level 3 link

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -226,7 +226,7 @@
   },
   "CSS3 Fonts": {
     "name": "CSS Fonts Module Level&nbsp;3",
-    "url": "https://drafts.csswg.org/css-fonts-3/",
+    "url": "https://www.w3.org/TR/css-fonts-3/",
     "status": "CR"
   },
   "CSS3 Fragmentation": {


### PR DESCRIPTION
Hello!
I noticed the link to the CSS Fonts Module Level 3 was going out to the draft although its status is a CR already. I updated the link accordingly.

Cheers,
Martin