### PR TITLE
take Kumascript Dockerfile from kuma

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,11 +40,16 @@ def lint_kumascript(docker_tag='') {
 }
 
 def image(what, docker_tag='') {
-    def what_cap = what.capitalize()
-    def tag_type = (docker_tag == '') ? 'commit-tagged' : 'latest-tagged'
-    withEnv(["KS_VERSION=${docker_tag}"]) {
-        utils.sh_with_notify("make ${what}-kumascript",
-                             "${what_cap} the ${tag_type} Kumascript image")
+    if ((what == 'build') && (docker_tag == 'all tags')) {
+        utils.sh_with_notify("make build-kumascript-with-all-tags",
+                             "Build the Kumascript image with all tags")
+    } else {
+        def what_cap = what.capitalize()
+        def tag_type = (docker_tag == '') ? 'commit-tagged' : 'latest-tagged'
+        withEnv(["KS_VERSION=${docker_tag}"]) {
+            utils.sh_with_notify("make ${what}-kumascript",
+                                 "${what_cap} the ${tag_type} Kumascript image")
+        }
     }
 }
 
@@ -76,8 +81,7 @@ node {
     switch (env.BRANCH_NAME) {
         case 'master':
             stage('Build') {
-                image('build')
-                image('build', 'latest')
+                image('build', 'all tags')
             }
             stage('Lint') {
                 lint_kumascript('latest')
@@ -85,7 +89,7 @@ node {
             stage('Test') {
                 test_kumascript('latest')
             }
-            stage('Push KumaScript Docker Image') {
+            stage('Push KumaScript Docker Images') {
                 image('push')
                 image('push', 'latest')
             }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ summary:
       for testing, you will want to run your local development version of MDN:
 
           cd ..
-          docker-compose build
+          docker-compose pull
           docker-compose up -d
           cd kumascript
 
@@ -71,7 +71,7 @@ Your pull request will be reviewed by one or more members of the MDN team, and
 if accepted, your changes will be merged into the master branch and scheduled
 for release to production.
 
-## Updating the Dockerfile and/or package.json file
+## Updating the docker/Dockerfile and/or package.json file
 
 If you update either one or both of these files, you'll need to do a little
 more before you run your local development version of MDN.
@@ -135,7 +135,7 @@ more before you run your local development version of MDN.
 
 ## Setup (Standalone)
 
-* Install [Node.js 10.x](https://nodejs.org/en/download/package-manager/)
+* Install [Node.js](https://nodejs.org/en/download/package-manager/)
 * Install the dependencies:
     * `npm install`
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:10.16.3@sha256:e0f7dabe991810057aee6ba7a7d4136fe7fc70e99235d79e6c7ae0177656a5c8
+
+RUN set -ex && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gettext \
+        mime-support \
+        build-essential \
+        python2.7 \
+        default-jre \
+    && rm -rf /var/lib/apt/lists/*
+
+# remove the node user from the base package and add a non-privileged user
+RUN userdel --force --remove node && \
+    adduser --uid 1000 --disabled-password --gecos '' --no-create-home kumascript
+
+ARG REVISION_HASH
+# make the git commit hash permanently available within this image.
+ENV REVISION_HASH $REVISION_HASH
+
+WORKDIR /
+
+COPY kumascript/package.json kumascript/npm-shrinkwrap.json /
+RUN npm config set python /usr/bin/python2.7 && \
+    # install the Node.js dependencies,
+    # with versions specified in npm-shrinkwrap.json
+    npm ci && \
+    # update any top-level npm packages listed in package.json,
+    # such as mdn-browser-compat-data,
+    # as allowed by each package's given "semver".
+    npm update
+ENV NODE_PATH=/node_modules
+RUN chown -R kumascript:kumascript $NODE_PATH
+
+# install the locale files
+WORKDIR /locale
+COPY --chown=kumascript:kumascript locale ./
+
+WORKDIR /app
+COPY --chown=kumascript:kumascript kumascript ./
+
+USER kumascript
+
+CMD ["node", "run.js"]
+
+EXPOSE 9080

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -1,0 +1,19 @@
+kumascript
+----------
+
+The kumascript Docker image contains the kumascript rendering engine and
+support files.
+
+The image must be created from the kuma repo since it depends upon that
+repo's ``locale`` sub-module. From the kuma repo's root directory, use
+``make build-kumascript`` for an image tagged with the current commit-hash,
+``make build-kumascript KS_VERSION=latest`` for one tagged with ``latest``,
+or ``make build-kumascript-with-all-tags`` for an image tagged with both.
+
+The image tagged ``latest`` is used by default for development, while an
+image tagged with a commit-hash can be used for deployment. The official
+images are created from the master branch in Jenkins__ and published to
+DockerHub__.
+
+.. __: https://ci.us-west-2.mdn.mozit.cloud/blue/organizations/jenkins/kumascript/branches/
+.. __: https://hub.docker.com/r/mdnwebdocs/kumascript/


### PR DESCRIPTION
This is a companion PR to https://github.com/mozilla/kuma/pull/5902. It should be reviewed and merged along with that PR.

This PR moves the Kumascript `Dockerfile` (and associated `README.md` file) from the Kuma repo into this repo where it belongs. It also takes advantage of the new `make build-kumascript-with-all-tags` command provided by https://github.com/mozilla/kuma/pull/5902.