### PR TITLE
Update DNT SpecData URL, and mark Obsolete

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1311,8 +1311,8 @@
   },
   "Tracking": {
     "name": "Tracking Preference Expression (DNT)",
-    "url": "https://w3c.github.io/dnt/drafts/tracking-dnt.html",
-    "status": "CR"
+    "url": "https://www.w3.org/TR/tracking-dnt/",
+    "status": "Obsolete"
   },
   "Typed Array": {
     "name": "Typed Array Specification",


### PR DESCRIPTION
The DNT spec has been permanently retired as a W3C Note, with the final URL https://www.w3.org/TR/tracking-dnt/.