### PR TITLE
feat(macros): Add {{EmbedTest262ReportResultsTable($0)}} to enable embeds of Test262.report results

### DIFF
--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -2,11 +2,12 @@
 // Embeds a Test262.report results table
 //
 // Parameters:
-//  $0 - An embed URL from test262.report (absolute)
-//  Example call {{EmbedTest262ReportResultsTable("https://test262.report/embed/features/globalThis?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true")}}
+//  $0 - An embed URL from test262.report (relative)
+//
+//  Example call {{EmbedTest262ReportResultsTable("/features/globalThis?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true")}}
 //
 
-var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="' + $0 + '"></iframe>';
+var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="https://test262.report/embed' + $0 + '"></iframe>';
 
 %>
 <%- str %>

--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -2,12 +2,14 @@
 // Embeds a Test262.report results table
 //
 // Parameters:
-//  $0 - An embed URL from test262.report (relative)
+//  $0 - A "feature" name from test262.report
 //
-//  Example call {{EmbedTest262ReportResultsTable("/features/globalThis?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true")}}
+//  Example calls:
+// {{EmbedTest262ReportResultsTable("globalThis")}}
+// {{EmbedTest262ReportResultsTable("BigInt")}}
 //
 
-var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="https://test262.report/embed' + $0 + '"></iframe>';
+var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="https://test262.report/embed/features/' + $0 + '?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>';
 
 %>
 <%- str %>

--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -8,8 +8,5 @@
 // {{EmbedTest262ReportResultsTable("globalThis")}}
 // {{EmbedTest262ReportResultsTable("BigInt")}}
 //
-
-var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="https://test262.report/embed/features/' + $0 + '?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>';
-
 %>
-<%- str %>
+<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;" src="https://test262.report/embed/features/<%= $0 %>?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>

--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -9,4 +9,4 @@
 // {{EmbedTest262ReportResultsTable("BigInt")}}
 //
 %>
-<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;" src="https://test262.report/embed/features/<%-encodeURIComponent($0)%>?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>
+<iframe width="100%" height="300" src="https://test262.report/embed/features/<%-encodeURIComponent($0)%>?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>

--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -9,4 +9,4 @@
 // {{EmbedTest262ReportResultsTable("BigInt")}}
 //
 %>
-<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;" src="https://test262.report/embed/features/<%= $0 %>?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>
+<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;" src="https://test262.report/embed/features/<%-encodeURIComponent($0)%>?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>

--- a/macros/EmbedTest262ReportResultsTable.ejs
+++ b/macros/EmbedTest262ReportResultsTable.ejs
@@ -1,0 +1,12 @@
+<%
+// Embeds a Test262.report results table
+//
+// Parameters:
+//  $0 - An embed URL from test262.report (absolute)
+//  Example call {{EmbedTest262ReportResultsTable("https://test262.report/embed/features/globalThis?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true")}}
+//
+
+var str = '<iframe frameborder="0" scrolling="no" style="width:100%;height:300px;" src="' + $0 + '"></iframe>';
+
+%>
+<%- str %>

--- a/tests/macros/EmbedTest262ReportResultsTable.test.js
+++ b/tests/macros/EmbedTest262ReportResultsTable.test.js
@@ -25,4 +25,11 @@ describeMacro('EmbedTest262ReportResultsTable', function() {
             ' src="https://test262.report/embed/features/dynamic-import?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
         );
     });
+    itMacro('Feature Tag: Encoded with encodeURIComponent()', function(macro) {
+        return assert.eventually.equal(
+            macro.call('?dynamic=import/foo&bar'),
+            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            ' src="https://test262.report/embed/features/%3Fdynamic%3Dimport%2Ffoo%26bar?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
+        );
+    });
 });

--- a/tests/macros/EmbedTest262ReportResultsTable.test.js
+++ b/tests/macros/EmbedTest262ReportResultsTable.test.js
@@ -7,28 +7,28 @@ describeMacro('EmbedTest262ReportResultsTable', function() {
     itMacro('Feature Tag: No non-alphabet characters', function(macro) {
         return assert.eventually.equal(
             macro.call('BigInt'),
-            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            '<iframe width="100%" height="300"' +
             ' src="https://test262.report/embed/features/BigInt?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
         );
     });
     itMacro('Feature Tag: Has a "."', function(macro) {
         return assert.eventually.equal(
             macro.call('Object.fromEntries'),
-            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            '<iframe width="100%" height="300"' +
             ' src="https://test262.report/embed/features/Object.fromEntries?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
         );
     });
     itMacro('Feature Tag: Has a "-"', function(macro) {
         return assert.eventually.equal(
             macro.call('dynamic-import'),
-            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            '<iframe width="100%" height="300"' +
             ' src="https://test262.report/embed/features/dynamic-import?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
         );
     });
     itMacro('Feature Tag: Encoded with encodeURIComponent()', function(macro) {
         return assert.eventually.equal(
             macro.call('?dynamic=import/foo&bar'),
-            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            '<iframe width="100%" height="300"' +
             ' src="https://test262.report/embed/features/%3Fdynamic%3Dimport%2Ffoo%26bar?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
         );
     });

--- a/tests/macros/EmbedTest262ReportResultsTable.test.js
+++ b/tests/macros/EmbedTest262ReportResultsTable.test.js
@@ -1,0 +1,28 @@
+/**
+ * @prettier
+ */
+const { assert, itMacro, describeMacro } = require('./utils');
+
+describeMacro('EmbedTest262ReportResultsTable', function() {
+    itMacro('Feature Tag: No non-alphabet characters', function(macro) {
+        return assert.eventually.equal(
+            macro.call('BigInt'),
+            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            ' src="https://test262.report/embed/features/BigInt?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
+        );
+    });
+    itMacro('Feature Tag: Has a "."', function(macro) {
+        return assert.eventually.equal(
+            macro.call('Object.fromEntries'),
+            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            ' src="https://test262.report/embed/features/Object.fromEntries?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
+        );
+    });
+    itMacro('Feature Tag: Has a "-"', function(macro) {
+        return assert.eventually.equal(
+            macro.call('dynamic-import'),
+            '<iframe frameborder="0" scrolling="no" style="width: 100%; height: 300px;"' +
+            ' src="https://test262.report/embed/features/dynamic-import?engines=chakra%2Cjavascriptcore%2Cspidermonkey%2Cv8&summary=true&include-browsers=true"></iframe>'
+        );
+    });
+});


### PR DESCRIPTION
@Elchi3 instructed me to create and submit a macro for this new feature that we're testing. We're expecting to announce it on October 1st. 

 Here's what the embed looks like: 

![image](https://user-images.githubusercontent.com/27985/65447280-2dbb5d00-de04-11e9-9044-88624e140340.png)

And in place: 

![image](https://user-images.githubusercontent.com/27985/65447270-285e1280-de04-11e9-83e6-d7dba85df3e4.png)

The strange gray background will be fixed and deployed by Wednesday of this week. 
