### PR TITLE
Mark ECMAScript & ECMA-402 as Living; drop "Draft"

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -725,9 +725,9 @@
     "status": "Standard"
   },
   "ESDraft": {
-    "name": "ECMAScript Latest Draft (ECMA-262)",
+    "name": "ECMAScript (ECMA-262)",
     "url": "https://tc39.es/ecma262/",
-    "status": "Draft"
+    "status": "Living"
   },
   "ES Int 1.0": {
     "name": "ECMAScript Internationalization API 1.0 (ECMA-402)",
@@ -740,9 +740,9 @@
     "status": "Standard"
   },
   "ES Int Draft": {
-    "name": "ECMAScript Internationalization API 4.0 (ECMA-402)",
+    "name": "ECMAScript Internationalization API (ECMA-402)",
     "url": "https://tc39.es/ecma402/",
-    "status": "Draft"
+    "status": "Living"
   },
   "Feature Policy": {
     "name": "Feature Policy",


### PR DESCRIPTION
This change marks the SpecData macro `"ESDraft"` and `"ES Int Draft"` values as `"status": "Living"` (rather than `"status": "Draft"`), drops `"Latest Draft"` from the name value for `"ESDraft"`, and drops the `"4.0"` version number from the name value for `"ES Int Draft"`.

Rationale: The https://tc39.es/ecma262/ and https://tc39.es/ecma402/ specs are now maintained as Living Standards in the exactly the same way the WHATWG HTML Standard is (and WHATWG DOM Standard, etc.). As stated at https://tc39.es/ecma262/#metadata-block, *“This document at https://tc39.es/ecma262/ is the most accurate up-to-date ECMAScript specification.”*