### PR TITLE
fix bogus jest/valid-describe linting error

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -128,9 +128,9 @@
             }
         },
         "acorn-jsx": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+            "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
             "dev": true
         },
         "acorn-walk": {
@@ -1106,12 +1106,12 @@
             }
         },
         "cli-cursor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "^3.1.0"
             }
         },
         "cli-width": {
@@ -1500,9 +1500,9 @@
             "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
         "emoji-regex": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
         "encodeurl": {
@@ -1597,49 +1597,68 @@
             }
         },
         "eslint": {
-            "version": "5.16.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-            "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
+            "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.9.1",
+                "ajv": "^6.10.0",
                 "chalk": "^2.1.0",
                 "cross-spawn": "^6.0.5",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^4.0.3",
-                "eslint-utils": "^1.3.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^5.0.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^1.4.3",
+                "eslint-visitor-keys": "^1.1.0",
+                "espree": "^6.1.2",
                 "esquery": "^1.0.1",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
+                "glob-parent": "^5.0.0",
                 "globals": "^11.7.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^6.2.2",
-                "js-yaml": "^3.13.0",
+                "inquirer": "^7.0.0",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.3.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.14",
                 "minimatch": "^3.0.4",
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
-                "semver": "^5.5.1",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "^2.0.1",
+                "semver": "^6.1.2",
+                "strip-ansi": "^5.2.0",
+                "strip-json-comments": "^3.0.1",
                 "table": "^5.2.3",
-                "text-table": "^0.2.0"
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1649,11 +1668,60 @@
                         "ms": "^2.1.1"
                     }
                 },
-                "ms": {
+                "eslint-scope": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+                    "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+                    "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-extglob": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
                     "dev": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
                 }
             }
         },
@@ -1695,29 +1763,37 @@
             }
         },
         "eslint-utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^1.0.0"
+                "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
             "dev": true
         },
         "espree": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-            "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+            "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.7",
-                "acorn-jsx": "^5.0.0",
-                "eslint-visitor-keys": "^1.0.0"
+                "acorn": "^7.1.0",
+                "acorn-jsx": "^5.1.0",
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+                    "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -1916,9 +1992,9 @@
             }
         },
         "external-editor": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
             "dev": true,
             "requires": {
                 "chardet": "^0.7.0",
@@ -1983,9 +2059,9 @@
             }
         },
         "figures": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+            "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
@@ -2064,9 +2140,9 @@
             }
         },
         "flatted": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-            "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
         },
         "for-in": {
@@ -2990,9 +3066,9 @@
             "dev": true
         },
         "import-fresh": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-            "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+            "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -3031,31 +3107,57 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "inquirer": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-            "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+            "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.2.0",
+                "ansi-escapes": "^4.2.1",
                 "chalk": "^2.4.2",
-                "cli-cursor": "^2.1.0",
+                "cli-cursor": "^3.1.0",
                 "cli-width": "^2.0.0",
                 "external-editor": "^3.0.3",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.11",
-                "mute-stream": "0.0.7",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.15",
+                "mute-stream": "0.0.8",
                 "run-async": "^2.2.0",
                 "rxjs": "^6.4.0",
-                "string-width": "^2.1.0",
+                "string-width": "^4.1.0",
                 "strip-ansi": "^5.1.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+                    "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.5.2"
+                    }
+                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+                    "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^5.2.0"
+                    }
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
@@ -4277,9 +4379,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "nan": {
@@ -4591,12 +4693,20 @@
             }
         },
         "onetime": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "^2.1.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                }
             }
         },
         "optimist": {
@@ -4741,12 +4851,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "path-key": {
@@ -5208,12 +5312,12 @@
             "dev": true
         },
         "restore-cursor": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
+                "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
             }
         },
@@ -5248,9 +5352,9 @@
             }
         },
         "rxjs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-            "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+            "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -5996,9 +6100,9 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
             "dev": true
         },
         "supports-color": {
@@ -6017,21 +6121,39 @@
             "dev": true
         },
         "table": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-            "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
             "dev": true,
             "requires": {
-                "ajv": "^6.9.1",
-                "lodash": "^4.17.11",
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
                 "slice-ansi": "^2.1.0",
                 "string-width": "^3.0.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
                     "dev": true
                 },
                 "string-width": {
@@ -6182,9 +6304,9 @@
             "dev": true
         },
         "tslib": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
             "dev": true
         },
         "tunnel-agent": {
@@ -6208,6 +6330,12 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
+        },
+        "type-fest": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+            "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+            "dev": true
         },
         "type-is": {
             "version": "1.6.16",
@@ -6356,6 +6484,12 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "v8-compile-cache": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+            "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+            "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "request": "2.88.0"
     },
     "devDependencies": {
-        "eslint": "^5.16.0",
+        "eslint": "^6.6.0",
         "eslint-config-prettier": "^3.6.0",
         "eslint-plugin-jest": "^22.15.2",
         "eslint-plugin-prettier": "^3.1.0",

--- a/src/api/mdn.js
+++ b/src/api/mdn.js
@@ -69,7 +69,7 @@ module.exports = {
      *   => "Hallo!" (in case the locale is 'de')
      */
     getLocalString(strings, key) {
-        if (!strings.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(strings, key)) {
             return key;
         }
 


### PR DESCRIPTION
Fixes #1269 

Upgrading to `eslint` version `6.6.0` gets rid of the bogus error, but flags a new one . The new error seemed legit, so I fixed it. NOTE: The updates to `package.json` and `npm-shrinkwrap.json` were both done via `npm install eslint@6.6.0`.