### PR TITLE
Remove overview property for Resize Observer

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -924,7 +924,6 @@
                             "ServiceWorkerGlobalScope: pushsubscriptionchange" ]
         },
         "Resize Observer API": {
-            "overview":   [ "Resize Observer API" ],
             "interfaces": [ "ResizeObservation",
                             "ResizeObserver",
                             "ResizeObserverEntry" ],


### PR DESCRIPTION
This PR removes the "overview" property from the group entry for the Resize Observer API, which currently points to a nonexistent page and causes ListGroups to show a broken link in https://developer.mozilla.org/en-US/docs/Web/API#Specifications.

*****

To test this change:

1. get your local Kuma running, and point it at this branch
2. scrape the Web/API page:

```
docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/API
```
3. refresh your KS with `docker-compose restart`
4. shift-refesh http://localhost:8000/en-US/docs/Web/API and observe that the list no longer includes the Resize Observer API (but is otherwise the same).
