### PR TITLE
Reveal BCD ID in rendered HTML

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -698,7 +698,7 @@ if (!compatData) {
 traverseFeatures(compatData, depth, '');
 
 if (features.length > 0) {
-    output = `<div class="bc-data" data-bcd-id="{identifier}">`;
+    output = `<div class="bc-data" data-id="{query}">`;
     output += '<a class="bc-github-link" href="https://github.com/mdn/browser-compat-data">Update compatibility data on GitHub</a>';
     output += `<table class="bc-table bc-table-${bcCategory}">`;
     output += writeCompatHead();

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -698,7 +698,7 @@ if (!compatData) {
 traverseFeatures(compatData, depth, '');
 
 if (features.length > 0) {
-    output = '<div class="bc-data">';
+    output = `<div class="bc-data" data-bcd-id="{identifier}">`;
     output += '<a class="bc-github-link" href="https://github.com/mdn/browser-compat-data">Update compatibility data on GitHub</a>';
     output += `<table class="bc-table bc-table-${bcCategory}">`;
     output += writeCompatHead();

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -698,7 +698,7 @@ if (!compatData) {
 traverseFeatures(compatData, depth, '');
 
 if (features.length > 0) {
-    output = `<div class="bc-data" data-id="{query}">`;
+    output = `<div class="bc-data" id="bcd:${query}">`;
     output += '<a class="bc-github-link" href="https://github.com/mdn/browser-compat-data">Update compatibility data on GitHub</a>';
     output += `<table class="bc-table bc-table-${bcCategory}">`;
     output += writeCompatHead();


### PR DESCRIPTION
Fixes #1238

I just made the change without knowing how to test this in `kuma`. Also, I don't know if `identifier` is the right string :) 
But the goal is to be able to do something like this:
```python
from pyquery import PyQuery as pq
doc = pq("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video")
for wrapper in doc('div.bcd-data').items():
    print(wrapper.data('bcd-id'))
    break
else:
    print("Has no BCD data table!")
```
and that should print the identifier that is equivalent to what we put in the front-matter of https://github.com/mdn/stumptown-content/blob/master/content/html/reference/elements/video/docs.md

PS. I don't know how to write and run unit tests for KS. 