### PR TITLE
Fix to update the class to remove two bins problem in obsolete header

### DIFF
--- a/macros/obsoleteGeneric.ejs
+++ b/macros/obsoleteGeneric.ejs
@@ -119,7 +119,7 @@ switch($0) {
         break;
     case 'header':
         if (string.length(tip)) { str = str + " " + tip; }
-        %><div class="blockIndicator obsolete obsoleteHeader"><p><strong><%-await template("ObsoleteBadge", [1])%> <%-str%></strong><br/><%-str_desc%></p></div><%
+        %><div class="blockIndicator obsoleteBadge obsoleteHeader"><p><strong><%-await template("ObsoleteBadge", [1])%> <%-str%></strong><br/><%-str_desc%></p></div><%
         break;
     case 'method':
         if (string.length(tip)) { str = str + " " + tip; }


### PR DESCRIPTION
**Obsolete** svg icon is calling a **mixin** that auto generates the **::before** bin to obsolete and obsoleteBadge only has the same red background
![Screenshot 2019-11-04 at 11 08 41](https://user-images.githubusercontent.com/8556085/68113240-99104880-fef3-11e9-9af6-21e8a0a4a035.png)

Before Fix
![Screenshot 2019-11-04 at 10 58 34](https://user-images.githubusercontent.com/8556085/68113018-0bccf400-fef3-11e9-8e54-641d3a852f01.png)

After fix of class

![Screenshot 2019-11-04 at 11 06 12](https://user-images.githubusercontent.com/8556085/68113107-420a7380-fef3-11e9-870e-53d76ab86871.png)


