### PR TITLE
feat: Update {{APIListAlpha}} to cope with newer title formats

### DIFF
--- a/macros/APIListAlpha.ejs
+++ b/macros/APIListAlpha.ejs
@@ -1,45 +1,65 @@
 <%
-// Creates a list of API Interfaces sorted alphabeticlly
+// Creates a list of API Interfaces sorted alphabetically
 
-var APIHref = $0 || '/en-US/docs/Web/API';
+const APIHref = $0 || '/en-US/docs/Web/API';
 
-function isInterface(pageSlug) {
-    var spaceIndex = pageSlug.indexOf('_');
-    
+/**
+ * Checks if the page is an interface page.
+ *
+ * @param {string} pageSlug
+ * @param {string[]} [tags]
+ */
+function isInterface(pageSlug, tags = null) {
+    const spaceIndex = pageSlug.indexOf('_');
+
     // If there are no spaces (represented by underscores), then we can
     // just return true, since this is by our rules an interface in that
-    // situation. Unless the slug is simply "Reference" (why the exception?).
-    
+    // situation.
+
+    // Unless the slug is simply "Reference", which is because that page
+    // used to host this macro, until it was moved to "Web/API".
+
     if ((spaceIndex == -1) && (pageSlug != "Reference")) {
         return true;
     }
-    
+
     // If the character after the space is '(', then this is assumed to be an
     // interface with a qualifier after its name (such as "(Firefox OS)").
     // These are allowed to appear in the index.
-    
+
     if ((spaceIndex < pageSlug.length-1) && (pageSlug[spaceIndex+1] == '(')) {
         return true;
     }
-    
-    // If we get to here, then it's not an interface.
-    
-    return false;
+
+    // If we get to here, then it's probably not an interface.
+
+    return containsTag(tags, 'Interface');
 }
 
-// Prepares the title of the link. This includes wrapping the appropriate
-// portion of the title with <code>. Returns null if the page should not
-// be included in the index.
-
-function buildTitle(base) {
+/**
+ * Prepares the title of the link. This includes wrapping the appropriate
+ * portion of the title with `<code>`.
+ *
+ * @param {string} base The page title
+ * @param {string} slug The page slug without the parent
+ *
+ * @return {[string, string]}
+ *         The first entry is the new appropriate portion wrapped with `<code>`.
+ *         The second entry is the raw title text.
+ */
+function buildTitle(base, slug) {
+    base = base.trim();
     var spaceIndex = base.indexOf(' ');
-    
+
     // If there are no spaces in the page's title, the entire base
     // string is the title, so we just wrap the whole thing in <code> and
     // return it.
-    
-    if ((spaceIndex == -1) && (base != "Reference")) {
-        return "<code>" + base + "</code>";
+
+    if (spaceIndex == -1) {
+        return [
+            `<code>${mdn.escapeHTML(base)}</code>`,
+            base,
+        ];
     }
 
     // If the character after the space is '(', then this is assumed to be an
@@ -48,12 +68,30 @@ function buildTitle(base) {
     // before the first space
 
     if ((spaceIndex < base.length-1) && (base[spaceIndex+1] == '(')) {
-        return "<code>" + base.substring(0, spaceIndex) + "</code>" + base.substring(spaceIndex);
+        return [
+            `<code>${
+                mdn.escapeHTML(base.substring(0, spaceIndex))
+            }</code>${
+                mdn.escapeHTML(base.substring(spaceIndex))
+            }`,
+            base,
+        ];
     }
 
-    // It's not an interface, so return null.
-    
-    return null;
+    const match = /^(?:API )?([^ ]+)(?: (?:-|Interface))?/i.exec(mdn.escapeHTML(base));
+    if (match) {
+        const result = match[1];
+        return [
+            `<code>${mdn.escapeHTML(result)}</code>`,
+            result,
+        ];
+    }
+
+    // Give up and return the slug
+    return [
+        `<code>${mdn.escapeHTML(slug)}</code>`,
+        slug,
+    ];
 }
 
 function containsTag(tagList, tag) {
@@ -65,66 +103,81 @@ function containsTag(tagList, tag) {
     return 0;
 }
 
-var pages = await page.subpagesExpand(APIHref); // get subpages, including tags
-var slug = env.slug;
-var locale = env.locale;
-var letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-var html = "";
+const pages = await page.subpagesExpand(APIHref); // get subpages, including tags
+const locale = env.locale;
+const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const numLetters = letters.length;
+const numPages = pages.length;
 
-var numLetters = letters.length;
-var numPages = pages.length;
-var p = 0;
+let html = "";
+let p = 0;
 
+for (let i = 0; i < numLetters; i++) {
+    const curLetter = letters[i];
+    let insertedHeading = false; // Haven't done this letter's heading yet
 
-for (var i = 0; i < numLetters; i++) {
-    var curLetter = letters[i];
-    var insertedHeading = false; // Haven't done this letter's heading yet
-    
     if (p < numPages) {
         do {
-            var tags = pages[p].tags;
-            var url = pages[p].url;
-            var summary = pages[p].summary;
-            var title = pages[p].title;
-            
+            const page = pages[p];
+            let builtTitle, badge = "";
+            let {
+                tags,
+                url,
+                summary = null,
+                title,
+                slug,
+            } = page;
+
             // Build the formatted title string; skip this page if it's not
             // an interface.
-            
-            var builtTitle = buildTitle(title);
-            if (builtTitle == null) {
+
+            slug = slug.replace('Web/API/', '');
+            if (!isInterface(slug, tags)) {
                 p++;
                 continue;
             }
 
-            var badge = "";
-            
+            [
+                builtTitle,
+                title,
+            ] = (buildTitle(title, slug));
+
             // add badges if needed
-            
+
             if (containsTag(tags, "Non-standard") || containsTag(tags, "Non standard")) {
                 badge = " " + await template("NonStandardBadge", ["1"]);
             }
-            
+
             if (containsTag(tags, "Obsolete")) {
                 badge += " " + await template("ObsoleteBadge", [1]);
             } else if (containsTag(tags, "Deprecated")) {
                 badge += " " + await template("DeprecatedBadge", [1]);
             }
-            
+
             if (containsTag(tags, "Experimental")) {
                 badge += " " + await template("ExperimentalBadge", ["1"]);
             }
-            
+
             // Wrap the badges in another span
-            
+
             if (badge.length) badge = '<span class="indexListBadges">' + badge + "</span>";
-                    
+
             if (title[0].toUpperCase() == curLetter) {
                 if (!containsTag(tags, "junk")) {
                     if (!insertedHeading) {
-                        html += "<span>" + curLetter + "</span><ul>";
+                        html += "\t<span>" + curLetter + "</span>\n\t<ul>";
                         insertedHeading = true;
                     }
-                    html += '\n<li><span class="indexListRow"><span class="indexListTerm"><a href="' + url.replace("en-US", locale) + '" title="' + wiki.escapeQuotes(summary) + '">' + builtTitle + '</a></span>' + badge + '</span></li>';
+                    html += '\n\t\t<li>' +
+                        '<span class="indexListRow">' +
+                            '<span class="indexListTerm">' +
+                                '<a href="' + url.replace("en-US", locale) + '"' +
+                                    (summary ? ` title="${mdn.escapeQuotes(summary)}"` : '') +
+                                    '>' +
+                                    builtTitle +
+                                '</a></span>' +
+                            badge +
+                        '</span></li>';
                 }
                 p++;
             } else {
@@ -132,7 +185,9 @@ for (var i = 0; i < numLetters; i++) {
             }
         } while (p < pages.length);
     }
-    html += "\n</ul>\n";
+    if (insertedHeading) {
+        html += "\n\t</ul>";
+    }
 }
 
 

--- a/macros/APIListAlpha.ejs
+++ b/macros/APIListAlpha.ejs
@@ -78,16 +78,9 @@ function buildTitle(base, slug) {
         ];
     }
 
-    const match = /^(?:API )?([^ ]+)(?: (?:-|Interface))?/i.exec(mdn.escapeHTML(base));
-    if (match) {
-        const result = match[1];
-        return [
-            `<code>${mdn.escapeHTML(result)}</code>`,
-            result,
-        ];
-    }
+    // Return the slug, since the title uses a future format,
+    // which can't be parsed in a 100% reliable manner.
 
-    // Give up and return the slug
     return [
         `<code>${mdn.escapeHTML(slug)}</code>`,
         slug,

--- a/src/api/mdn.js
+++ b/src/api/mdn.js
@@ -115,9 +115,10 @@ module.exports = {
         return string.replace(/\$\w+\$/g, replacePlaceholder);
     },
 
-    /**
-     * Given a string, escapes all quotes within it.
-     */
+    /** Escape the given string for HTML inclusion. */
+    escapeHTML: util.htmlEscape,
+
+    /** Given a string, escapes all quotes within it and strips HTML tags. */
     escapeQuotes: util.escapeQuotes,
 
     /**

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -99,11 +99,14 @@ const util = (module.exports = {
     },
 
     /**
-     * #### htmlEscape(string)
      * Escape the given string for HTML inclusion.
      *
      * @param {string} s
      * @return {string}
+     *
+     * @example
+     * htmlEscape('for (let i = 0; i < 10; i++) console.log("i = " + i)');
+     * // => 'for (let i = 0; i &lt; 10; i++) console.log(&quot;i = &quot; + i)'
      */
     htmlEscape(s) {
         return ('' + s)
@@ -113,6 +116,16 @@ const util = (module.exports = {
             .replace(/"/g, '&quot;');
     },
 
+    /**
+     * Given a string, escapes all quotes within it and strips HTML tags.
+     *
+     * @param {string} a
+     * @return {string} The string with quotes escaped and HTML removed.
+     *
+     * @example
+     * escapeQuotes('Value is: <code>"str"</code>.');
+     * // => 'Value is: &quot;str&quot;.'
+     */
     escapeQuotes(a) {
         var b = '';
         for (var i = 0, len = a.length; i < len; i++) {

--- a/tests/macros/APIListAlpha.test.js
+++ b/tests/macros/APIListAlpha.test.js
@@ -1,0 +1,50 @@
+/**
+ * @prettier
+ */
+const fs = require('fs');
+const path = require('path');
+const {
+    beforeEachMacro,
+    describeMacro,
+    itMacro,
+    assert,
+} = require('./utils');
+
+/**
+ * @typedef {object} Page
+ * @property {string[]} [tags]
+ * @property {string} locale
+ * @property {string} slug
+ * @property {string} title
+ * @property {string} url
+ * @property {string} [summary]
+ * @property {Page[]} [translations]
+ */
+
+/**
+ * Load all the fixtures.
+ */
+const subpagesPath = path.resolve(__dirname, 'fixtures/APIListAlpha/top-level.json');
+/** @type {Page[]} */
+const subpagesJSON = JSON.parse(fs.readFileSync(subpagesPath, 'utf8'));
+
+describeMacro('APIListAlpha', () => {
+    beforeEachMacro(macro => {
+        macro.ctx.page.subpagesExpand = jest.fn(async (page) => {
+            expect(page).toEqual('/en-US/docs/Web/API');
+            return subpagesJSON;
+        });
+    });
+
+    itMacro('Expected result', macro => {
+        return assert.eventually.equal(macro.call(), `<div class="index">
+	<span>T</span>
+	<ul>
+		<li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/TestInterface"><code>TestInterface</code></a></span></span></li>
+		<li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/TestInterface2"><code>TestInterface2</code></a></span></span></li>
+		<li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/TestMixin"><code>TestMixin</code></a></span></span></li>
+		<li><span class="indexListRow"><span class="indexListTerm"><a href="/en-US/docs/Web/API/TestOther" title="See this Discourse thread for details."><code>TestOther</code></a></span></span></li>
+	</ul>
+</div>`)
+    });
+});

--- a/tests/macros/fixtures/APIListAlpha/top-level.json
+++ b/tests/macros/fixtures/APIListAlpha/top-level.json
@@ -1,0 +1,49 @@
+[
+    {
+        "tags": [
+            "Overview"
+        ],
+        "locale": "en-US",
+        "slug": "Web/API/Test_API",
+        "title": "Test API",
+        "url": "/en-US/docs/Web/API/Test_API"
+    },
+
+    {
+        "tags": [
+            "Interface"
+        ],
+        "locale": "en-US",
+        "slug": "Web/API/TestInterface",
+        "title": "TestInterface",
+        "url": "/en-US/docs/Web/API/TestInterface"
+    },
+    {
+        "tags": [
+            "Interface"
+        ],
+        "locale": "en-US",
+        "slug": "Web/API/TestInterface2",
+        "title": "TestInterface2 - Electric Boogaloo",
+        "url": "/en-US/docs/Web/API/TestInterface2"
+    },
+    {
+        "tags": [
+            "Interface"
+        ],
+        "locale": "en-US",
+        "slug": "Web/API/TestMixin",
+        "title": "TestMixin Interface",
+        "url": "/en-US/docs/Web/API/TestMixin"
+    },
+    {
+        "tags": [
+            "Interface"
+        ],
+        "locale": "en-US",
+        "slug": "Web/API/TestOther",
+        "title": "API TestOther - The new experimental CSS-style syntax with a description is supported. (yay!)",
+        "summary": "See <a href=\"https://discourse.mozilla.org/t/38861\">this Discourse thread</a> for details.",
+        "url": "/en-US/docs/Web/API/TestOther"
+    }
+]


### PR DESCRIPTION
The way `{{APIListAlpha}}` is currently implemented won’t be compatible with some of the planned changes to page titles, some of which are already being done [on CSS pages](https://discourse.mozilla.org/t/38861).

[This page](https://developer.mozilla.org/docs/User:ExE-Boss/Macro_issues/APIListAlpha) demonstrates what happens when any of the newer title formats are used.

## Relevant Discourse threads:
- https://discourse.mozilla.org/t/results-of-first-css-reference-title-a-b-test/38861
- https://discourse.mozilla.org/t/api-documentation-structure-idea/31967
- https://discourse.mozilla.org/t/incorrect-titles-for-method-property-articles/31641
- https://discourse.mozilla.org/t/brainstorming-updating-titles-of-css-reference-pages/23126
- https://discourse.mozilla.org/t/proposal-changing-the-titles-of-html-element-reference-pages/19112

---

review?(@a2sheppy, @escattone, @wbamberg)