### PR TITLE
Add responsive design article to learning area sidebar

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -101,6 +101,7 @@ var text = mdn.localStringMap({
         'Floats': 'Floats',
         'Positioning': 'Positioning',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension' : 'Fundamental Layout Comprehension',
@@ -304,6 +305,7 @@ var text = mdn.localStringMap({
         'Floats': 'Float',
         'Positioning': 'Positionierung',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -507,6 +509,7 @@ var text = mdn.localStringMap({
         'Floats': '"Floats" - Flutuando elementos',
         'Positioning': 'Posicionamento',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -692,6 +695,7 @@ var text = mdn.localStringMap({
         'Floats': 'Float',
         'Positioning': 'Позиционирование',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -872,6 +876,7 @@ var text = mdn.localStringMap({
         'Floats': '浮动',
         'Positioning': '定位',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -1056,6 +1061,7 @@ var text = mdn.localStringMap({
         'Floats': '浮動',
         'Positioning': '定位',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -1262,6 +1268,7 @@ var text = mdn.localStringMap({
         'Floats': 'Floats',
         'Positioning': 'Positioning',
         'Multiple-column_Layout': 'Multiple-column Layout',
+        'Responsive_design': 'Responsive design',
         'Legacy_Layout_Methods': 'Legacy Layout Methods',
         'Supporting_Older_Browsers': 'Supporting Older Browsers',
         'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
@@ -1521,6 +1528,7 @@ var text = mdn.localStringMap({
             <li><a href="<%=baseURL%>CSS/CSS_layout/Floats"><%=text['Floats']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Positioning"><%=text['Positioning']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Multiple-column_Layout"><%=text['Multiple-column_Layout']%></a></li>
+            <li><a href="<%=baseURL%>CSS/CSS_layout/Responsive_Design"><%=text['Responsive_design']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Legacy_Layout_Methods"><%=text['Legacy_Layout_Methods']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Supporting_Older_Browsers"><%=text['Supporting_Older_Browsers']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Fundamental_Layout_Comprehension"><%=text['Fundamental_Layout_Comprehension']%></a></li>


### PR DESCRIPTION
This PR adds a link to Rachel Andrew's new [Responsive design](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design) article to the appropriate place in the learning area sidebar.

I've tested this in my local Kuma instance, and it works fine.

Page was scraped into the local environment using `docker exec kuma_worker_1 python ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design
`