### PR TITLE
Translate WebAssembly Sidebar links to Spanish

### DIFF
--- a/macros/WebAssemblySidebar.ejs
+++ b/macros/WebAssemblySidebar.ejs
@@ -16,6 +16,20 @@ var text = mdn.localStringMap({
       'Caching_modules' : 'Caching compiled WebAssembly modules',
       'Exported_functions' : 'Exported WebAssembly functions',
     'Object_reference' : 'Object reference'
+  },
+  'es': {
+    'WebAssembly_home_page' : 'Página principal de WebAssembly',
+    'Tutorials' : 'Tutoriales',
+      'WebAssembly_concepts' : 'Conceptos de WebAssembly',
+      'Compiling_to_wasm' : 'Compilar de C/C++ a WebAssembly',
+      'Compiling_rust_to_wasm' : 'Compilar de Rust a WebAssembly',
+      'JavaScript_API' : 'Usar la API WebAssembly de JavaScript',
+      'Text_format' : 'Entendiendo el formato de texto WebAssembly',
+      'Text_format_to_wasm' : 'Convertir el formato de texto WebAssembly a wasm',
+      'Loading_and_running' : 'Cargar y ejecutar código WebAssembly',
+      'Caching_modules' : 'Almacenar módulos compilados de WebAssembly en la caché',
+      'Exported_functions' : 'Funciones exportadas de WebAssembly',
+    'Object_reference' : 'Referencia de objetos'
   }
 });
 %>


### PR DESCRIPTION
Hi!
I just translated the [WebAssembly home page to Spanish][1] and noticed that the sidebar links were still in English. I hope this is the right place to translate them.

Thanks!

[1]: https://developer.mozilla.org/es/docs/WebAssembly