### PR TITLE
Update URLs for some specs moved between W3C and WICG

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -956,7 +956,7 @@
   },
   "Media Capabilities": {
     "name": "Media Capabilities",
-    "url": "https://wicg.github.io/media-capabilities/",
+    "url": "https://w3c.github.io/media-capabilities/",
     "status": "Draft"
   },
   "Media Capture": {
@@ -971,12 +971,12 @@
   },
   "Media Playback Quality": {
     "name": "Media Playback Quality",
-    "url": "https://wicg.github.io/media-playback-quality/",
+    "url": "https://w3c.github.io/media-playback-quality/",
     "status": "ED"
   },
   "Media Session": {
     "name": "Media Session Standard",
-    "url": "https://wicg.github.io/mediasession/",
+    "url": "https://w3c.github.io/mediasession/",
     "status": "Draft"
   },
   "Media Source Extensions": {
@@ -1026,7 +1026,7 @@
   },
   "Network Information": {
     "name": "Network Information API",
-    "url": "https://w3c.github.io/netinfo/",
+    "url": "https://wicg.github.io/netinfo/",
     "status": "Draft"
   },
   "OpenGL ES 2.0": {
@@ -1621,7 +1621,7 @@
   },
   "Web Speech API": {
     "name": "Web Speech API",
-    "url": "https://w3c.github.io/speech-api/",
+    "url": "https://wicg.github.io/speech-api/",
     "status": "Draft"
   },
   "Web Telephony": {


### PR DESCRIPTION
This change updates the SpecData URLs for some specs that have moved from WICG URLs to W3C URLs, and others that have moved from W3C URLs to WICG URLs.