### PR TITLE
Add entry for CSSPseudoElement to InterfaceData macro

### DIFF
--- a/macros/InterfaceData.json
+++ b/macros/InterfaceData.json
@@ -185,6 +185,12 @@
       "inh": "CSSValue",
       "impl": []
     },
+    "CSSPseudoElement": {
+      "inh": "EventTarget",
+      "impl": [
+        "Animatable"
+      ]
+    },
     "CSSStyleDeclaration": {
       "inh": "",
       "impl": []


### PR DESCRIPTION
`CSSPseudoElement` [inherits from `EventTarget`](https://www.w3.org/TR/css-pseudo-4/#ref-for-eventtarget) and [includes `Animatable`](https://www.w3.org/TR/web-animations-1/#extensions-to-the-pseudoelement-interface).

MDN page: https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement