### PR TITLE
Add Visual Viewport to GroupData

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1289,6 +1289,14 @@
             "properties": [],
             "events":     []
         },
+        "Visual Viewport": {
+            "overview":   [ "Visual Viewport API"],
+            "interfaces": [ "VisualViewport" ],
+            "methods":    [],
+            "properties": [ "Window.visualViewport" ],
+            "events":     [ "VisualViewport: resize",
+                            "VisualViewport: scroll" ]
+        },
         "Web Animations": {
             "overview":   [ "Web Animations API" ],
             "guides":     [ "/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API",


### PR DESCRIPTION
This patch adds a record for the Visual Viewport API to the  
GroupData.json file. This is based on the following spec  
draft:

https://wicg.github.io/visual-viewport/#the-visualviewport-interface

We already document this API.