### PR TITLE
Fix Russian translation strings property

### DIFF
--- a/macros/LocalizationStatusInSection.ejs
+++ b/macros/LocalizationStatusInSection.ejs
@@ -196,8 +196,8 @@ var l10nStrings = mdn.localString({
     "de"   : "Strings",
     "fr"   : "Chaînes",
     "ja"   : "文字列数",
-    "ru"   : "字符串",
-    "zh-CN": ""
+    "ru"   : "Строки",
+    "zh-CN": "字符串"
 });
 
 var l10nMacroStrings = mdn.localString({


### PR DESCRIPTION
Fixed misprint from Chinese to Russian. Returned Russian translation.
It was deleted by mistake in bb6885d4