### PR TITLE
CSSPseudoElement no longer includes Animatable

### DIFF
--- a/macros/InterfaceData.json
+++ b/macros/InterfaceData.json
@@ -191,9 +191,7 @@
     },
     "CSSPseudoElement": {
       "inh": "EventTarget",
-      "impl": [
-        "Animatable"
-      ]
+      "impl": []
     },
     "CSSStyleDeclaration": {
       "inh": "",


### PR DESCRIPTION
[`CSSPseudoElement`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement) no longer includes `Animatable` in the latest [Web Animations](https://drafts.csswg.org/web-animations/#dom-animatable-animate) spec. See:
* https://github.com/mdn/browser-compat-data/pull/5784
* https://github.com/w3c/csswg-drafts/issues/4301
* https://wiki.developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement$compare?locale=en-US&to=1608131&from=1557611