### PR TITLE
Update ARIARole.ejs w/ link to W3C Recommendation

### DIFF
--- a/macros/ARIARole.ejs
+++ b/macros/ARIARole.ejs
@@ -4,6 +4,6 @@
 //
 //  $0 - role
 
-var link = 'https://w3c.github.io/aria/#' + $0;
+var link = 'https://www.w3.org/TR/wai-aria-1.1/#' + $0;
 %>
 <code><a href="<%=link%>" class="external"><%=$0%></a></code>


### PR DESCRIPTION
Use canonical link to W3C Recommendation instead of the W3C Editor's Draft.