### PR TITLE
Added XSLT specifications to SpecData macro

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1664,16 +1664,6 @@
     "url": "https://www.w3.org/TR/xpath-31/",
     "status": "REC"
   },
-  "XSLT 1.0": {
-    "name": "XSLT 1.0",
-    "url": "https://www.w3.org/TR/xslt-10/",
-    "status": "REC"
-  },
-  "XSLT 2.0": {
-    "name": "XSLT 2.0",
-    "url": "https://www.w3.org/TR/xslt20/",
-    "status": "REC"
-  },
   "XSLT 3.0": {
     "name": "XSLT 3.0",
     "url": "https://www.w3.org/TR/xslt-30/",

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1663,5 +1663,20 @@
     "name": "XPath 3.1",
     "url": "https://www.w3.org/TR/xpath-31/",
     "status": "REC"
+  },
+  "XSLT 1.0": {
+    "name": "XSLT 1.0",
+    "url": "https://www.w3.org/TR/xslt-10/",
+    "status": "REC"
+  },
+  "XSLT 2.0": {
+    "name": "XSLT 2.0",
+    "url": "https://www.w3.org/TR/xslt20/",
+    "status": "REC"
+  },
+  "XSLT 3.0": {
+    "name": "XSLT 3.0",
+    "url": "https://www.w3.org/TR/xslt-30/",
+    "status": "REC"
   }
 }


### PR DESCRIPTION
As the title says, this adds the three XSLT specifications released so far. See https://www.w3.org/TR/?title=xsl%20transformations.

There's actually a fourth one called ["XSL Transformations (XSLT) Version 2.0 (Second Edition)"](https://www.w3.org/TR/2009/PER-xslt20-20090421/), but it looks like it never reached the recommendation status.

Also, I used the short names for those specs like it's done for other specifications. "XSLT 3.0" is just easier recognizible than "XSL Transformations (XSLT) Version 3.0".

Sebastian