### PR TITLE
Add option to automatically insert BCD table section header

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -8,6 +8,9 @@ Parameters
 $0 – A query string indicating for which feature to retrieve compat data for.
 $1 – A depth setting indicating how deep sub features should be added to the table
 (flattened, default: 1, first level of sub feature data will be included).
+$2 - An optinal boolean indicating whether to add section header before the table,
+(boolean, default: false. The section header is a translated eqivalent of
+<h2 id="Browser_compatibility">Browser compatibility</h2>
 
 Example calls
 
@@ -33,6 +36,7 @@ Example calls
 const bcd = require('@mdn/browser-compat-data');
 var query = $0;
 var depth = $1 || 1;
+const displayHeader = $2 === true;
 var output = '';
 var category = query.split(".")[0];
 var legendItems = new Set(); // entries will be unique
@@ -42,6 +46,76 @@ var localize = mdn.getLocalString;
 
 var s_no_data_found = mdn.localString({
   'en-US': `No compatibility data found. Please contribute data for "${query}" (depth: ${depth}) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.`
+});
+
+/*
+ * TODO: move this to the MDN localization infrastructure.
+ */
+var sectionHeaderTextLocal = mdn.localString({
+  'en-US': 'Browser compatibility',
+  'de': 'Browserkompatibilität',
+  'es': 'Tabla de compabilidad de navegadores',
+  'fr': 'Tableau de compatibilité',
+  'ja': 'ブラウザー実装状況',
+//    'ka': '',
+//    'ko': '',
+//    'ms': '',
+//    'nl': '',
+//    'pl': '',
+//    'ro': '',
+  'ru': 'Поддержка браузерами', // таблицa совместимости
+//    'sq': '',
+//    'th': '',
+//    'tr': '',
+//    'vi': '',
+//    'bn-BD': '',
+//    'fy-NL': '',
+//    'ga-IE': '',
+    'pt-BR': 'Tabela de compatibilidade entre Navegadores',
+//    'pt-PT': '',
+    'zh-CN': '浏览器兼容性表格',
+    'zh-TW': '兼容表格'
+});
+
+/*
+ * TODO: move this to the MDN localization infrastructure.
+ * Note: these values should match href attributes from ./SeeCompatTable.ejs,
+ * if those are declared in str.
+ */
+var sectionHeaderIdLocal = mdn.localString({
+//  'ca': 'Browser_compatibility',
+//  'cs': 'Browser_compatibility',
+  'de': 'Browser_compatibility',
+//    'el': 'Browser_compatibility',
+  'es': 'Browser_compatibility',
+//    'fa': 'Browser_compatibility',
+//    'fi': 'Browser_compatibility',
+  'fr': 'Compatibilité_des_navigateurs',
+//    'he': 'Browser_compatibility',
+//    'hr': 'Browser_compatibility',
+//    'hu': 'Browser_compatibility',
+//    'id': 'Browser_compatibility',
+//    'it': 'Browser_compatibility',
+  'ja': 'Browser_compatibility',
+//    'ka': 'Browser_compatibility',
+//    'ko': 'Browser_compatibility',
+//    'ms': 'Browser_compatibility',
+//    'nl': 'Browser_compatibility',
+//    'pl': 'Browser_compatibility',
+//    'ro': 'Browser_compatibility',
+  'ru': 'Browser_compatibility',
+//    'sq': 'Browser_compatibility',
+//    'th': 'Browser_compatibility',
+//    'tr': 'Browser_compatibility',
+//    'vi': 'Browser_compatibility',
+//    'bn-BD': 'Browser_compatibility',
+//    'fy-NL': 'Browser_compatibility',
+//    'ga-IE': 'Browser_compatibility',
+  'pt-BR': 'Compatibilidade_de_navegadores',
+//    'pt-PT': 'Browser_compatibility',
+  'zh-CN': 'Browser_compatibility',
+  'zh-TW': 'Browser_compatibility',
+  'en-US': 'Browser_compatibility'
 });
 
 const browsers = {
@@ -65,6 +139,19 @@ if (category === 'webextensions') {
   bcCategory = 'ext';
   displayBrowsers = [...browsers["webextensions-desktop"], ...browsers["webextensions-mobile"]];
   platforms = ['webextensions-desktop', 'webextensions-mobile'];
+}
+
+/**
+ * Writes the localized section header with the appropriate id
+ */
+function writeSectionHeader() {
+    let output = '';
+
+    if (displayHeader === true) {
+        output += `<h2 id="${sectionHeaderIdLocal}">${sectionHeaderTextLocal}</h2>`
+    }
+
+    return output;
 }
 
 /**
@@ -698,7 +785,8 @@ if (!compatData) {
 traverseFeatures(compatData, depth, '');
 
 if (features.length > 0) {
-    output = `<div class="bc-data" id="bcd:${query}">`;
+    output = writeSectionHeader();
+    output += '<div class="bc-data" id="bcd:${query}">';
     output += '<a class="bc-github-link" href="https://github.com/mdn/browser-compat-data">Update compatibility data on GitHub</a>';
     output += `<table class="bc-table bc-table-${bcCategory}">`;
     output += writeCompatHead();

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -50,6 +50,36 @@ describeMacro('Compat', function() {
         expect(lintHTML(result)).toBeFalsy();
     });
 
+    itMacro(
+        'Creates correct section header for the API data table',
+        function(macro) {
+            return macro.call('api.feature', 1, true).then(function(result) {
+                let dom = JSDOM.fragment(result);
+                const header = dom.querySelector('h2');
+                assert.equal(
+                    header.id,
+                    'Browser_compatibility'
+                );
+                assert.equal(
+                    header.textContent,
+                    'Browser compatibility'
+                );
+            });
+        }
+    );
+    itMacro(
+        'Does not insert section header by default',
+        function(macro) {
+            return macro.call('api.feature').then(function(result) {
+                let dom = JSDOM.fragment(result);
+                assert.equal(
+                    dom.querySelector('h2'),
+                    null
+                );
+            });
+        }
+    );
+
     // Different content areas have different platforms (desktop, mobile, server)
     // which consist of different browsers
     // Tests content_areas.json


### PR DESCRIPTION
Fixes #1177.

## Summary
Add option for `Compat` macro to automatically insert section header. Off by default for backward compatibility.

This PR might require some more work to get it perfect. See the end of the post.

## Motivation
### Broken links
The [`{{SeeCompatTable}}`](https://github.com/mdn/kumascript/blob/master/macros/SeeCompatTable.ejs) macro inserts a link to the compatibility table, assuming a specific id (see macro for details). Unfortunately, translators almost never use the proper id (they just create a `<h2>` and its id is automatically set to header text with spaces replaced with underscores), which breaks these links. So far, I haven't seen a page with this link working.
### Consistency
During localization, contributors have to choose how to name the BCD table section. This is rather a trivial choice, but many contributors pick a different translation. This looks unaesthetic and unprofessional, even ad-hock.
### Less markup, even for en-US locale
Currently, contributors have to write:
```
<h2 id="Browser_compatibility">Browser compatibility</h2>
<p>{{Compat("api.HTMLElement.innerText")}}</p>
```
This PR allows to write just:
```
<p>{{Compat("api.HTMLElement.innerText", 1, true)}}</p>
```

## Backwards compatibility
This PR is entirely backward-compatible. It introduces a third argument, optional boolean that defaults to `false` which means "do nothing". If the boolean is set to true, it creates a section header with proper id.

### Implementation details
As you see, this is a very straight-forward edit: just add `<h2 id="${sectionHeaderIdLocal}">${sectionHeaderTextLocal}</h2>`, the rest will be done by front-end JS.

## Translations
I used the ids from the `{{SeeCompatTable}}` to fix the links.
I don't know languages other than English and Russian so I just copied the "Browser compatibility" translations from the links and translated pages.