### PR TITLE
Remove glossary titles and styling

### DIFF
--- a/macros/Glossary.ejs
+++ b/macros/Glossary.ejs
@@ -1,23 +1,18 @@
 <%
 // Inserts a link to a term's entry in our glossary.
-// Appropriate styling is applied.
 //
 // Parameters:
 //
 //  $0 - Term name
 //  $1 - name to display (optional)
-//  $2 - Remove custom style on links; boolean (optional)
 
 let str = $1 || $0;
-let css = !$2 ? "glossaryLink" : "";
 
-// Terme location
-let URL_EN = "/en-US/docs/Glossary/";
 let URL    = mdn.localString({
     "ar"   : "/ar/docs/Glossary/",
     "bg"   : "/bg/docs/Речник/",
     "de"   : "/de/docs/Glossary/",
-    "en-US": URL_EN,
+    "en-US": "/en-US/docs/Glossary/",
     "es"   : "/es/docs/Glossary/",
     "fr"   : "/fr/docs/Glossaire/",
     "ja"   : "/ja/docs/Glossary/",
@@ -27,44 +22,6 @@ let URL    = mdn.localString({
     "uk"   : "/uk/docs/Glossary/"
 });
 
-let sep = mdn.localString({
-    "en-US":": ",
-    "fr"   :"&nbsp;: "
-});
+URL += $0.replace(/\s+/g,'_');
 
-URL_EN += $0.replace(/\s+/g,'_');
-URL    += $0.replace(/\s+/g,'_');
-
-let page    = await wiki.getPage(URL);
-let summary = mdn.localString({
-    "ar"   : "لم يتم تعريف المصطلح ("+ str +") بعد، يرجى النظر في المساهمة بتعريفه!",
-    "bg"   : "Все още няма определение за понятието „" + str + "“. Моля, създайте го.",
-    "de"   : "Die Definition dieses Ausdrucks (" + str + ") wurde noch nicht geschrieben; bitte hilf mit und trage sie bei!",
-    "en-US": "The definition of that term (" + str + ") has not been written yet; please consider contributing it!",
-    "es"   : "La definición de ese término (" + str + ") no se ha escrito todavía; por favor considera contribuir escribiendola!",
-    "fr"   : "La définition de ce terme («&nbsp;"+ str +"&nbsp;») n'a pas encore été rédigée. Nous serions heureux de vous voir l'écrire&nbsp;!",
-    "ja"   : "この用語 (" + str + ") の定義はまだ書かれていません。ぜひご寄稿ください！",
-    "ko"   : "용어 (" + str + ") 의 정의가 아직 번역되지 않았습니다. 번역에 동참해주세요!",
-    "pt-BR": "A definição do termo (" + str + ") ainda não foi escrita; por favor, considere fazer essa contribuição!",
-    "ru"   : "Определение термина «" + str + "» ещё не написано; может быть, вы напишете?",
-    "uk"   : "Визначення терміна «" + str + "» на разі відсутнє. Додайте самі, коли ваша ласка."
-});
-
-if (page && page.summary) {
-    summary = str + sep + mdn.escapeQuotes(page.summary);
-} else if (env.locale !== "en-US") {
-    page = await wiki.getPage(URL_EN);
-    URL  = URL_EN.replace('en-US', env.locale);
-    if (page && page.translations && page.translations.length > 0) {
-        for(let obj of page.translations) {
-            if (obj.locale === env.locale) {
-                URL  = obj.url;
-                page = await wiki.getPage(URL);
-                if (page && page.summary) {
-                    summary = str + sep + mdn.escapeQuotes(page.summary);
-                }
-            }
-        }
-    }
-}
-%><a href="<%- URL %>" title="<%-summary%>" class="<%-css%>"><%= str %></a>
+%><a href="<%- URL %>"><%= str %></a>

--- a/macros/Glossary.ejs
+++ b/macros/Glossary.ejs
@@ -8,20 +8,16 @@
 
 let str = $1 || $0;
 
-let URL    = mdn.localString({
-    "ar"   : "/ar/docs/Glossary/",
-    "bg"   : "/bg/docs/Речник/",
-    "de"   : "/de/docs/Glossary/",
-    "en-US": "/en-US/docs/Glossary/",
-    "es"   : "/es/docs/Glossary/",
-    "fr"   : "/fr/docs/Glossaire/",
-    "ja"   : "/ja/docs/Glossary/",
-    "ko"   : "/ko/docs/Glossary/",
-    "pt-BR": "/pt-BR/docs/Glossario/",
-    "ru"   : "/ru/docs/Словарь/",
-    "uk"   : "/uk/docs/Glossary/"
-});
-
+let URL = "/en-US/docs/Glossary/";
 URL += $0.replace(/\s+/g,'_');
+
+if (env.locale !== "en-US") {
+    let page = await wiki.getPage(URL);
+    for(let translation of page.translations) {
+        if (translation.locale === env.locale) {
+            URL = translation.url;
+        }
+    }
+}
 
 %><a href="<%- URL %>"><%= str %></a>

--- a/macros/Glossary.ejs
+++ b/macros/Glossary.ejs
@@ -13,9 +13,11 @@ URL += $0.replace(/\s+/g,'_');
 
 if (env.locale !== "en-US") {
     let page = await wiki.getPage(URL);
-    for(let translation of page.translations) {
-        if (translation.locale === env.locale) {
-            URL = translation.url;
+    if (page && page.translations) {
+        for(let translation of page.translations) {
+            if (translation.locale === env.locale) {
+                URL = translation.url;
+            }
         }
     }
 }


### PR DESCRIPTION
This removes titles from the glossary macro. See https://github.com/mdn/sprints/issues/2787 for background. (I'm surprised how this implementation is completely different and a lot more complex than in jsxref. It seems to do a lot more heavy lifting and additional requests. Woah!)

It also removes the special class `glossaryLink` that is used for styling. I wasn't sure about this one, but actually I see no benefit having it. The special styling was kind of hinting that there is a tooltip or something special going on with this link, but we're removing the title, so what's the point? Further, it is unclear to me if we are going to support `glossaryLink` as a class in stumptown. So, with this PR, this is back to just a plain link. Feedback appreciated on this topic.