### PR TITLE
Bump CSS Variable to CR in SpecData.json

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -356,7 +356,7 @@
   },
   "CSS3 Variables": {
     "name": "CSS Custom Properties for Cascading Variables Module Level&nbsp;1",
-    "url": "https://drafts.csswg.org/css-variables/",
+    "url": "https://www.w3.org/TR/css-variables-1/",
     "status": "CR"
   },
   "CSS3 Writing Modes": {


### PR DESCRIPTION
The status was bumped to CR, but the URL wasn’t updated. There seem to be more cases introduced in #565; shall I fix them all?

Note: it’s weird that CI result isn’t linked to this PR, but it’s actually [passed](https://travis-ci.org/github/mdn/kumascript/builds/698793440).