### PR TITLE
IDB 3 now has new things not in IDB 2

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -910,9 +910,14 @@
     "status": "REC"
   },
   "IndexedDB 2": {
-    "name": "Indexed Database API Draft",
-    "url": "https://w3c.github.io/IndexedDB/",
+    "name": "Indexed Database API 2.0",
+    "url": "https://www.w3.org/TR/IndexedDB/",
     "status": "REC"
+  },
+  "IndexedDB 3": {
+    "name": "Indexed Database API 3.0",
+    "url": "https://w3c.github.io/IndexedDB/",
+    "status": "ED"
   },
   "InputDeviceCapabilities": {
     "name": "InputDeviceCapabilities",


### PR DESCRIPTION
For example, https://wiki.developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases claims to be a REC, but it's not in https://www.w3.org/TR/IndexedDB/.