### PR TITLE
Remove inline styling from prev and next buttons

### DIFF
--- a/macros/PreviousMenuNext.ejs
+++ b/macros/PreviousMenuNext.ejs
@@ -44,11 +44,11 @@ var s_Menu = mdn.localString({
 
 
 if ($0) {
-    strPrevious = '<a href="/' + lang + '/docs/' + string.replace($0, ' ', '_') + '"><span><i class="icon-arrow-left" aria-hidden="true"></i><span class="label">' + s_PreviousNext[0] + '</span></a>';
+    strPrevious = '<a href="/' + lang + '/docs/' + string.replace($0, ' ', '_') + '"><i class="icon-arrow-left" aria-hidden="true"></i><span class="label">' + s_PreviousNext[0] + '</span></a>';
 }
 
 if ($1) {
-    strNext = '<a href="/' + lang + '/docs/' + string.replace($1, ' ', '_') + '"><span><span class="label">' + s_PreviousNext[1] + '</span><i class="icon-arrow-right" aria-hidden="true"></i></a>';
+    strNext = '<a href="/' + lang + '/docs/' + string.replace($1, ' ', '_') + '"><span class="label">' + s_PreviousNext[1] + '</span><i class="icon-arrow-right" aria-hidden="true"></i></a>';
 }
 
 if ($2) {
@@ -59,11 +59,11 @@ if ($2) {
   var finalString = linkText.replace(re,' ');
 
   if($0 && $1) {
-    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   } else if($0) {
-    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   } else if($1) {
-    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   }
 }
 

--- a/macros/PreviousMenuNext.ejs
+++ b/macros/PreviousMenuNext.ejs
@@ -15,8 +15,6 @@ var strPrevious = "";
 var strNext = "<br>";
 var strMenu = "";
 
-var buttonStyle = "display:inline-block;background: #eaeff2;border-radius:4px;box-shadow: inset 0 -1px #bbbfc2;color: #4d4353;padding:0.3em 0.8em;";
-
 var s_PreviousNext = mdn.localString({
     "en-US": [" Previous ",          " Next  "],
     "cs"   : [" Předchozí ",  " Následující  "],
@@ -44,34 +42,13 @@ var s_Menu = mdn.localString({
 });
 
 
-// for LTR
-var prevTextAlign = "left";
-var nextTextAlign = "right";
-
-var prevFloatValue = "left";
-var nextFloatValue = "right";
-
-// for RTL
-switch(lang) {
-    case "ar":
-    case "fa":
-    case "he":
-        prevTextAlign = "right";
-        nextTextAlign = "left";
-        prevFloatValue = "right";
-        nextFloatValue = "left";
-        break;
-    default:
-        break;
-}
-
 
 if ($0) {
-    strPrevious = '<a style="float:' + prevFloatValue + '; width: 20%; text-align:' + prevTextAlign + ';" href="/' + lang + '/docs/' + string.replace($0, ' ', '_') + '"><span style="' + buttonStyle + '"><i class="icon-arrow-left" aria-hidden="true"></i>' + s_PreviousNext[0] + '</a>';
+    strPrevious = '<a href="/' + lang + '/docs/' + string.replace($0, ' ', '_') + '"><span><i class="icon-arrow-left" aria-hidden="true"></i><span class="label">' + s_PreviousNext[0] + '</span></a>';
 }
 
 if ($1) {
-    strNext = '<a style="width: 20%;float:' + nextFloatValue + ';text-align: ' + nextTextAlign + ';" href="/' + lang + '/docs/' + string.replace($1, ' ', '_') + '"><span style="' + buttonStyle + '">' + s_PreviousNext[1] + '<i class="icon-arrow-right" aria-hidden="true"></i></a>';
+    strNext = '<a href="/' + lang + '/docs/' + string.replace($1, ' ', '_') + '"><span><span class="label">' + s_PreviousNext[1] + '</span><i class="icon-arrow-right" aria-hidden="true"></i></a>';
 }
 
 if ($2) {
@@ -80,19 +57,18 @@ if ($2) {
   var linkText = linkTextArray[linkTextArray.length-1];
   var re = /_/gi;
   var finalString = linkText.replace(re,' ');
-  
+
   if($0 && $1) {
-    strMenu = '<a style="float:' + prevFloatValue + '; width: 60%;text-align: center;" href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span style="' + buttonStyle + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   } else if($0) {
-    strMenu = '<a style="float:' + nextFloatValue + '; width: 60%;text-align: ' + nextTextAlign + ';" href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span style="' + buttonStyle + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   } else if($1) {
-    strMenu = '<a style="float:' + prevFloatValue + '; width: 60%;text-align: ' + prevTextAlign + ';" href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span style="' + buttonStyle + '"><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
+    strMenu = '<a href="/' + lang + '/docs/' + string.replace($2, ' ', '_') + '"><span><i class="icon-arrow-up" aria-hidden="true"></i>' + s_Menu + finalString + '</a>';
   }
 }
 
 
 
 %><div class="prevnext">
-    <div><%- strPrevious %><%- strMenu %><%- strNext %></div>
-    <p>&nbsp;</p>
+  <%- strPrevious %><%- strMenu %><%- strNext %>
 </div>


### PR DESCRIPTION
**Changes**
- Remove inline styling from the previous and next buttons. The CSS has been moved to kuma (see PR https://github.com/mdn/kuma/pull/7162). Thanks to @a2sheppy for his investigation into this matter! 

**Desktop changes**
 _screenshots taken from http://localhost.org:8000/ar/docs/Learn/Server-side/Django/Tutorial_local_library_website_
<img width="883" alt="desktop-changes" src="https://user-images.githubusercontent.com/650/83200201-d434cc00-a110-11ea-8b0f-45eff4df352b.png">

**Mobile changes**
<img width="881" alt="mobile-changes" src="https://user-images.githubusercontent.com/650/83200308-09d9b500-a111-11ea-998a-6affcde19898.png">


**To test** 
Visit http://localhost.org:8000/en-US/docs/Learn/Server-side/Django/Tutorial_local_library_website and use prev and next buttons at top

Closes #6913

Depends on PR https://github.com/mdn/kuma/pull/7162

@schalkneethling r+ ? (I can't add you or anyone as a reviewer for some reason, so tagging you here)