### PR TITLE
disable flawed jest/valid-describe eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
             "args": "none",
             "varsIgnorePattern": "^_",
             "argsIgnorePattern": "^_"
-        }]
+        }],
+        "jest/valid-describe": "off"
     }
 }


### PR DESCRIPTION
Fixes #1269 

This PR disables the flawed `jest/valid-describe` eslint rule (e.g., see discussion at https://github.com/jest-community/eslint-plugin-jest/issues/203).