### PR TITLE
Add some JavaScript draft specifications

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -934,6 +934,21 @@
     "url": "https://w3c.github.io/IntersectionObserver/",
     "status": "WD"
   },
+  "Intl.DateTimeFormat.formatRange": {
+    "name": "Intl.DateTimeFormat.formatRange",
+    "url": "https://tc39.es/proposal-intl-DateTimeFormat-formatRange/",
+    "status": "Draft"
+  },
+  "Intl.DisplayNames": {
+    "name": "Intl.DisplayNames",
+    "url": "https://tc39.es/proposal-intl-displaynames/",
+    "status": "Draft"
+  },
+  "Intl.ListFormat": {
+    "name": "Intl.ListFormat",
+    "url": "https://tc39.es/proposal-intl-list-format/",
+    "status": "Draft"
+  },
   "Keyboard Lock": {
     "name": "Keyboard Lock",
     "url": "https://wicg.github.io/keyboard-lock/",
@@ -953,6 +968,11 @@
     "name": "Layout Instability API",
     "url": "https://wicg.github.io/layout-instability/",
     "status": "ED"
+  },
+  "Legacy RegExp features": {
+    "name": "Legacy RegExp features in JavaScript",
+    "url": "https://github.com/tc39/proposal-regexp-legacy-features/",
+    "status": "Draft"
   },
   "Long Tasks": {
     "name": "Long Tasks API 1",
@@ -1114,6 +1134,11 @@
     "url": "https://w3c.github.io/performance-timeline/",
     "status": "CR"
   },
+  "Pipeline operator": {
+    "name": "Pipeline operator",
+    "url": "https://tc39.es/proposal-pipeline-operator/",
+    "status": "Draft"
+  },
   "Pointer Events": {
     "name": "Pointer Events",
     "url": "https://www.w3.org/TR/pointerevents1/",
@@ -1149,10 +1174,20 @@
     "url": "https://wicg.github.io/priority-hints/",
     "status": "Draft"
   },
+  "Promise.any": {
+    "name": "Promise.any",
+    "url": "https://tc39.es/proposal-promise-any/",
+    "status": "Draft"
+  },
   "Proximity Events": {
     "name": "Proximity Sensor",
     "url": "https://w3c.github.io/proximity/",
     "status": "WD"
+  },
+  "Public and private instance fields": {
+    "name": "Public and private instance fields",
+    "url": "https://tc39.es/proposal-class-fields/",
+    "status": "Draft"
   },
   "Push API": {
     "name": "Push API",


### PR DESCRIPTION
See https://github.com/mdn/stumptown-content/issues/462.

This PR adds to SpecData.json some specifications that are currently being directly linked to in the JS docs.

The specifications are:
https://tc39.es/proposal-class-fields/
https://tc39.github.io/proposal-pipeline-operator/
https://tc39.es/proposal-promise-any/
https://tc39.es/proposal-intl-DateTimeFormat-formatRange/
https://tc39.es/proposal-intl-displaynames/
https://tc39.github.io/proposal-intl-list-format/
https://github.com/tc39/proposal-regexp-legacy-features/

I've no idea really what the rules are here: whether it's OK for example to link to [stage 1 specs that noone implements](https://tc39.es/proposal-pipeline-operator/), and whether there are any conventions for names and things. It seems particularly weird that https://github.com/tc39/proposal-regexp-legacy-features/ is just a link to a GitHub repo rather than an actually published spec, but I couldn't find an actual spec link anywhere (see for example https://tc39.es/#proposals, which has a spec link for the other proposals but not for this one).