### PR TITLE
fix(macros): Sort sidebar icons

### DIFF
--- a/macros/APIRef.ejs
+++ b/macros/APIRef.ejs
@@ -180,21 +180,19 @@ function buildSublist(pages, title) {
 
     result += '<li>';
 
-    if (hasTag(aPage, 'Experimental')) {
-        result += badges.ExperimentalBadge;
-    }
-
     if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
         result += badges.NonStandardBadge;
     }
 
-    if (hasTag(aPage, 'Deprecated')) {
-        result += badges.DeprecatedBadge;
+    if (hasTag(aPage, 'Experimental')) {
+        result += badges.ExperimentalBadge;
     }
 
     if (hasTag(aPage, 'Obsolete')) {
         result += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
+    } else if (hasTag(aPage, 'Deprecated')) {
+        result += badges.DeprecatedBadge;
     }
 
     if (rtlLocales.indexOf(locale) != -1) {

--- a/macros/CSSRef.ejs
+++ b/macros/CSSRef.ejs
@@ -220,21 +220,19 @@ if (slug) {
 
         result += '<li>';
 
-        if (hasTag(aPage, 'Experimental')) {
-            result += badges.ExperimentalBadge;
-        }
-
         if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
             result += badges.NonStandardBadge;
         }
 
-        if (hasTag(aPage, 'Deprecated')) {
-            result += badges.DeprecatedBadge;
+        if (hasTag(aPage, 'Experimental')) {
+            result += badges.ExperimentalBadge;
         }
 
         if (hasTag(aPage, 'Obsolete')) {
             result += badges.ObsoleteBadge;
             result += '<s class="obsoleteElement">';
+        } else if (hasTag(aPage, 'Deprecated')) {
+            result += badges.DeprecatedBadge;
         }
 
         if (rtlLocales.indexOf(locale) != -1) {

--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -180,21 +180,19 @@ function buildSublist(pages, title, opened) {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['translationCTA'] + '">' + text['translate'] + '</a>';
     }
 
-    if (containsTag(aPage, 'Experimental')) {
-        result += badges.ExperimentalBadge;
-    }
-
     if (containsTag(aPage, 'Non-standard') || containsTag(aPage, 'Non Standard')) {
         result += badges.NonStandardBadge;
     }
 
-    if (containsTag(aPage, 'Deprecated')) {
-        result += badges.DeprecatedBadge;
+    if (containsTag(aPage, 'Experimental')) {
+        result += badges.ExperimentalBadge;
     }
 
     if (containsTag(aPage, 'Obsolete')) {
         result += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
+    } else if (containsTag(aPage, 'Deprecated')) {
+        result += badges.DeprecatedBadge;
     }
 
     if (rtlLocales.indexOf(locale) != -1) {

--- a/macros/ListSubpagesForSidebar.ejs
+++ b/macros/ListSubpagesForSidebar.ejs
@@ -21,11 +21,11 @@ var parent = $2 ? 1 : 0;
 var startDelim = $3;
 var endDelim = $4;
 
-// If the path ends with a slash, remove it.    
+// If the path ends with a slash, remove it.
 if (path.substr(-1, 1) === '/') {
     path = path.slice(0, -1);
 }
-    
+
 var pages = await page.subpagesExpand(path, -1, parent);
 var containsTag = page.hasTag;
 var escapeQuotes = mdn.escapeQuotes;
@@ -95,42 +95,40 @@ function createLink(item) {
             }
         });
     }
-    
+
     var cta = '';
      if (!translated && locale != 'en-US') {
         cta += ' <a href="'+ url +'$translate" style="opacity:0.5" title="'+ text['title'] + '">' + text['translate'] + '</a>';
     }
-    
+
     result += '<li>';
-    
-    if (containsTag(item, 'Experimental')) {
-        result += badges.ExperimentalBadge;
-    }
-    
+
     if (containsTag(item, 'Non-standard') || containsTag(item, 'Non Standard')) {
         result += badges.NonStandardBadge;
     }
-    
-    if (containsTag(item, 'Deprecated')) {
-        result += badges.DeprecatedBadge;
+
+    if (containsTag(item, 'Experimental')) {
+        result += badges.ExperimentalBadge;
     }
-    
+
     if (containsTag(item, 'Obsolete')) {
         result += badges.ObsoleteBadge;
+    } else if (containsTag(item, 'Deprecated')) {
+        result += badges.DeprecatedBadge;
     }
-    
+
     result += '<a href="' + url + '" title="' + summary + '">' + code + title + endcode + '</a>' + cta + '</li>';
     return result;
 }
 
 if (pages.length) {
     output += openTag;
-    
+
     pages.forEach(function(item) {
         if (!item) { return; }
         output += createLink(item);
     });
-    
+
     output += closeTag;
 }
 %>

--- a/macros/WebExtAPISidebar.ejs
+++ b/macros/WebExtAPISidebar.ejs
@@ -67,21 +67,19 @@ function buildSublist(pages, title, ignoreBadges) {
 
     if (!ignoreBadges) {
 
-        if (hasTag(aPage, 'Experimental')) {
-            result += badges.ExperimentalBadge;
-        }
-
         if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
             result += badges.NonStandardBadge;
         }
 
-        if (hasTag(aPage, 'Deprecated')) {
-            result += badges.DeprecatedBadge;
+        if (hasTag(aPage, 'Experimental')) {
+            result += badges.ExperimentalBadge;
         }
 
         if (hasTag(aPage, 'Obsolete')) {
             result += badges.ObsoleteBadge;
             result += '<s class="obsoleteElement">';
+        } else if (hasTag(aPage, 'Deprecated')) {
+            result += badges.DeprecatedBadge;
         }
     }
 

--- a/macros/jsindex.ejs
+++ b/macros/jsindex.ejs
@@ -72,19 +72,18 @@ var found = mdn.localString({
      for (i in result) { %>
          <li>
 
-            <% if (hasTag(result[i].tags, 'Experimental')) { %>
-                <span class="sidebar-icon"><%-await template("ExperimentalBadge", [1])%></span>
-            <% } %>
             <% if (hasTag(result[i].tags, 'Non-standard')) { %>
                  <span class="sidebar-icon"><%-await template("NonStandardBadge", [1])%></span>
             <% } %>
-            <% if (hasTag(result[i].tags, 'Deprecated')) { %>
-                 <span class="sidebar-icon"><%-await template("DeprecatedBadge", [1])%></span>
+            <% if (hasTag(result[i].tags, 'Experimental')) { %>
+                <span class="sidebar-icon"><%-await template("ExperimentalBadge", [1])%></span>
             <% } %>
             <% if (hasTag(result[i].tags, 'Obsolete')) { %>
                 <span class="sidebar-icon"><%-await template("ObsoleteBadge", [1])%></span>
+            <% } else if (hasTag(result[i].tags, 'Deprecated')) { %>
+                 <span class="sidebar-icon"><%-await template("DeprecatedBadge", [1])%></span>
             <% } %>
-            
+
              <% if (hasTag(result[i].tags, 'Obsolete')) { %>
                 <s class="obsoleteElement">
             <% } %>
@@ -94,7 +93,7 @@ var found = mdn.localString({
             <% if (hasTag(result[i].tags, 'Obsolete')) { %>
                 </s>
             <% } %>
-        
+
         </li>
     <% } %>
 </ul>

--- a/tests/macros/apiref.test.js
+++ b/tests/macros/apiref.test.js
@@ -83,8 +83,8 @@ const expectedMethods = {
             title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.'
         },
         {
-            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
-            text: '    MyTestMethod3',
+            badges: ['icon-beaker', 'icon-warning-sign', 'icon-trash'],
+            text: '   MyTestMethod3',
             target: '/en-US/docs/Web/API/TestInterface/TestMethod3',
             title: 'The MyTestMethod3 property of the TestInterface interface has all the badges.'
         }
@@ -103,8 +103,8 @@ const expectedMethods = {
             title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.'
         },
         {
-            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
-            text: '    MyTestMethod3 [Traduire]',
+            badges: ['icon-beaker', 'icon-warning-sign', 'icon-trash'],
+            text: '   MyTestMethod3 [Traduire]',
             target: '/fr/docs/Web/API/TestInterface/TestMethod3',
             title: 'The MyTestMethod3 property of the TestInterface interface has all the badges.'
         }
@@ -123,8 +123,8 @@ const expectedMethods = {
             title: 'The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).'
         },
         {
-            badges: ['icon-beaker', 'icon-thumbs-down-alt', 'icon-warning-sign', 'icon-trash'],
-            text: '    MyTestMethod3',
+            badges: ['icon-beaker', 'icon-warning-sign', 'icon-trash'],
+            text: '   MyTestMethod3',
             target: '/ja/docs/Web/API/TestInterface/TestMethod3',
             title: 'The MyTestMethod3 property of the TestInterface interface has all the badges (ja translation).'
         }


### PR DESCRIPTION
This sorts the sidebar icons, so that the Non‑standard icon comes before the Experimental icon, so that cases where a feature is both Experimental and Non‑standard (e.g.: [`‑moz‑context‑properties`](https://developer.mozilla.org/docs/Web/CSS/-moz-context-properties)), the Non‑standard icon comes first.

Also makes it so that the “Obsolete” icon always takes precedence over the “Deprecated” icon, instead of just in some cases.