### PR TITLE
Drop obsolete "Pointer Events 2 Ext" from SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1099,11 +1099,6 @@
     "url": "https://www.w3.org/TR/pointerevents2/",
     "status": "REC"
   },
-  "Pointer Events 2 Ext": {
-    "name": "Pointer Events - Level 2 Extensions",
-    "url": "https://w3c.github.io/pointerevents/extension.html",
-    "status": "Draft"
-  },
   "Pointer Events 3": {
     "name": "Pointer Events – Level 3",
     "url": "https://w3c.github.io/pointerevents/",


### PR DESCRIPTION
The https://w3c.github.io/pointerevents/extension.html spec is now 404; https://github.com/w3c/pointerevents/commit/add40d9 removed it from the W3C Pointer Events repo. (The content has been incorporated directly into the Pointer Events spec.)