### PR TITLE
Update SpecData.json spec URL for Geolocation API

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -771,7 +771,7 @@
   },
   "Geolocation": {
     "name": "Geolocation API",
-    "url": "https://dev.w3.org/geo/api/spec-source.html",
+    "url": "https://w3c.github.io/geolocation-api/",
     "status": "REC"
   },
   "Geometry Interfaces": {


### PR DESCRIPTION
This change updates the SpecData URL for the Geolocation API to its actual current location at to https://w3c.github.io/geolocation-api/ (which the old https://dev.w3.org/geo/api/spec-source.html URL redirects to).