### PR TITLE
updating geolocation api groupdata

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -430,10 +430,12 @@
                             "Window: gamepaddisconnected" ]
         },
         "Geolocation API": {
-            "interfaces": [ "Coordinates",
-                            "Geolocation",
-                            "Position",
-                            "PositionError",
+            "overview":   [ "Geolocation API" ],
+            "guides":     [ "/docs/Web/API/Geolocation_API/Using" ],
+            "interfaces": [ "Geolocation",
+                            "GeolocationCoordinates",
+                            "GeolocationPosition",
+                            "GeolocationPositionError",
                             "PositionOptions" ],
             "methods":    [],
             "properties": [ "Navigator.geolocation" ],

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -431,12 +431,12 @@
         },
         "Geolocation API": {
             "overview":   [ "Geolocation API" ],
-            "guides":     [ "/docs/Web/API/Geolocation_API/Using" ],
+            "guides":     [ "/docs/Web/API/Geolocation_API/Using_the_Geolocation_API" ],
+            "dictionaries": [ "PositionOptions" ],
             "interfaces": [ "Geolocation",
                             "GeolocationCoordinates",
                             "GeolocationPosition",
-                            "GeolocationPositionError",
-                            "PositionOptions" ],
+                            "GeolocationPositionError"],
             "methods":    [],
             "properties": [ "Navigator.geolocation" ],
             "events":     []


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1575144, geolocation has had the following interface naming updates:

 * Coordinates -> GeolocationCoordinates
 * Position -> GeolocationPosition
 * PositionError -> GeolocationPositionError

In addition, I added in the Geolocation API overview page, and linked to the "Using..." guide that I created.
