### PR TITLE
Fixing event URL resolution

### DIFF
--- a/macros/event.ejs
+++ b/macros/event.ejs
@@ -20,7 +20,7 @@ var URL = "/" + lang + "/docs/Web/Events/" + api + $2;
 // Add your local when you have moved your pages
 var filter = ['en-US'];
 
-if (filter.indexOf(lang) === -1) { URL = "/" + lang + '/docs/Web/Reference/Events/' + api + $2; }
+if (filter.indexOf(lang) === -1) { URL = "/" + lang + "/docs/Web/API/Element/" + api + "_event" + $2; }
 
  
 var anch = '';


### PR DESCRIPTION
Some pages which were not located at the historical "location" for events (namely "docs/Web/Reference/Events/") are not resolved when at a new location.
e.g. when using {{event("mousedown")}} from a French page, the link is red and goes to the en-US page while the French page does exist

Filed this after updating the mouseover page for mdn/sprints#2707