### PR TITLE
Add the Fetch Metadata spec to SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -759,6 +759,11 @@
     "url": "https://fetch.spec.whatwg.org/",
     "status": "Living"
   },
+  "Fetch Metadata": {
+    "name": "Fetch Metadata Request Headers",
+    "url": "https://w3c.github.io/webappsec-fetch-metadata/",
+    "status": "ED"
+  },
   "File API": {
     "name": "File API",
     "url": "https://w3c.github.io/FileAPI/",


### PR DESCRIPTION
A number of MDN articles now reference the Fetch Metadata spec; e.g., https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Fetch-Dest.