### PR TITLE
Link W3C HTML5 spec reference to the latest Rec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -866,7 +866,7 @@
   },
   "HTML5 W3C": {
     "name": "HTML5",
-    "url": "https://www.w3.org/TR/html50/",
+    "url": "https://www.w3.org/TR/html52/",
     "status": "REC"
   },
   "HTML5.1": {


### PR DESCRIPTION
There is absolutely no point in linking anything to the *Superseded* version of the HTML5 spec from 2014, it can be just misleading. The latest iteration of W3C HTML5 spec is HTML5.2 Recommendation. In theory, it would be nice to link to https://w3.org/TR/html5 (which was once used for "the last HTML5 Recommendation"), but it currently redirects to the WHATWG spec (for purpose).