### PR TITLE
Remove underscores in French title

### DIFF
--- a/macros/MDNSidebar.ejs
+++ b/macros/MDNSidebar.ejs
@@ -124,7 +124,7 @@ const text = mdn.localStringMap({
       "MDN_guide_for_readers": "Aides à la lecture de MDN",
       "Promote_MDN": "Promotion de MDN",
       "Send_feedback_about_MDN": "Faire un retour sur MDN",
-    "Get_started_on_MDN": "Débuter_sur_MDN",
+    "Get_started_on_MDN": "Débuter sur MDN",
     "Help_improve_MDN": "Contribuer au MDN",
       "Things_you_can_do": "Guides \"Comment faire\"",
       "Localizing_MDN": "Localiser MDN",


### PR DESCRIPTION
Remove underscores on "Débuter sur MDN" of the sidebar.
![6b7c7ea6-e504-4591-a003-5e7624e8f591](https://user-images.githubusercontent.com/18282103/58983115-59272700-87d6-11e9-9859-9b81245e90ed.png)
