### PR TITLE
Update Media Session API in GroupData.json

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -764,8 +764,15 @@
             "interfaces": [ "MediaMetadata",
                             "MediaSession"],
             "methods":    [],
-            "properties": [],
-            "events":     []
+            "properties": [ "navigator.mediaSession" ],
+            "events":     [],
+            "dictionaries": [ "MediaImage",
+                              "MediaMetadataInit",
+                              "MediaPositionState",
+                              "MediaSessionActionDetails" ],
+            "types":      [ "MediaSessionAction",
+                            "MediaSessionPlaybackState" ],
+            "callbacks":  [ "MediaSessionActionHandler" ]
         },
         "Media Source Extensions": {
             "overview": [ "Media Source Extensions API" ],


### PR DESCRIPTION
Adds several missing things to the Media Session API,
including the `navigator.mediaSession` property and
all the dictionaries, types, and callbacks.

Source:
* https://w3c.github.io/mediasession/#idl-index