### PR TITLE
fix ListGroups.test.js broken by PR 1106

### DIFF
--- a/tests/macros/ListGroups.test.js
+++ b/tests/macros/ListGroups.test.js
@@ -37,7 +37,7 @@ const expectedHTML =
         <li>
             <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
-                <span title="This is an experimental API that should not be used in production code.">
+                <span title="This is an experimental API that should not be used in production code." class="icon-only-inline">
                     <i class="icon-beaker"></i>
                 </span>
             </span>


### PR DESCRIPTION
This PR fixes `tests/macros/ListGroups.test.js`, which broke when #1106 was merged.