### PR TITLE
Add logical assignment operator spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -979,6 +979,11 @@
     "url": "https://github.com/tc39/proposal-regexp-legacy-features/",
     "status": "Draft"
   },
+  "Logical Assignment": {
+    "name": "Logical Assignment Operators",
+    "url": "https://tc39.es/proposal-logical-assignment/",
+    "status": "Draft"
+  },
   "Long Tasks": {
     "name": "Long Tasks API 1",
     "url": "https://w3c.github.io/longtasks/",


### PR DESCRIPTION
For https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment#Specifications and friends.