### PR TITLE
remove explicit python from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,6 @@ RUN set -ex && \
         gettext \
         mime-support \
         build-essential \
-        python2.7 \
         default-jre \
     && rm -rf /var/lib/apt/lists/*
 
@@ -21,10 +20,7 @@ ENV REVISION_HASH $REVISION_HASH
 WORKDIR /
 
 COPY kumascript/package.json kumascript/npm-shrinkwrap.json /
-RUN npm config set python /usr/bin/python2.7 && \
-    # install the Node.js dependencies,
-    # with versions specified in npm-shrinkwrap.json
-    npm ci && \
+RUN npm ci && \
     # update any top-level npm packages listed in package.json,
     # such as mdn-browser-compat-data,
     # as allowed by each package's given "semver".


### PR DESCRIPTION
Fixes https://github.com/mdn/kumascript/issues/1274

Do not explicitly set the Python version. Use whatever comes bundled with the `node` Docker image. All of the Kuma and Kumascript tests still pass.

I just wanted to get this work submitted, since I had done it a while ago and, with everything going on, didn't want to lose it.