### PR TITLE
Add spec for CSS Box Model Level 4

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -375,7 +375,7 @@
     "status": "WD"
   },
   "CSS4 Box": {
-    "name": "CSS Box Model Level 4",
+    "name": "CSS Box Model Module Level 4",
     "url": "https://drafts.csswg.org/css-box-4/",
     "status": "ED"
   },

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -374,6 +374,11 @@
     "url": "https://drafts.csswg.org/css-ui-4/",
     "status": "WD"
   },
+  "CSS4 Box": {
+    "name": "CSS Basic Box Model Level 4",
+    "url": "https://drafts.csswg.org/css-box-4/",
+    "status": "ED"
+  },
   "CSS4 Cascade": {
     "name": "CSS Cascading and Inheritance Level&nbsp;4",
     "url": "https://drafts.csswg.org/css-cascade/",

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -375,7 +375,7 @@
     "status": "WD"
   },
   "CSS4 Box": {
-    "name": "CSS Basic Box Model Level 4",
+    "name": "CSS Box Model Level 4",
     "url": "https://drafts.csswg.org/css-box-4/",
     "status": "ED"
   },


### PR DESCRIPTION
This PR adds an entry to SpecData.json for [CSS Box Model Level 4](https://drafts.csswg.org/css-box-4/), which is needed for our [`margin-trim`](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/margin-trim) documentation.