### PR TITLE
chore(deps): update dependency ejs to v2.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1495,9 +1495,9 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "ejs": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-            "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+            "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
         },
         "emoji-regex": {
             "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ejs": "2.6.1",
+        "ejs": "2.7.4",
         "express": "4.16",
         "lru-cache": "5.1.1",
         "mdn-browser-compat-data": "0.x",


### PR DESCRIPTION
This&nbsp;updates **EJS** to&nbsp;v2.7.14.

<!--
# ------------------------ >8 ------------------------
# Remove everything below this line from the commit message
-->

<details open>
<summary>
<h2>KumaScript affecting changes:</h2>
<table><td>
📝 <strong>Note:</strong> See&nbsp;<a href="https://github.com/mde/ejs/releases">mde/ejs@v2.7.4</a> for&nbsp;a&nbsp;full&nbsp;list of&nbsp;changes.
</td></table>
</summary>

## [v2.7.2](https://github.com/mde/ejs/releases/v2.7.2)
### Features
- Added support for destructuring locals (mde/ejs#452)
- Added support for disabling legacy `include` directives (mde/ejs#458, mde/ejs#459)
- Compiled functions are now shown in the debugger (mde/ejs#456)

### Bug Fixes
- Improved performance of HTML output generation (mde/ejs#470)

</details>

---

review?(@davidflanagan, @escattone)