### PR TITLE
Remove index page links from doc status

### DIFF
--- a/macros/DocStatus.ejs
+++ b/macros/DocStatus.ejs
@@ -319,12 +319,14 @@ await getL10nPages(languages);
 <%
 for (var obj in metrics) {
 if (metrics.hasOwnProperty(obj) && typeof metrics[obj] !== 'undefined') {
+    let out = metrics[obj].title;
     var href = metrics[obj].link;
     if (href && href.indexOf('#', 0) === 0) {
         href = env.path + href;
+        out = `<a href="${href}">${metrics[obj].title}</a>`;
     }
 %>
-    <th><a href="<%=href%>"><%=metrics[obj].title%></a></th>
+    <th><%-out%></th>
 <% }} %>
     </tr>
   </thead>

--- a/macros/DocStatus.ejs
+++ b/macros/DocStatus.ejs
@@ -41,7 +41,6 @@ var bugPageURL = 'https://bugzilla.mozilla.org/show_bug.cgi?id=';
 var metrics = {
     pages: {
         title: 'Pages',
-        link: enURL + '/Index',
         counter: 0
     },
     noTags: {

--- a/macros/DocStatusSummary.ejs
+++ b/macros/DocStatusSummary.ejs
@@ -79,7 +79,7 @@ function getPages(pageList) {
             if (containsNeedsWorkTag(pageList[i].tags)) { metrics["needsTags"][2]++; }
             if (hasReviewTag(pageList[i].review_tags, 'editorial')) { metrics["editorialReviews"][2]++; }
             if (hasReviewTag(pageList[i].review_tags, 'technical')) { metrics["technicalReviews"][2]++; }
-            
+
             var subpage = getPages(pageList[i].subpages);
             if (subpage) {
                 pageCounter++;
@@ -94,16 +94,14 @@ function getPages(pageList) {
 
 getPages(pageList);
 
-var indexPage = $0 + '/Index';
-
 %>
 <table class="docstatussummary standard-table">
   <thead>
     <tr>
-      <th><a href="<%=indexPage%>"><%=s_pages%></a></th>
+      <th><%=s_pages%></th>
 <%
  for (var key in metrics) {
-  if (metrics.hasOwnProperty(key)) { 
+  if (metrics.hasOwnProperty(key)) {
       var href = metrics[key][1];
       var title = metrics[key][0].replace(/_/g, " ");
       if (href.indexOf('#', 0) === 0) {


### PR DESCRIPTION
To get rid of index pages, we want to rip them out of doc status.
This is a minimal changes PR, because I don't want to touch anything here and doc status will be retired later anyway, too.