### PR TITLE
dont double escape page titles

### DIFF
--- a/macros/Index.ejs
+++ b/macros/Index.ejs
@@ -68,7 +68,7 @@ getPages(pageList);
 <% for (i=0; i < result.length; i++) { %>
 <tr>
     <td rowspan="2"><%=i+1%></td>
-    <td rowspan="2"><a href='<%=result[i].url%>'><%=result[i].title%></a></td>
+    <td rowspan="2"><a href='<%=result[i].url%>'><%-result[i].title%></a></td>
     <td><strong><%=result[i].tags.join(", ")%></strong></td>
 </tr>
 <tr>

--- a/macros/Index.ejs
+++ b/macros/Index.ejs
@@ -46,7 +46,7 @@ var result = [];
 function getPages(pageList) {
     if (pageList) {
         for (var i = 0; i < pageList.length; i++) {
-            result.push({title: pageList[i].title.replace('<','&lt;').replace('>','&gt;'), url: pageList[i].url, tags: pageList[i].tags.sort(), summary: pageList[i].summary || '<strong>No summary!</strong>'})
+            result.push({title: pageList[i].title.replace(/</g,'&lt;').replace(/>/g,'&gt;'), url: pageList[i].url, tags: pageList[i].tags.sort(), summary: pageList[i].summary || '<strong>No summary!</strong>'})
             var subpage = getPages(pageList[i].subpages);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/mdn/kuma/issues/6475

<img width="990" alt="Screen Shot 2020-03-03 at 5 17 01 PM" src="https://user-images.githubusercontent.com/26739/75825364-29ac4780-5d73-11ea-93f2-5900c98f079e.png">

I'm a little bit uncertain about what's going on here but the change works. I've tried it in Kuma. 
If you make this change, you get that above screenshot. 
Seems the [macros hasn't been touched in over a year](https://github.com/mdn/kumascript/blob/master/macros/Index.ejs)

But if you look at [this line](https://github.com/mdn/kumascript/blob/2e04c8d31bfb6900a82cd69cc0fd3e6110ed307d/macros/Index.ejs#L49) it builds up an array of pages. And for each title it transforms `<tag>` to `&lt;tag&gt;` with manual string replace. So, any HTML turns into already escaped HTML. Then, when you've done that you can confidently use `<%-` instead of `<%=`. 

However, it used to do 
```javascript
... title.replace('<','&lt;').replace('>','&gt;')
```
which is dangerous because of this example:
```
> var title = '<tag>'
'<tag>'
> title.replace('<','&lt;').replace('>','&gt;')
'&lt;tag&gt;'
> title += ' <other>'
'<tag> <other>'
> title.replace('<','&lt;').replace('>','&gt;')
'&lt;tag&gt; <other>'
```
If you don't use `/REGEX/g` it won't replace EVERY occurance. But this works:
```
> title.replace(/</g,'&lt;').replace(/>/g,'&gt;')
'&lt;tag&gt; &lt;other&gt;'
```
