### PR TITLE
[minor] Add ref for css overflow level 4 to SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -265,8 +265,13 @@
     "status": "WD"
   },
   "CSS3 Overflow": {
-    "name": "CSS Overflow Module Level 3",
+    "name": "CSS Overflow Module Level&nbsp;3",
     "url": "https://drafts.csswg.org/css-overflow-3/",
+    "status": "WD"
+  },
+  "CSS4 Overflow": {
+    "name": "CSS Overflow Module Level&nbsp;4",
+    "url": "https://drafts.csswg.org/css-overflow-4/",
     "status": "WD"
   },
   "CSS3 Namespaces": {


### PR DESCRIPTION
Tried updating ref to css overflow level 4 in `text-overflow` doc and noticed there's no macro.

- https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow
- https://drafts.csswg.org/css-overflow-4/#text-overflow
