### PR TITLE
adding JavaScript modules article to JS Sidebar

### DIFF
--- a/macros/JsSidebar.ejs
+++ b/macros/JsSidebar.ejs
@@ -30,6 +30,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'Iterators and generators',
     'Guide_Meta': 'Meta programming',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': 'Complete beginners',
     'Basics': 'JavaScript basics',
     'First_steps': 'JavaScript first steps',
@@ -93,6 +94,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'Итераторы и генераторы',
     'Guide_Meta': 'Метапрограммирование',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': 'Базовые',
     'Basics': 'Основы JavaScript',
     'First_steps': 'JavaScript first steps',
@@ -156,6 +158,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'Itérateurs et générateurs',
     'Guide_Meta': 'Meta-programmation',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': 'Débutant',
     'Basics': 'Les bases en JavaScript',
     'First_steps': 'Premiers pas en JavaScript',
@@ -219,6 +222,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'Iterators and generators',
     'Guide_Meta': 'Meta programming',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': '快速入门',
     'Basics': 'JavaScript 基础知识',
     'First_steps': 'JavaScript first steps',
@@ -282,6 +286,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'Iteratoren und Generatoren',
     'Guide_Meta': 'Metaprogrammierung',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': 'Einleitend',
     'Basics': 'JavaScript Grundlagen',
     'First_steps': 'JavaScript first steps',
@@ -345,6 +350,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Using promises',
     'Guide_Iterators_Generators': 'イテレーターとジェネレーター',
     'Guide_Meta': 'メタプログラミング',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': '初級編',
     'Basics': 'JavaScript の基礎',
     'First_steps': 'JavaScript first steps',
@@ -408,6 +414,7 @@ var text = mdn.localStringMap({
     'Guide_promises' : 'Usando "promises"',
     'Guide_Iterators_Generators': 'Iteradores e geradores',
     'Guide_Meta': 'Metaprogramação',
+    'Guide_Modules': 'JavaScript modules',
     'Complete_beginners': 'Completos iniciantes',
     'Basics': 'O básico de JavaScript',
     'First_steps': 'Primeiros passos com JavaScript',
@@ -488,6 +495,7 @@ var text = mdn.localStringMap({
           <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Using_promises"><%=text['Guide_promises']%></a></li>
           <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Iterators_and_generators"><%=text['Guide_Iterators_Generators']%></a></li>
           <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Meta_programming"><%=text['Guide_Meta']%></a></li>
+          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Modules"><%=text['Guide_Modules']%></a></li>
         </ol>
     </details>
   </li>


### PR DESCRIPTION
I wrote a new guide covering JavaScript modules: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules

This PR adds it to the JsSidebar macro.