### PR TITLE
feat(macros/Compat): Process MDN links in notes

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -31,6 +31,7 @@ Example calls
 */
 
 const bcd = require('mdn-browser-compat-data');
+const posthtml = require('posthtml')([posthtmlProcessMdnLinks]);
 var query = $0;
 var depth = $1 || 1;
 var output = '';
@@ -102,6 +103,25 @@ function writeIcon(iconSlug, replacer, isLegend) {
   return output;
 }
 
+/**
+ * @param {string} url Must be a URL linking to a page on MDN
+ * @return {string} Returns the relative MDN URL, or the empty string
+ *                  if the URL would link to the current page.
+ */
+function processMdnUrl(url) {
+    let href = url.replace('https://developer.mozilla.org', '');
+    if (url.includes('#') && href.split('#')[0] === '/docs/' + env.slug) {
+        href = url.substring(url.indexOf('#'))
+    }
+    if (href === '/docs/' + env.slug) {
+        return '';
+    }
+    if (href[0] === '/') {
+        href = '/' + env.locale + href;
+    }
+    return href;
+}
+
 function writeFeatureName(row, feature) {
   let desc = '';
   let featureIcons = '';
@@ -123,12 +143,8 @@ function writeFeatureName(row, feature) {
   }
   // Add relative MDN url, but don't link to the current page
   if (feature.mdn_url) {
-    let href = feature.mdn_url.replace('https://developer.mozilla.org', '');
-    if (feature.mdn_url.includes('#') && href.split('#')[0] === '/docs/' + env.slug) {
-      href = feature.mdn_url.substring(feature.mdn_url.indexOf('#'))
-    }
-    if (href !== '/docs/' + env.slug) {
-      if (href[0] === '/') href = '/' + env.locale + href;
+    let href = processMdnUrl(feature.mdn_url);
+    if (href) {
       desc = `<a href="${href}">${desc}</a>`;
     }
   }
@@ -394,6 +410,23 @@ function writeCellIcons(support) {
   return output;
 }
 
+function posthtmlProcessMdnLinks(tree) {
+    tree.match({ tag: 'a' }, node => {
+        let {attrs} = node;
+        let {href} = attrs;
+
+        if (href) {
+            attrs.href = processMdnUrl(href);
+        }
+
+        return node;
+    })
+}
+
+function processHtmlStringWithMdnUrls(html) {
+    return posthtml.process(html, {sync: true}).html;
+}
+
 /*
 Create notes section
 
@@ -434,13 +467,13 @@ function writeNotes(support, browserId) {
         for (let note of support.notes) {
           notes.push({
             icon: writeIcon('footnote'),
-            text: note
+            text: processHtmlStringWithMdnUrls(note)
           });
         }
       } else {
         notes.push({
           icon: writeIcon('footnote'),
-          text: support.notes
+          text: processHtmlStringWithMdnUrls(support.notes)
         });
       }
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1466,6 +1466,32 @@
                 "esutils": "^2.0.2"
             }
         },
+        "dom-serializer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+            "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+                },
+                "entities": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+                    "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
         "domexception": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1473,6 +1499,23 @@
             "dev": true,
             "requires": {
                 "webidl-conversions": "^4.0.2"
+            }
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "double-ended-queue": {
@@ -1509,6 +1552,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -2928,6 +2976,31 @@
             "dev": true,
             "requires": {
                 "whatwg-encoding": "^1.0.1"
+            }
+        },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "http-errors": {
@@ -4483,8 +4556,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -4829,6 +4901,29 @@
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
+        },
+        "posthtml": {
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
+            "integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
+            "requires": {
+                "posthtml-parser": "^0.4.1",
+                "posthtml-render": "^1.1.5"
+            }
+        },
+        "posthtml-parser": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.1.tgz",
+            "integrity": "sha512-h7vXIQ21Ikz2w5wPClPakNP6mJeJCK6BT0GpqnQrNNABdR7/TchNlFyryL1Bz6Ww53YWCKkr6tdZuHlxY1AVdQ==",
+            "requires": {
+                "htmlparser2": "^3.9.2",
+                "object-assign": "^4.1.1"
+            }
+        },
+        "posthtml-render": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.5.tgz",
+            "integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w=="
         },
         "prelude-ls": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "mdn-data": "2.x",
         "morgan": "1.9.1",
         "newrelic": "5.9.0",
+        "posthtml": "^0.11.6",
         "redis": "^2.8.0",
         "request": "2.88.0"
     },

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -28,7 +28,7 @@ fs.readdirSync(fixture_dir).forEach(function(fn) {
 
 describeMacro('Compat', function() {
     beforeEachMacro(function(macro) {
-        macro.ctx.require = jest.fn(pkg => fixtureCompatData);
+        jest.setMock('mdn-browser-compat-data', fixtureCompatData);
 
         /*        macro.ctx.require = sinon.stub();
         macro.ctx.require.withArgs('mdn-browser-compat-data').returns(fixtureCompatData);
@@ -752,6 +752,26 @@ describeMacro('Compat', function() {
                     ),
                     'ic-footnote'
                 );
+            });
+        }
+    );
+    itMacro(
+        'Links in notes are correctly processed',
+        function(macro) {
+            macro.ctx.env.slug = 'Notes/Feature';
+            return macro.call('notes.feature').then(function(result) {
+                let dom = JSDOM.fragment(result);
+                let anchors = Array.from(dom.querySelectorAll('.bc-browser-opera > .bc-history > dl > dd > a'));
+                expect(anchors).toHaveLength(3);
+
+                expect(anchors[0].getAttribute('href')).toEqual('/en-US/docs/Sandbox');
+                expect(anchors[0]).toHaveProperty('textContent', 'with link');
+
+                expect(anchors[1].getAttribute('href')).toBeFalsy();
+                expect(anchors[1]).toHaveProperty('textContent', 'with link to self')
+
+				expect(anchors[2].getAttribute('href')).toEqual('#Anchor');
+                expect(anchors[2]).toHaveProperty('textContent', 'with link to anchor on self');
             });
         }
     );

--- a/tests/macros/fixtures/compat/notes.json
+++ b/tests/macros/fixtures/compat/notes.json
@@ -26,6 +26,19 @@
                                 "Array note 2 in second support range: Currently supported only by Google Daydream."
                             ]
                         }
+                    ],
+                    "opera": [
+                        {
+                            "version_added": "15",
+                            "notes": "Simple note <a href='https://developer.mozilla.org/docs/Sandbox'>with link</a>"
+                        },
+                        {
+                            "version_added": "15",
+                            "notes": [
+                                "Array note 1 <a href='https://developer.mozilla.org/docs/Notes/Feature'>with link to self</a>",
+                                "Array note 2 <a href='https://developer.mozilla.org/docs/Notes/Feature#Anchor'>with link to anchor on self</a>"
+                            ]
+                        }
                     ]
                 }
             }


### PR DESCRIPTION
Follow‑up to #1085, this applies MDN URL handling to MDN links in notes as well by using PostHTML, which is a lightweight HTML parsing and transformation library.