### PR TITLE
updating resize observer groupdata

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -953,6 +953,7 @@
                             "ServiceWorkerGlobalScope: pushsubscriptionchange" ]
         },
         "Resize Observer API": {
+            "overview":   [ "Resize Observer API" ],
             "interfaces": [ "ResizeObserver",
                             "ResizeObserverEntry" ],
             "methods":    [],

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -953,13 +953,11 @@
                             "ServiceWorkerGlobalScope: pushsubscriptionchange" ]
         },
         "Resize Observer API": {
-            "interfaces": [ "ResizeObservation",
-                            "ResizeObserver",
+            "interfaces": [ "ResizeObserver",
                             "ResizeObserverEntry" ],
             "methods":    [],
             "properties": [],
-            "events":     [],
-            "callbacks":  [ "ResizeObserverCallback" ]
+            "events":     []
         },
         "Resource Timing API": {
             "overview":   [ "Resource Timing API" ],


### PR DESCRIPTION
This PR does tow things, both related to the GroupData for Resize Observer API:

1. Removes ResizeObservation form the list of interfaces. As per https://drafts.csswg.org/resize-observer/#resize-observation-interface, it is an internal object not exposes to JavaScript, so there is no point including it in MDN docs.
2. Removes the ResizeObserverCallback. We can argue about this later, but I need to get this documented quickly, and I really don't see the point in having a separate page for the callback, which is really part of the constructor and won't be used anywhere else.