### PR TITLE
Add History API sidebar to GroupData.json

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -458,6 +458,17 @@
             "properties": [],
             "events":     []
         },
+        "History API": {
+          "overview": [
+            "Performance API"
+          ],
+          "interfaces": [
+            "History"
+          ],
+          "methods": [],
+          "properties": [],
+          "events": []
+        },
         "HTML DOM": {
             "interfaces": [ "BeforeUnloadEvent",
                             "DOMStringMap",

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -460,7 +460,7 @@
         },
         "History API": {
           "overview": [
-            "Performance API"
+            "History API"
           ],
           "interfaces": [
             "History"


### PR DESCRIPTION
Adding the History API to the sidebar. Per [mdn/sprints 1892](https://app.zenhub.com/workspaces/mdn-sprint-board-5ab3d23fd0f4ea53b0022a61/issues/mdn/sprints/1892)

This will add the History API items to thestandard sidebar.