### PR TITLE
Add Web Animations Level 2 spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1371,8 +1371,13 @@
   },
   "Web Animations": {
     "name": "Web Animations",
-    "url": "https://drafts.csswg.org/web-animations/",
+    "url": "https://drafts.csswg.org/web-animations-1/",
     "status": "WD"
+  },
+  "Web Animations 2": {
+    "name": "Web Animations Level 2",
+    "url": "https://drafts.csswg.org/web-animations-2/",
+    "status": "Draft"
   },
   "WebAssembly Core": {
     "name": "WebAssembly Core Specification",


### PR DESCRIPTION
There is now a draft spec for Web Animations Level 2, it can be found here: https://drafts.csswg.org/web-animations-2/

Some features already documented on MDN have been moved from Level 1 to Level 2, for example: https://developer.mozilla.org/en-US/docs/Web/API/KeyframeEffect/iterationComposite