### PR TITLE
Add CSS4 Overflow to SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -399,6 +399,11 @@
     "url": "https://drafts.csswg.org/mediaqueries-4/",
     "status": "CR"
   },
+  "CSS4 Overflow": {
+    "name": "CSS Overflow Module Level&nbsp;4",
+    "url": "https://drafts.csswg.org/css-overflow-4/",
+    "status": "WD"
+  },
   "CSS4 Pseudo-Elements": {
     "name": "CSS Pseudo-Elements Level&nbsp;4",
     "url": "https://drafts.csswg.org/css-pseudo-4/",


### PR DESCRIPTION
https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/text-overflow has a Specifications table with a macro which references "CSS4 Overflow", but the MDN backend doesn’t (yet) recognize that value, so it displays "Unknown".