### PR TITLE
Add CSS Properties and Values API to SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -514,6 +514,11 @@
     "url": "https://www.w3.org/TR/css-overscroll-1/",
     "status": "WD"
   },
+  "CSS Properties and Values API": {
+    "name": "CSS Properties and Values API Level&nbsp;1",
+    "url": "https://drafts.css-houdini.org/css-properties-values-api-1/",
+    "status": "WD"
+  },
   "CSS Rhythmic Sizing": {
     "name": "CSS Rhythmic Sizing",
     "url": "https://drafts.csswg.org/css-rhythm/",


### PR DESCRIPTION
https://wiki.developer.mozilla.org/en-US/docs/Web/API/CSS/RegisterProperty has a Specifications table with a macro which references "CSS Properties and Values API", but the MDN backend doesn’t (yet) recognize that value, so it displays "Unknown".