### PR TITLE
Adding Shapes 2, Writing Modes to PR

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -357,7 +357,7 @@
   "CSS3 Writing Modes": {
     "name": "CSS Writing Modes Module Level&nbsp;3",
     "url": "https://drafts.csswg.org/css-writing-modes-3/",
-    "status": "CR"
+    "status": "PR"
   },
   "CSS4 Backgrounds": {
     "name": "CSS Backgrounds and Borders Module Level&nbsp;4",
@@ -553,6 +553,11 @@
     "name": "CSS Shapes Module Level&nbsp;1",
     "url": "https://drafts.csswg.org/css-shapes/",
     "status": "CR"
+  },
+  "CSS Shapes 2": {
+    "name": "CSS Shapes Module Level&nbsp;2",
+    "url": "https://drafts.csswg.org/css-shapes-2/",
+    "status": "ED"
   },
   "CSS Text Size Adjust": {
     "name": "CSS Mobile Text Size Adjustment Module Level&nbsp;1",


### PR DESCRIPTION
Adding the CSS Shapes Level 2 spec: https://drafts.csswg.org/css-shapes-2

The Writing Modes spec is now a Proposed Rec: https://www.w3.org/TR/css-writing-modes-3/