### PR TITLE
add initial config for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "masterIssue": true,
+  "dockerfile": {
+    "pinDigests": true
+  },
+  "rebaseStalePrs": true,
+  "timezone": "UTC",
+  "schedule": ["before 13:00 on mondays"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [
+    "package.json"
+  ],
   "masterIssue": true,
   "dockerfile": {
     "pinDigests": true


### PR DESCRIPTION
Proposed initial config for `renovate`. `renovate` is not yet enabled for this repo, but I'd like to enable it once #1249 lands in order to pin the digests in the Dockerfile. This config also exposes `package.json` to `renovate`, but we might not want to do that yet.