### PR TITLE
Add BigInt typed array types

### DIFF
--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -61,7 +61,7 @@ var groupData = {
     "Error": ["Error", "EvalError", "InternalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"],
     "Intl": ["Intl", "Collator", "DateTimeFormat", "ListFormat", "NumberFormat", "PluralRules", "RelativeTimeFormat"],
     "TypedArray": ["TypedArray", "Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
-                   "Int32Array", "Uint32Array", "Float32Array", "Float64Array"],
+                   "Int32Array", "Uint32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array"],
     "Proxy": ["Proxy", "handler"],
     "WebAssembly": ["WebAssembly", "WebAssembly.Module", "WebAssembly.Global", "WebAssembly.Instance", "WebAssembly.Memory",
                     "WebAssembly.Table", "WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError"],


### PR DESCRIPTION
These are ugly JSRef sidebar hacks introduced by me 5 years ago, but it is needed so that the sidebars on
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array and
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array

have the correct members from TypedArray, like you can see on the other typed array pages:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array

Please let me know if you could review this sprint or I will find someone else.