### PR TITLE
Add CSS Easing Functions spec to SpecData

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -214,6 +214,11 @@
     "url": "https://drafts.csswg.org/css-display/",
     "status": "CR"
   },
+  "CSS Easing 1": {
+    "name": "CSS Easing Functions Level&nbsp;1",
+    "url": "https://drafts.csswg.org/css-easing-1/",
+    "status": "CR"
+  },
   "CSS3 Environment Variables": {
     "name": "CSS Environment Variables Module Level&nbsp;1",
     "url": "https://drafts.csswg.org/css-env-1/",
@@ -563,11 +568,6 @@
     "name": "CSS Mobile Text Size Adjustment Module Level&nbsp;1",
     "url": "https://drafts.csswg.org/css-size-adjust/",
     "status": "ED"
-  },
-  "CSS Timing 1": {
-    "name": "CSS Timing Functions Level&nbsp;1",
-    "url": "https://drafts.csswg.org/css-timing-1/",
-    "status": "WD"
   },
   "CSS Transforms 2": {
     "name": "CSS Transforms Level&nbsp;2",


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/322502c renamed the "CSS Timing Functions" spec to "CSS Easing Functions".  https://drafts.csswg.org/css-timing-1/ now redirects to https://drafts.csswg.org/css-easing-1/