### PR TITLE
add browser release date to compatibility table

### DIFF
--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -228,6 +228,31 @@ function getCellString(added, removed, partial) {
 }
 
 /*
+Returns the version number to appear in a cell
+
+`added` and `removed` are either null, true, false or a string containing a version number
+`partial` is either null, true, or false indicating partial_implementation
+*/
+function getVersionNumber(added, removed, partial) {
+  let output = undefined;
+
+  if(added !== null && added !== true && added !== false) {
+    output = added;
+  }
+
+  if (removed) {
+    output = undefined;
+  } else if (partial) {
+    output = undefined;
+    // Display "Partial" instead of "Yes", "No", or "?" if we have no version string
+    if (!(typeof(added) !== 'string')) {
+      output = added;
+    }
+  }
+  return output;
+}
+
+/*
 Given the support information for a browser, this returns
 a CSS class to apply to the table cell.
 
@@ -523,14 +548,25 @@ function writeCompatCells(supportData) {
     let needsNotes = false;
     let support = supportData[browserNameKey];
     let supportInfo = '';
+    let versionNumber = null;
     if (support) {
       if (Array.isArray(support)) {
         // Take first support data
+        versionNumber = getVersionNumber(
+          support[0].version_added,
+          support[0].version_removed,
+          support[0].partial_implementation
+        )
         supportInfo += getCellString(support[0].version_added,
                                      support[0].version_removed,
                                      support[0].partial_implementation);
         needsNotes = true;
       } else {
+        versionNumber = getVersionNumber(
+          support.version_added,
+          support.version_removed,
+          support.partial_implementation
+        )
         supportInfo += getCellString(support.version_added,
                                      support.version_removed,
                                      support.partial_implementation);
@@ -551,7 +587,17 @@ function writeCompatCells(supportData) {
       output += ' bc-has-history';
     }
 
-    output += `"><span class="bc-browser-name">${browserName}</span>${supportInfo}`;
+    output += '"';
+
+    if (versionNumber !== null) {
+      let releaseDate = getData(`browsers.${browserNameKey}.releases.${versionNumber}.release_date`, bcd)
+
+      if(releaseDate) {
+        output += ` title="${releaseDate}"`
+      }
+    }
+
+    output += `><span class="bc-browser-name">${browserName}</span>${supportInfo}`;
 
     if (needsNotes) {
       output += writeCellIcons(support);

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -54,6 +54,18 @@ describeMacro('Compat', function() {
     // which consist of different browsers
     // Tests content_areas.json
     itMacro(
+        'Includes browser version release dates',
+        function(macro) {
+            return macro.call('api.feature').then(function(result) {
+                let dom = JSDOM.fragment(result);
+                assert.equal(
+                    dom.querySelector('td.bc-browser-firefox').title,
+                    "2004-11-09"
+                );
+            });
+        }
+    );
+    itMacro(
         'Creates correct platform and browser columns for API data',
         function(macro) {
             return macro.call('api.feature').then(function(result) {

--- a/tests/macros/fixtures/compat/content_areas.json
+++ b/tests/macros/fixtures/compat/content_areas.json
@@ -64,5 +64,20 @@
                 }
             }
         }
+    },
+    "browsers": {
+        "firefox": {
+          "name": "Firefox",
+          "pref_url": "about:config",
+          "releases": {
+            "1": {
+                    "release_date": "2004-11-09",
+                    "release_notes": "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
+                    "status": "retired",
+                    "engine": "Gecko",
+                    "engine_version": "1.7"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Problem statement
As a developer looking at a feature on MDN to check its browser compatibility, the browser version number data is not super meaningful to me, because I don't know the release date for each browser version.

### Proposed solution
This PR adds a `title` attribute to each version number cell in the browser compatibility table with the release date for the browser version.

- Joel & Anonymous developer Joel is mentoring