### PR TITLE
Fix 3 overview pages in GroupData.json

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -624,6 +624,7 @@
                             "HTMLElement: dragend" ]
         },
         "Image Capture API": {
+            "overview": [ "MediaStream Image Capture API" ],
             "interfaces": [ "ImageCapture",
                             "PhotoCapabilities" ],
             "methods":    [],
@@ -727,6 +728,7 @@
             "events":     []
         },
         "Media Source Extensions": {
+            "overview": [ "Media_Source_Extensions_API" ],
             "interfaces": [ "MediaSource",
                             "SourceBuffer",
                             "SourceBufferList",
@@ -1640,6 +1642,7 @@
                             "Window: vrdisplaypresentchange" ]
         },
         "WebVTT": {
+            "overview": [ "WebVTT API" ],
             "guides":     [ { "url":   "/docs/Web/API/Web_Video_Text_Tracks_Format",
                               "title": "WebVTT file format" } ],
             "interfaces": [ "VTTCue",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -728,7 +728,7 @@
             "events":     []
         },
         "Media Source Extensions": {
-            "overview": [ "Media_Source_Extensions_API" ],
+            "overview": [ "Media Source Extensions API" ],
             "interfaces": [ "MediaSource",
                             "SourceBuffer",
                             "SourceBufferList",


### PR DESCRIPTION
This PR fixes three of the links in [Web/API](https://developer.mozilla.org/en-US/docs/Web/API) by adding the correct `"overview"` property for that API in GroupData.json.

This change was previously discussed in https://discourse.mozilla.org/t/defaultapisidebar-apiref-and-groupdata/40210/18, specifically:

> “Image Capture API”, “Media Source Extensions”, and “WebVTT” all have overview pages but the implicit name-derived links are incorrect, so this can be fixed just by giving them explicit overview properties.

To test it:

1. get a local Kuma running, using the original version of GroupData.json (e.g. mdn/kumascript/master)

2. scrape the relevant documents into your local Kuma:

```
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Image_Capture_API
```

3. visit http://localhost:8000/en-US/docs/Web/API and observe that the following links are red:
* Image Capture API
* Media Source Extensions
* WebVTT

4. check out the branch containing this PR, and refresh your KS with `docker-compose restart`

5. shift-refesh http://localhost:8000/en-US/docs/Web/API  and observe that those three links are now blue

