### PR TITLE
Update SpecData status for Pointer Events API

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1071,13 +1071,13 @@
   },
   "Pointer Events": {
     "name": "Pointer Events",
-    "url": "https://www.w3.org/TR/pointerevents/",
-    "status": "REC"
+    "url": "https://www.w3.org/TR/pointerevents1/",
+    "status": "Obsolete"
   },
   "Pointer Events 2": {
     "name": "Pointer Events – Level 2",
-    "url": "https://w3c.github.io/pointerevents/",
-    "status": "WD"
+    "url": "https://www.w3.org/TR/pointerevents2/",
+    "status": "REC"
   },
   "Pointer Events 2 Ext": {
     "name": "Pointer Events - Level 2 Extensions",

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1084,6 +1084,11 @@
     "url": "https://w3c.github.io/pointerevents/extension.html",
     "status": "Draft"
   },
+  "Pointer Events 3": {
+    "name": "Pointer Events – Level 3",
+    "url": "https://w3c.github.io/pointerevents/",
+    "status": "ED"
+  },
   "Pointer Lock": {
     "name": "Pointer Lock",
     "url": "https://w3c.github.io/pointerlock/",


### PR DESCRIPTION
Pointer Events – Level 2 appears to have become a W3C reccomendation on 4 April 2019. The current editor's draft still says Level 2 at the top, it hasn't been updated to say Level 3 yet.