### PR TITLE
fix: Make `require(…)` function in macros relative to `macroDirectory`

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -140,7 +140,9 @@ class Environment {
          * @type {NodeRequireFunction}
          */
         // TODO: This doesn't support macros in sub-directories
-        globals.require = createRequireFromPath(this.templates.macroDirectory);
+        globals.require = createRequireFromPath(
+            (templates && templates.macroDirectory) || `${__dirname}/../macros`
+        );
 
         this.prototypeEnvironment = freeze(globals);
     }

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,4 +1,23 @@
 /**
+ * @prettier
+ */
+const { createRequireFromPath } = require('module');
+
+const kumaPrototype = require('./api/kuma.js');
+const mdnPrototype = require('./api/mdn.js');
+const stringPrototype = require('./api/string.js');
+const wikiPrototype = require('./api/wiki.js');
+const uriPrototype = require('./api/uri.js');
+const webPrototype = require('./api/web.js');
+const pagePrototype = require('./api/page.js');
+
+/**
+ * The properties of this object will be globals in the macro
+ * execution environment.
+ */
+const globalsPrototype = {};
+
+/**
  * An Environment object defines the API available to KumaScript macros
  * through the MDN, wiki, page and other global objects. When you create
  * an Environment object, pass an object that defines the per-page
@@ -15,36 +34,7 @@
  * of that execution environment. Because the functions will all be bound
  * (see the prepareProto() function at the end of this file) they can not
  * use `this` to refer to the objects in which they are actually defined.
- *
- * TODO(djf): The *Prototype objects could each be defined in a
- * separate src/api/*.js file and imported with require(). That would
- * be tidier, and would keep separate the code with poor test coverage
- * from the rest of the file which is well tested.
- *
- * @prettier
  */
-
-// The properties of this object will be globals in the macro
-// execution environment.
-const globalsPrototype = {
-    /**
-     * #### require(name)
-     *
-     * Load an npm package (the real "require" has its own cache).
-     *
-     * @type {NodeRequireFunction}
-     */
-    require: require
-};
-
-const kumaPrototype = require('./api/kuma.js');
-const mdnPrototype = require('./api/mdn.js');
-const stringPrototype = require('./api/string.js');
-const wikiPrototype = require('./api/wiki.js');
-const uriPrototype = require('./api/uri.js');
-const webPrototype = require('./api/web.js');
-const pagePrototype = require('./api/page.js');
-
 class Environment {
     // Intialize an environment object that will be used to render
     // all of the macros in one document or page. We pass in a context
@@ -103,6 +93,7 @@ class Environment {
             return freeze(p);
         }
 
+        /** @type {import('./templates.js')} */
         this.templates = templates;
         let globals = Object.create(prepareProto(globalsPrototype));
 
@@ -140,6 +131,16 @@ class Environment {
         // implement on globalsPrototype because it needs acccess to
         // this.templates.
         globals.template = this._renderTemplate.bind(this);
+
+        /**
+         * #### require(name)
+         *
+         * Load an npm package (the real "require" has its own cache).
+         *
+         * @type {NodeRequireFunction}
+         */
+        // TODO: This doesn't support macros in sub-directories
+        globals.require = createRequireFromPath(this.templates.macroDirectory);
 
         this.prototypeEnvironment = freeze(globals);
     }

--- a/tests/environment.test.js
+++ b/tests/environment.test.js
@@ -30,7 +30,6 @@ const expectedObjects = [
 
 const expectedFunctions = [
     'require',
-    'Require',
     'template',
 
     'kuma.htmlEscape',


### PR DESCRIPTION
Currently, the only occurrences of `require(…)` in macros are used to import the `mdn‑data` and `mdn‑browser‑compat‑data` packages, so this isn’t a breaking change that would affect anything.

It also makes relative `require(…)` work the way people expect (except for sub‑directories, which is a bit more complex), rather than requiring relative to `environment.js`.

I’ve also removed uppercase `Require`, as it’s completely unused in macros and it’s a legacy pattern I don’t want to support.

---

review?(@davidflanagan, @Elchi3, @escattone, @peterbe)