### PR TITLE
Make ListGroups omit groups that don't contain an overview property

### DIFF
--- a/macros/ListGroups.ejs
+++ b/macros/ListGroups.ejs
@@ -42,13 +42,12 @@ for(let name of groupNames) {
   let groupObj = groupData[name];
   let firstLetter = name[0];
   let groupOutput = '';
-  let overviewName = name;
   let badge = "";
 
-  if (groupObj.hasOwnProperty("overview")) {
-    overviewName = groupObj.overview;
+  if (groupObj.overview === undefined) {
+    continue;
   }
-
+  let overviewName = groupObj.overview;
   let groupUrl = APIHref + "/" + spacesToUnderscores(htmlEscape(overviewName));
   let page = await wiki.getPage(groupUrl);
 

--- a/tests/macros/ListGroups.test.js
+++ b/tests/macros/ListGroups.test.js
@@ -23,7 +23,7 @@ const groupDataFixture = fs.readFileSync(groupDataFixturePath, 'utf8');
  */
 const overviewPages = {
     '/en-US/docs/Web/API/An_overview_page_for_ATestInterface_API': { tags: ['foo', 'bar'] },
-    '/en-US/docs/Web/API/A2TestInterface': { tags: ['experimental'] },
+    '/en-US/docs/Web/API/A2TestInterface_overview': { tags: ['experimental'] },
     '/en-US/docs/Web/API/An_overview_page_for_BTestInterface_API': { tags: [] }
 }
 
@@ -35,7 +35,7 @@ const expectedHTML =
     <span>A</span>
     <ul>
         <li>
-            <a href='/en-US/docs/Web/API/A2TestInterface'>A2TestInterface</a>
+            <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
                 <span title="This is an experimental API that should not be used in production code.">
                     <i class="icon-beaker"></i>

--- a/tests/macros/fixtures/listgroups/groupdata.json
+++ b/tests/macros/fixtures/listgroups/groupdata.json
@@ -4,6 +4,9 @@
             "overview":   [ "An overview page for BTestInterface API"]
         },
         "A2TestInterface": {
+            "overview":   [ "A2TestInterface overview"]
+        },
+        "CTestInterface": {
         },
         "ATestInterface": {
             "overview":   [ "An overview page for ATestInterface API"]


### PR DESCRIPTION
This PR updates the ListGroups.ejs macro so it doesn't show groups that don't contain an `"overview"` property.

This change was previously discussed in https://discourse.mozilla.org/t/defaultapisidebar-apiref-and-groupdata/40210/18, in particular this bit:

> Another thing we could do is this. At the moment, ListGroups will use the group’s overview property to build a link, if the overview property exists. But if the overview property does not exist, ListGroups will use the group’s name to build a link (https://github.com/mdn/kumascript/blob/master/macros/ListGroups.ejs#L45-L52). This means that an author can specify the group explicitly using overview or implicitly using the group name. I think we should stop doing this, and only use overview, and update GroupData to set overview for all groups that actually have overview pages.
>
> This means ListGroups would stop showing broken links for nonexistent overview pages.
>
> Also note that this ListGroups behavior is inconsistent with APIRef and DefaultAPISidebar, which only use the overview property to get an overview URL. So making this change would make all three macros consistent, and remove a bit of obscure magic from the ListGroups macro.

The effect of this change is that:

* currently,  for all APIs that don't have overview pages (see https://github.com/mdn/sprints/issues/1537), https://developer.mozilla.org/en-US/docs/Web/API#Specifications will contain broken links
* after this change, these broken links won't be included and the page will look a little less sad.

*****

To test this change:

1. get your local Kuma running, and point it at this branch
2. scrape the Web/API page:

```
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API
```
3. refresh your KS with `docker-compose restart`
4. shift-refesh http://localhost:8000/en-US/docs/Web/API and observe that the list no longer includes any of the APIs listed in https://github.com/mdn/sprints/issues/1537



