### PR TITLE
Add Peer JS WebRTC Tutorial to WebRTC Sidebar Macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ docs
 node_modules/
 *.log
 *~
+.idea
 

--- a/macros/WebRTCSidebar.ejs
+++ b/macros/WebRTCSidebar.ejs
@@ -79,6 +79,7 @@ var text = mdn.localStringMap({
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/adapter.js"><%=text['adapter_js']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/Taking_still_photos"><%=text['still_photos']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample"><%=text['simple_sample']%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/build_a_phone_with_peerjs"><%=text['build_a_phone_with_peer_js']%></a></li>
       </ol>
     </details>
   </li>

--- a/macros/WebRTCSidebar.ejs
+++ b/macros/WebRTCSidebar.ejs
@@ -31,6 +31,7 @@ var text = mdn.localStringMap({
     'Contribute': 'Contribute',
     'Doc_status': 'WebRTC doc status',
     'The_MDN_project': 'The MDN project',
+    'build_a_phone_with_peer_js': 'Building an internet-connected phone with Peer.js',
   },
   'ru': {
     'WebRTC_API': 'WebRTC API',
@@ -79,7 +80,7 @@ var text = mdn.localStringMap({
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/adapter.js"><%=text['adapter_js']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/Taking_still_photos"><%=text['still_photos']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample"><%=text['simple_sample']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/build_a_phone_with_peerjs"><%=text['build_a_phone_with_peer_js']%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API/Build_a_phone_with_peerjs"><%=text['build_a_phone_with_peer_js']%></a></li>
       </ol>
     </details>
   </li>


### PR DESCRIPTION
I've added my internet-connected phone tutorial to the WebRTC macro as per @chrisdavidmills recommendation. However, I've been unable to test this since the required `.env-dist.dev` & docker compose files are missing.