### PR TITLE
CSS Containment spec. updates

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -466,7 +466,7 @@
   },
   "CSS Containment": {
     "name": "CSS Containment Module Level 1",
-    "url": "https://drafts.csswg.org/css-contain/",
+    "url": "https://drafts.csswg.org/css-contain-1/",
     "status": "REC"
   },
   "CSS Color Adjust": {

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -469,6 +469,11 @@
     "url": "https://drafts.csswg.org/css-contain-1/",
     "status": "REC"
   },
+  "CSS Containment 2": {
+    "name": "CSS Containment Module Level 2",
+    "url": "https://drafts.csswg.org/css-contain-2/",
+    "status": "WD"
+  },
   "CSS Color Adjust": {
     "name": "CSS Color Adjustment Module Level 1",
     "url": "https://drafts.csswg.org/css-color-adjust-1/",


### PR DESCRIPTION
The URL for the CSS Containment specification didn't contain a version number. Because the spec. already advanced to version 2 now, the URL linked to the new version instead of the old one. Therefore I have added the version 1 now.

Additionally, I have added the second level of the specification.