### PR TITLE
add MathML Core spec

### DIFF
--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1029,6 +1029,11 @@
     "url": "https://www.w3.org/TR/MathML3/",
     "status": "REC"
   },
+  "MathMLCore": {
+    "name": "MathML Core",
+    "url": "https://mathml-refresh.github.io/mathml-core/",
+    "status": "Draft"
+  },
   "Media Capabilities": {
     "name": "Media Capabilities",
     "url": "https://w3c.github.io/media-capabilities/",


### PR DESCRIPTION
While documenting for this bug https://bugzilla.mozilla.org/show_bug.cgi?id=1665975 I am adding a page for `math-style` which is defined in the MathML Core spec: https://mathml-refresh.github.io/mathml-core/#the-math-style-property

This PR adds that spec.



