### PR TITLE
fix: Make `context.__proto__` unscopable

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -158,6 +158,7 @@ class Environment {
     // macro on a page by including the arguments to be passed to that macro.
     getExecutionContext(args) {
         let context = Object.create(this.prototypeEnvironment);
+        context[Symbol.unscopables] = { __proto__: true };
 
         // Make a defensive copy of the arguments so that macros can't
         // modify the originals. Use an empty array if no args provided.


### PR DESCRIPTION
While debugging macros, I’ve&nbsp;noticed that `with` includes the&nbsp;`__proto__` property.

This makes it&nbsp;unscopable so&nbsp;that there’s no&nbsp;`__proto__` property in&nbsp;the&nbsp;macro’s dynamic scope, since&nbsp;it’s&nbsp;never&nbsp;used in&nbsp;macros and&nbsp;its&nbsp;existence could lead to&nbsp;odd and&nbsp;hard to&nbsp;debug bugs.

review?(@davidflanagan, @wbamberg)