### PR TITLE
Add Safari to WebExt browsers

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -48,7 +48,7 @@ const browsers = {
   "desktop": ['chrome', 'edge', 'firefox', 'ie', 'opera', 'safari'],
   "mobile": ['webview_android', 'chrome_android', 'firefox_android', 'opera_android', 'safari_ios', 'samsunginternet_android'],
   "server": ['nodejs'],
-  "webextensions-desktop": ['chrome', 'edge', 'firefox', 'opera'],
+  "webextensions-desktop": ['chrome', 'edge', 'firefox', 'opera', 'safari'],
   "webextensions-mobile": ['firefox_android']
 };
 

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -168,7 +168,7 @@ describeMacro('Compat', function() {
                 );
                 assert.equal(
                     dom.querySelector('.bc-platform-desktop').colSpan,
-                    4
+                    5
                 );
                 assert.equal(
                     dom.querySelector('.bc-platform-mobile').colSpan,


### PR DESCRIPTION
Safari now supports WebExtensions as announced at wwdc20.