### PR TITLE
adding conditional level 4 spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -379,6 +379,11 @@
     "url": "https://drafts.csswg.org/css-color/",
     "status": "WD"
   },
+  "CSS4 Conditional": {
+    "name": "CSS Conditional Rules Module Level&nbsp;4",
+    "url": "https://drafts.csswg.org/css-conditional-4/",
+    "status": "ED"
+  },
   "CSS4 Fonts": {
     "name": "CSS Fonts Module Level&nbsp;4",
     "url": "https://drafts.csswg.org/css-fonts-4/",


### PR DESCRIPTION
Adding the CSS Conditional Level 4 spec: https://drafts.csswg.org/css-conditional-4/

Needed in order to update the selector support in `@supports`, which is shippin gin Firefox 69.