### PR TITLE
Add WeakReafs spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1430,7 +1430,7 @@
     "status": "Draft"
   },
   "WeakRefs": {
-    "name": "WeakRefs proposal",
+    "name": "WeakRefs",
     "url": "https://tc39.es/proposal-weakrefs/",
     "status": "Draft"
   },

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1429,6 +1429,11 @@
     "url": "https://wicg.github.io/visual-viewport/",
     "status": "Draft"
   },
+  "WeakRefs": {
+    "name": "WeakRefs proposal",
+    "url": "https://tc39.es/proposal-weakrefs/",
+    "status": "Draft"
+  },
   "Web Animations": {
     "name": "Web Animations",
     "url": "https://drafts.csswg.org/web-animations-1/",


### PR DESCRIPTION
Annoying to do this, but as said in https://github.com/mdn/kumascript/pull/1380 we need draft specs to be added, so the linter doesn't fail on a malformed spec section.

This is the spec for https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef