### PR TITLE
Fix Indexed DB versions 1 and 2 specification URLs

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -876,7 +876,7 @@
   },
   "IndexedDB": {
     "name": "Indexed Database API",
-    "url": "https://www.w3.org/TR/IndexedDB/",
+    "url": "https://www.w3.org/TR/2015/REC-IndexedDB-20150108/",
     "status": "REC"
   },
   "IndexedDB 2": {

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -881,7 +881,7 @@
   },
   "IndexedDB 2": {
     "name": "Indexed Database API 2.0",
-    "url": "https://w3c.github.io/IndexedDB/",
+    "url": "https://www.w3.org/TR/IndexedDB-2/",
     "status": "REC"
   },
   "InputDeviceCapabilities": {


### PR DESCRIPTION
# Information
1. https://w3c.github.io/IndexedDB/ links to the latest Editor's draft and therefore probably does not belong to the MDN tables.
2. https://www.w3.org/TR/IndexedDB/ links to the latest TR (Indexed Database API 2.0 at the time of writing) so should not be used for version 1 or 2 because version 3 is underway.
3. https://www.w3.org/TR/2015/REC-IndexedDB-20150108/ is the permanent link for version 1, I did not find a more pretty link
4. https://www.w3.org/TR/2018/REC-IndexedDB-2-20180130/ is a permanent link for version 2 for sure, but I think https://www.w3.org/TR/IndexedDB-2/ is also permanent link for version 2. I chose the latter because the URL looks better.