### PR TITLE
Adds CSS Overflow Level 4 spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -399,6 +399,11 @@
     "url": "https://drafts.csswg.org/mediaqueries-4/",
     "status": "CR"
   },
+  "CSS4 Overflow": {
+    "name": "CSS Overflow Module Level 4",
+    "url": "https://drafts.csswg.org/css-overflow-4/",
+    "status": "WD"
+  },
   "CSS4 Pseudo-Elements": {
     "name": "CSS Pseudo-Elements Level&nbsp;4",
     "url": "https://drafts.csswg.org/css-pseudo-4/",


### PR DESCRIPTION
While working on https://github.com/mdn/sprints/issues/2402 spotted that `text-overflow` had incorrect spec links as the definitions have moved to the CSS Overflow spec, adding the new Level 4 spec to correct that.