### PR TITLE
Fix typo in URL for Using the Screen Capture API in sidebar

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1174,7 +1174,7 @@
             "events":     []
         },
         "Screen Capture API": {
-            "guides":     [ { "url":   "/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture_API",
+            "guides":     [ { "url":   "/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture",
                               "title": "Using the Screen Capture API" }],
             "interfaces": [],
             "dictionaries": [],


### PR DESCRIPTION
This had ".../Using_Screen_Capture_API" instead of
".../Using_Screen_Capture" in the slug, resulting in a 404. Fixed.