### PR TITLE
Mark HTML Imports as an obsolete spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -842,7 +842,7 @@
   "HTML Imports": {
     "name": "HTML Imports",
     "url": "https://w3c.github.io/webcomponents/spec/imports/",
-    "status": "WD"
+    "status": "Obsolete"
   },
   "HTML Media Capture": {
     "name": "HTML Media Capture",


### PR DESCRIPTION
The HTML imports spec has been abandoned, so it seems more accurate to list it as obsolete vs working draft.

I'm not sure if there is a formal tag needed for this on the W3C side before we would want to update this JSON file? But, evidence that it is obsoleted includes:

MDN's HTML imports page: https://developer.mozilla.org/en-US/docs/Web/Web_Components/HTML_Imports

Chrome's intent to remove its implementation: https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/h-JwMiPUnuU/sl79aLoLBQAJ

Mozilla's intent to not implement: https://hacks.mozilla.org/2014/12/mozilla-and-web-components/