### PR TITLE
Both AudioContexts inherit BaseAudioContext

### DIFF
--- a/macros/InterfaceData.json
+++ b/macros/InterfaceData.json
@@ -45,7 +45,7 @@
       "impl": []
     },
     "AudioContext": {
-      "inh": "EventTarget",
+      "inh": "BaseAudioContext",
       "impl": []
     },
     "AudioDestinationNode": {
@@ -1300,7 +1300,7 @@
       "impl": []
     },
     "OfflineAudioContext": {
-      "inh": "AudioContext",
+      "inh": "BaseAudioContext",
       "impl": []
     },
     "OfflineResourceList": {


### PR DESCRIPTION
According the [the spec](https://www.w3.org/TR/webaudio/#BaseAudioContext) both AudioContext and OfflineAudioContext inherit from BaseAudioContext.

This would probably also resolve mdn/sprints/issues/3565