### PR TITLE
Add Long Tasks overview; rename group

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -832,7 +832,8 @@
             "properties": [ "Navigator.mozL10n" ],
             "events":     []
         },
-        "Long Tasks": {
+        "Long Tasks API": {
+            "overview": [ "Long Tasks API" ],
             "interfaces": [ "PerformanceLongTaskTiming",
                             "TaskAttributionTiming" ],
             "methods":    [],


### PR DESCRIPTION
This is a fix for https://github.com/mdn/sprints/issues/1483. As @jmswisher says there, the problem is that "overview" is missing from the group data.

Another problem is that https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API is using the wrong macro - APIRef instead of DefaultAPISidebar - because it's **totally confusing** which one to use. But that's a fix we make in the Wiki not KumaScript.

I've also updated the name of the group from  "Long Tasks" to "Long Tasks API" - this means it'll show up as "Long Tasks API" in https://developer.mozilla.org/en-US/docs/Web/API.

We have regression tests for GroupData now so there is a reasonable chance that this won't break stuff.

*****

To test this manually you can scrape:

    docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API --depth 10

and

    docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API

... into your local Kuma, then visit http://localhost:8000/en-US/docs/Web/API, shift-refresh to rebuild the page, and you should see the "Long Tasks API" link appearing, and it should take you to http://localhost:8000/en-US/docs/Web/API/Long_Tasks_API.




