### PR TITLE
Make JSRef not claim Object inherits from Function

### DIFF
--- a/macros/JSRef.ejs
+++ b/macros/JSRef.ejs
@@ -43,7 +43,7 @@ var inheritance = ["Object", "Function"];
 var inheritanceData = {
     "Math": ["Object"],
     "Function": ["Object"],
-    "Object": ["Function"],
+    "Object": [],
     "JSON": ["Object"],
     "Intl": ["Object"],
     "arguments": [],


### PR DESCRIPTION
This change makes the code for the JSRef macro not set the inheritance data for Object to Function.

Otherwise, without this change, when viewing the MDN article at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object, the sidebar there incorrectly shows Object inheriting from Function.