### PR TITLE
prepare for the 1.x releases of mdn-browser-compat-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "ejs": "2.6.1",
         "express": "4.16",
         "lru-cache": "5.1.1",
-        "mdn-browser-compat-data": "0.x",
+        "mdn-browser-compat-data": "1.x",
         "mdn-data": "2.x",
         "morgan": "1.9.1",
         "newrelic": "5.9.0",


### PR DESCRIPTION
Fixes #1279 

**NOTE: This PR will fail the Travis tests until version `1.0.0` of the [`mdn-browser-compat-data` npm package](https://www.npmjs.com/package/mdn-browser-compat-data) is released.**