### PR TITLE
Add overview key for Screen Capture in GroupData

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -1013,6 +1013,7 @@
             "events":     []
         },
         "Screen Capture API": {
+            "overview":   [ "Screen Capture API" ],
             "guides":     [ "/docs/Web/API/Screen_Capture_API/Using_Screen_Capture" ],
             "interfaces": [],
             "dictionaries": [],


### PR DESCRIPTION
This change adds a `overview` key and value for the Screen Capture API in the `macros/GroupData.json` file.

Otherwise, without this change, the system doesn’t recognize the Screen Capture API as having an overview page — and that seems to cause at least one user-facing problem: it prevents the Screen Capture API from showing up on https://developer.mozilla.org/en-US/docs/Web/API

---

See https://github.com/mdn/sprints/issues/3701 for a related bug report from a user.