### PR TITLE
Fix case mistake in GroupData entry for XDomainRequest

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1783,7 +1783,7 @@
             "callbacks":  [ "XRFrameRequestCallback" ]
         },
         "XDomain": {
-            "interfaces": [ "XDomainrequest" ],
+            "interfaces": [ "XDomainRequest" ],
             "methods":    [],
             "properties": [],
             "events":     []


### PR DESCRIPTION
Was incorrectly `XDomainrequest`.

See MDN documentation for correct case. Non-standard API, so there's no spec.