### PR TITLE
Fix SpecData.json Subresource Integrity spec url

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1256,7 +1256,7 @@
   },
   "Subresource Integrity": {
     "name": "Subresource Integrity",
-    "url": "https://w3c.github.io/webappsec/specs/subresourceintegrity/",
+    "url": "https://w3c.github.io/webappsec-subresource-integrity/",
     "status": "REC"
   },
   "SVG and HTML": {


### PR DESCRIPTION
https://w3c.github.io/webappsec/specs/subresourceintegrity/ now redirects to https://w3c.github.io/webappsec-subresource-integrity/