### PR TITLE
use new @mdn/browser-compat-data

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /
 COPY kumascript/package.json kumascript/npm-shrinkwrap.json /
 RUN npm ci && \
     # update any top-level npm packages listed in package.json,
-    # such as mdn-browser-compat-data,
+    # such as @mdn/browser-compat-data,
     # as allowed by each package's given "semver".
     npm update
 ENV NODE_PATH=/node_modules

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -30,7 +30,7 @@ Example calls
 
 */
 
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 var query = $0;
 var depth = $1 || 1;
 var output = '';

--- a/macros/WebExtAllCompatTables.ejs
+++ b/macros/WebExtAllCompatTables.ejs
@@ -15,7 +15,7 @@ objects under that object, generating an aggregated table for each object.
 This macro can be inserted anywhere, and takes no arguments.
 */
 
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 var features = bcd.webextensions.api;
 var featureList = Object.keys(features).sort();
 var output = '';

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,6 +24,14 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@mdn/browser-compat-data": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.1.tgz",
+            "integrity": "sha512-3EoAQjXcR+UXAjb48z5el061KLZt2oLULeIcHgKSAqk8SyQLSE4zKj/+Y2nhqaXygkDPXiQ+vf0JMamdy161ZQ==",
+            "requires": {
+                "extend": "3.0.2"
+            }
+        },
         "@newrelic/koa": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
@@ -4116,14 +4124,6 @@
             "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
             "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
             "dev": true
-        },
-        "mdn-browser-compat-data": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.0.tgz",
-            "integrity": "sha512-I6MI6a9cEeUoHKN/5R5/CQA3HXYnQOuqvrp53B1QdNas9vJ1Jok6Ldt7ClEL8kywWbaoRXkJOfV0EbZbrWCdeQ==",
-            "requires": {
-                "extend": "3.0.2"
-            }
         },
         "mdn-data": {
             "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
         "node": ">=12.0.0"
     },
     "dependencies": {
+        "@mdn/browser-compat-data": "^2.0.1",
         "ejs": "2.6.1",
         "express": "4.16",
         "lru-cache": "5.1.1",
-        "mdn-browser-compat-data": "^1.0.0",
         "mdn-data": "^2.0.6",
         "morgan": "1.9.1",
         "newrelic": "5.9.0",

--- a/tests/fixtures/server/macros/require-used.ejs
+++ b/tests/fixtures/server/macros/require-used.ejs
@@ -1,6 +1,6 @@
 <%
 var queryString = $0,
-    bcd = require('mdn-browser-compat-data');
+    bcd = require('@mdn/browser-compat-data');
 
 function getData() {
   return queryString.split('.').reduce(function(prev, curr) {

--- a/tests/macros/Compat.test.js
+++ b/tests/macros/Compat.test.js
@@ -31,7 +31,7 @@ describeMacro('Compat', function() {
         macro.ctx.require = jest.fn(pkg => fixtureCompatData);
 
         /*        macro.ctx.require = sinon.stub();
-        macro.ctx.require.withArgs('mdn-browser-compat-data').returns(fixtureCompatData);
+        macro.ctx.require.withArgs('@mdn/browser-compat-data').returns(fixtureCompatData);
 */
     });
 


### PR DESCRIPTION
Fixes #1425 

Per https://github.com/mdn/browser-compat-data/issues/6640, stop using deprecated `mdn-browser-compat-data` npm package and use the new `@mdn/browser-compat-data` package instead.