### PR TITLE
fix(macros): Improve {{XULElem}} displayed text

### DIFF
--- a/macros/XULElem.ejs
+++ b/macros/XULElem.ejs
@@ -19,5 +19,4 @@ if (wiki.pageExists(destNewType)) {
     url = destNewType;
 }
 
-
-%><code><a href="<%=url%>" title="<%=$0%>"><%=$0%></a></code>
+%><code><a href="<%=url%>">&lt;xul:<%=$0%>&gt;</a></code>

--- a/tests/macros/XULElement.test.js
+++ b/tests/macros/XULElement.test.js
@@ -1,0 +1,18 @@
+/**
+ * @prettier
+ */
+const { assert, itMacro, describeMacro } = require('./utils');
+
+describeMacro('XULElem', () => {
+    for (const locale of ['en-US', 'de', 'fr']) {
+        for (const element of ['iframe', 'window']) {
+            itMacro(`${locale} ${element}`, macro => {
+                macro.ctx.env.locale = locale;
+                return assert.eventually.equal(
+                    macro.call(element),
+                    `<code><a href="/${locale}/docs/Mozilla/Tech/XUL/${element}">&lt;xul:${element}&gt;</a></code>`
+                );
+            });
+        }
+    }
+});


### PR DESCRIPTION
This makes it so that `{{XULElem('element')}}` is displayed as `<xul:element>` instead of just `element`.

---

review?(@wbamberg)