### PR TITLE
adding tooling module to sidebar

### DIFF
--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -180,7 +180,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -426,7 +426,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : 'Setze deine eigene Testumgebung auf',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -672,7 +672,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : 'Configurando seu próprio ambiente de testes automatizados',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -902,7 +902,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : 'Установка вашей автоматической среды тестирования',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -1136,7 +1136,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : '设置您的自动测试环境',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -1365,7 +1365,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : '設定自己的自動化測試環境',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -1625,7 +1625,7 @@ var text = mdn.localStringMap({
         'Setting_up_your_own_test_automation_environment' : 'Setting up your own test automation environment',
       'Git_and_GitHub' : 'Git and GitHub',
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
-      'Understanding_client-side_web_development_tools' : 'Understanding client-side web development tools',
+      'Client-side_web_development_tools' : 'Client-side web development tools',
         'Client-side_web_development_tools_index' : 'Client-side web development tools index',
         'Client-side_tooling_overview' : 'Client-side tooling overview',
         'Command_line_crash_course' : 'Command line crash course',
@@ -1969,7 +1969,7 @@ var text = mdn.localStringMap({
   <li><a href="<%=baseURL%>Tools_and_testing"><strong><%=text['Tools_and_testing']%></strong></a></li>
   <li class="toggle">
     <details <%=currentPageIsUnder('Tools_and_testing/Understanding_client-side_tools')%>>
-        <summary><%=text['Understanding_client-side_web_development_tools']%></summary>
+        <summary><%=text['Client-side_web_development_tools']%></summary>
         <ol>
           <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools"><%=text['Client-side_web_development_tools_index']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Overview"><%=text['Client-side_tooling_overview']%></a></li>

--- a/macros/LearnSidebar.ejs
+++ b/macros/LearnSidebar.ejs
@@ -1968,31 +1968,15 @@ var text = mdn.localStringMap({
   </li>
   <li><a href="<%=baseURL%>Tools_and_testing"><strong><%=text['Tools_and_testing']%></strong></a></li>
   <li class="toggle">
-    <details <%=currentPageIsUnder('Tools_and_testing/Cross_browser_testing')%>>
-        <summary><%=text['Cross_browser_testing']%></summary>
+    <details <%=currentPageIsUnder('Tools_and_testing/Understanding_client-side_tools')%>>
+        <summary><%=text['Understanding_client-side_web_development_tools']%></summary>
         <ol>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing"><%=text['Cross_browser_testing_overview']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Introduction"><%=text['Introduction_to_cross_browser_testing']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Testing_strategies"><%=text['Strategies_for_carrying_out_testing']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/HTML_and_CSS"><%=text['Handling_common_HTML_and_CSS_problems']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/JavaScript"><%=text['Handling_common_JavaScript_problems']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Accessibility"><%=text['Handling_common_accessibility_problems']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Feature_detection"><%=text['Implementing_feature_detection']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Automated_testing"><%=text['Introduction_to_automated_testing']%></a></li>
-          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Your_own_automation_environment"><%=text['Setting_up_your_own_test_automation_environment']%></a></li>
-        </ol>
-    </details>
-  </li>
-  <li class="toggle">
-    <details <%=currentPageIsUnder('Tools_and_testing/GitHub')%>>
-        <summary><%=text['Git_and_GitHub']%></summary>
-        <ol>
-          <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub_overview']%></a></li>
-          <li><a href="https://guides.github.com/activities/hello-world/">Hello World</a></li>
-          <li><a href="https://guides.github.com/introduction/git-handbook/">Git Handbook</a></li>
-          <li><a href="https://guides.github.com/activities/forking/">Forking Projects</a></li>
-          <li><a href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests">About pull requests</a></li>
-          <li><a href="https://guides.github.com/features/issues/">Mastering Issues</a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools"><%=text['Client-side_web_development_tools_index']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Overview"><%=text['Client-side_tooling_overview']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Command_line"><%=text['Command_line_crash_course']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Package_management"><%=text['Package_management_basics']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Introducing_complete_toolchain"><%=text['Introducing_a_complete_toolchain']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Understanding_client-side_tools/Deployment"><%=text['Deploying_our_app']%></a></li>
         </ol>
     </details>
   </li>
@@ -2045,6 +2029,35 @@ var text = mdn.localStringMap({
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering  "><%=text['Vue_conditional_rendering:_editing_existing_todos']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Vue_refs_focus_management"><%=text['Focus_management_with_Vue_refs']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Vue_resources"><%=text['Vue_resources']%></a></li>
+        </ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details <%=currentPageIsUnder('Tools_and_testing/GitHub')%>>
+        <summary><%=text['Git_and_GitHub']%></summary>
+        <ol>
+          <li><a href="<%=baseURL%>Tools_and_testing/GitHub"><%=text['Git_and_GitHub_overview']%></a></li>
+          <li><a href="https://guides.github.com/activities/hello-world/">Hello World</a></li>
+          <li><a href="https://guides.github.com/introduction/git-handbook/">Git Handbook</a></li>
+          <li><a href="https://guides.github.com/activities/forking/">Forking Projects</a></li>
+          <li><a href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests">About pull requests</a></li>
+          <li><a href="https://guides.github.com/features/issues/">Mastering Issues</a></li>
+        </ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details <%=currentPageIsUnder('Tools_and_testing/Cross_browser_testing')%>>
+        <summary><%=text['Cross_browser_testing']%></summary>
+        <ol>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing"><%=text['Cross_browser_testing_overview']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Introduction"><%=text['Introduction_to_cross_browser_testing']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Testing_strategies"><%=text['Strategies_for_carrying_out_testing']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/HTML_and_CSS"><%=text['Handling_common_HTML_and_CSS_problems']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/JavaScript"><%=text['Handling_common_JavaScript_problems']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Accessibility"><%=text['Handling_common_accessibility_problems']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Feature_detection"><%=text['Implementing_feature_detection']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Automated_testing"><%=text['Introduction_to_automated_testing']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Cross_browser_testing/Your_own_automation_environment"><%=text['Setting_up_your_own_test_automation_environment']%></a></li>
         </ol>
     </details>
   </li>


### PR DESCRIPTION
I completely failed to actually add [our new tooling module](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools) to the learn sidebar, so this PR does that.

Plus I've reordered the tools and testing modules so that they appear in the same order as they do in the topic page: https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing.

@Elchi3 can you give this a quick check to see if you think it makes sense?

Then @escattone can you please refresh the /Learn pages once this is done?

This is not hyper urgent, but it'd be nice to get it done before too much longer has passed.