### PR TITLE
add Picture-in-Picture API to GroupData.json and SpecData.json

### DIFF
--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -918,6 +918,23 @@
             "properties": [ "Navigator.permissions",
                             "WorkerNavigator.permissions"],
             "events":     []
+		},
+        "Picture-in-Picture API": {
+            "overview":   [ "Picture-in-Picture API" ],
+            "guides":     [ "/docs/Web/API/Picture-in-Picture_API/Guide" ],
+            "interfaces": [ "PictureInPictureWindow" ],
+            "methods":    [ "HTMLVideoElement.requestPictureInPicture()",
+                            "Document.exitPictureInPicture()" ],
+            "properties": [ "HTMLVideoElement.autoPictureInPicture",
+							"HTMLVideoElement.disablePictureInPicture",
+							"HTMLVideoElement.onenterpictureinpicture",
+							"HTMLVideoElement.onleavepictureinpicture",
+                            "Document.pictureInPictureEnabled",
+                            "DocumentOrShadowRoot.pictureInPictureElement",
+                            "PictureInPictureWindow.onresize" ],
+            "events":     [ "HTMLVideoElement: enterpictureinpicture",
+                            "HTMLVideoElement: leavepictureinpicture",
+                            "PictureInPictureWindow: resize" ]
         },
         "Pointer Events": {
             "overview":   [ "Pointer events" ],

--- a/macros/GroupData.json
+++ b/macros/GroupData.json
@@ -918,7 +918,7 @@
             "properties": [ "Navigator.permissions",
                             "WorkerNavigator.permissions"],
             "events":     []
-		},
+	},
         "Picture-in-Picture API": {
             "overview":   [ "Picture-in-Picture API" ],
             "guides":     [ "/docs/Web/API/Picture-in-Picture_API/Guide" ],
@@ -926,9 +926,9 @@
             "methods":    [ "HTMLVideoElement.requestPictureInPicture()",
                             "Document.exitPictureInPicture()" ],
             "properties": [ "HTMLVideoElement.autoPictureInPicture",
-							"HTMLVideoElement.disablePictureInPicture",
-							"HTMLVideoElement.onenterpictureinpicture",
-							"HTMLVideoElement.onleavepictureinpicture",
+			    "HTMLVideoElement.disablePictureInPicture",
+			    "HTMLVideoElement.onenterpictureinpicture",
+			    "HTMLVideoElement.onleavepictureinpicture",
                             "Document.pictureInPictureEnabled",
                             "DocumentOrShadowRoot.pictureInPictureElement",
                             "PictureInPictureWindow.onresize" ],

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1178,12 +1178,12 @@
     "name": "Permissions Policy",
     "url": "https://w3c.github.io/webappsec-permissions-policy/",
     "status": "ED"
-	},
-	"Picture-in-Picture": {
-		"name": "Picture-in-Picture API",
-		"url": "https://w3c.github.io/picture-in-picture/",
-		"status": "Draft"
-	},
+  },
+  "Picture-in-Picture": {
+    "name": "Picture-in-Picture API",
+    "url": "https://w3c.github.io/picture-in-picture/",
+    "status": "Draft"
+  },
   "Pipeline operator": {
     "name": "Pipeline operator",
     "url": "https://tc39.es/proposal-pipeline-operator/",

--- a/macros/SpecData.json
+++ b/macros/SpecData.json
@@ -1178,7 +1178,12 @@
     "name": "Permissions Policy",
     "url": "https://w3c.github.io/webappsec-permissions-policy/",
     "status": "ED"
-  },
+	},
+	"Picture-in-Picture": {
+		"name": "Picture-in-Picture API",
+		"url": "https://w3c.github.io/picture-in-picture/",
+		"status": "Draft"
+	},
   "Pipeline operator": {
     "name": "Pipeline operator",
     "url": "https://tc39.es/proposal-pipeline-operator/",


### PR DESCRIPTION
This PR adds the [Picture-in-Picture API](https://w3c.github.io/picture-in-picture/) to `GroupData.json` and `SpecData.json` for the `DefaultAPISidebar` and `SpecName` macro to work.

Work in progress related to mdn/sprints#3425