### PR TITLE
Remove cssinfo media and canonical order

### DIFF
--- a/macros/CSSInfo.ejs
+++ b/macros/CSSInfo.ejs
@@ -293,10 +293,6 @@ if (name === "preview-wiki-content") {
     }
 
     properties = properties.concat({
-        name: "media",
-        label: localize(localStrings, "media")
-    },
-    {
         name: "computed",
         label: await template("Xref_csscomputed")
     });
@@ -307,11 +303,6 @@ if (name === "preview-wiki-content") {
             label: localize(localStrings, "animationType")
         });
     }
-
-    properties = properties.concat({
-        name: "order",
-        label: localize(localStrings, "canonicalOrder")
-    });
 
     if (cssInfo.stacking) {
         properties = properties.concat({


### PR DESCRIPTION
Fix for https://github.com/mdn/sprints/issues/2880, and also https://github.com/mdn/kumascript/issues/740.

I started looking into this because of https://github.com/mdn/sprints/issues/2880, which reports that the "Media" entry in CSS info boxes is broken sometimes. Since [we agreed ages ago to retire this item and also "Canonical order"](https://discourse.mozilla.org/t/updates-to-the-css-info-boxes/30855), just removing them seemed the best way to fix the bug.

Initially I thought this might require us to remove the underlying data, but having looked at the CSSInfo macro it seems that just not displaying these items is simple. I've tested this in a local Kuma and it seems to do the right thing.

Still, this macro doesn't have tests so a careful review is needed.

It would still be nice to:
(1) understand which items in mdn/data are actually used by third parties
(2) understand which CSS info box items we actually want to display

...but this seems like a step in the right direction, anyway.
