### PR TITLE
adding new tooling articles to the learning area sidebar

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -179,6 +179,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : 'Introduction to automated testing',
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -396,6 +397,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : 'Einführung in automatisiertes Testen',
         'Setting_up_your_own_test_automation_environment' : 'Setze deine eigene Testumgebung auf',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -613,6 +615,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : 'Introdução a testes automatizados',
         'Setting_up_your_own_test_automation_environment' : 'Configurando seu próprio ambiente de testes automatizados',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -814,6 +817,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : 'Вступление в автоматическое тестирование',
         'Setting_up_your_own_test_automation_environment' : 'Установка вашей автоматической среды тестирования',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -1019,6 +1023,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : '自动测试介绍',
         'Setting_up_your_own_test_automation_environment' : '设置您的自动测试环境',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -1219,6 +1224,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : '自動化測試介紹',
         'Setting_up_your_own_test_automation_environment' : '設定自己的自動化測試環境',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -1450,6 +1456,7 @@ var text = mdn.localStringMap({
         'Introduction_to_automated_testing' : 'Introduction to automated testing',
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
       'Git_and_GitHub' : 'Git and GitHub',
+        'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
@@ -1782,6 +1789,19 @@ var text = mdn.localStringMap({
   </li>
   <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub']%></a></li>
   <li class="toggle">
+    <details <%=currentPageIsUnder('Tools_and_testing/GitHub')%>>
+        <summary><%=text['Git_and_GitHub']%></summary>
+        <ol>
+          <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub_overview']%></a></li>
+          <li><a href="https://guides.github.com/activities/hello-world/">Hello World</a></li>
+          <li><a href="https://guides.github.com/introduction/git-handbook/">Git Handbook</a></li>
+          <li><a href="https://guides.github.com/activities/forking/">Forking Projects</a></li>
+          <li><a href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests">About pull requests</a></li>
+          <li><a href="https://guides.github.com/features/issues/">Mastering Issues</a></li>
+        </ol>
+    </details>
+  </li>
+  <li class="toggle">
     <details <%=currentPageIsUnder('Tools_and_testing/Understanding_client-side_tools')%>>
         <summary><%=text['Understanding_client-side_web_development_tools']%></summary>
         <ol>
@@ -1794,7 +1814,6 @@ var text = mdn.localStringMap({
         </ol>
     </details>
   </li>
-
   <li data-default-state="<%=currentPageIsUnder('Server-side')%>"><a href="<%=baseURL%>Server-side"><strong><%=text['Server-side_website_programming']%></strong></a></li>
   <li class="toggle">
     <details <%=currentPageIsUnder('Server-side/First_steps')%>>

--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -1787,7 +1787,6 @@ var text = mdn.localStringMap({
         </ol>
     </details>
   </li>
-  <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub']%></a></li>
   <li class="toggle">
     <details <%=currentPageIsUnder('Tools_and_testing/GitHub')%>>
         <summary><%=text['Git_and_GitHub']%></summary>

--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -178,6 +178,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : 'Implementing feature detection',
         'Introduction_to_automated_testing' : 'Introduction to automated testing',
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : 'Server-side website programming',
       'First_steps' : 'First steps',
         'First_steps_overview' : 'First steps overview',
@@ -387,6 +395,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : 'Einbauen von Feature-Erkennung',
         'Introduction_to_automated_testing' : 'Einführung in automatisiertes Testen',
         'Setting_up_your_own_test_automation_environment' : 'Setze deine eigene Testumgebung auf',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : 'Serverseitige Webseitenprogrammierung',
       'First_steps' : 'Erste Schritte',
         'First_steps_overview' : 'Erste Schritte — Übersicht',
@@ -596,6 +612,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : 'Implementando detecção de funcionalidade',
         'Introduction_to_automated_testing' : 'Introdução a testes automatizados',
         'Setting_up_your_own_test_automation_environment' : 'Configurando seu próprio ambiente de testes automatizados',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : 'Programação de servidores de Aplicação',
       'First_steps' : 'Primeiros passos',
         'First_steps_overview' : 'Visão geral para os primeiros passos',
@@ -789,6 +813,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : 'Проверка поддержки возможностей',
         'Introduction_to_automated_testing' : 'Вступление в автоматическое тестирование',
         'Setting_up_your_own_test_automation_environment' : 'Установка вашей автоматической среды тестирования',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : 'Программирование серверной части сайта',
       'First_steps' : 'Первые шаги',
         'First_steps_overview' : 'Первые шаги',
@@ -986,6 +1018,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : '建置功能侦测',
         'Introduction_to_automated_testing' : '自动测试介绍',
         'Setting_up_your_own_test_automation_environment' : '设置您的自动测试环境',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : '服务端网页编程',
       'First_steps' : '第一步',
         'First_steps_overview' : '第一步概述',
@@ -1178,6 +1218,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : '建置功能偵測',
         'Introduction_to_automated_testing' : '自動化測試介紹',
         'Setting_up_your_own_test_automation_environment' : '設定自己的自動化測試環境',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : '伺服端網站程式設計',
       'First_steps' : '第一步',
         'First_steps_overview' : '第一步概述',
@@ -1401,6 +1449,14 @@ var text = mdn.localStringMap({
         'Implementing_feature_detection' : 'Implementing feature detection',
         'Introduction_to_automated_testing' : 'Introduction to automated testing',
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
+      'Git_and_GitHub' : 'Git and GitHub',
+      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+        'Client-side_web_development_tools_index' : 'Client-side web development tools index',
+        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Command_line_crash_course' : 'Command line crash course',
+        'Package_management_basics' : 'Package management basics',
+        'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
+        'Deploying_our_app' : 'Deploying our app',
     'Server-side_website_programming' : 'Server-side website programming',
       'First_steps' : 'First steps',
         'First_steps_overview' : 'First steps overview',
@@ -1721,6 +1777,20 @@ var text = mdn.localStringMap({
           <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Feature_detection"><%=text['Implementing_feature_detection']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Automated_testing"><%=text['Introduction_to_automated_testing']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Your_own_automation_environment"><%=text['Setting_up_your_own_test_automation_environment']%></a></li>
+        </ol>
+    </details>
+  </li>
+  <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub']%></a></li>
+  <li class="toggle">
+    <details <%=currentPageIsUnder('Tools_and_testing/Understanding_client-side_tools')%>>
+        <summary><%=text['Understanding_client-side_web_development_tools']%></summary>
+        <ol>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools"><%=text['Client-side_web_development_tools_index']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Overview"><%=text['Client-side_tooling_overview']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Command_line"><%=text['Command_line_crash_course']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Package_management"><%=text['Package_management_basics']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain"><%=text['Introducing_a_complete_toolchain']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Deployment"><%=text['Deploying_our_app']%></a></li>
         </ol>
     </details>
   </li>


### PR DESCRIPTION
This PR adds the following to the Learning Area sidebar:

* https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/GitHub
* https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools, and all of its sub-srticles